### PR TITLE
feat(config): use ~/.config/gaal on macOS instead of Application Support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ See [docs/architecture.md](docs/architecture.md) for a full description of the p
 
 Key points:
 - `internal/engine` is the single orchestrator — add no business logic there.
-- All file-system paths must use `os.UserHomeDir()`, `os.UserConfigDir()`, and `os.UserCacheDir()` — never hardcode `~/.config/`, `%AppData%`, etc.
+- For per-user gaal config paths, go through the helpers in `internal/config` and `internal/core/agent` (which intentionally override `os.UserConfigDir()` on macOS to prefer `$XDG_CONFIG_HOME` and otherwise use `~/.config/`). For other paths, use `os.UserHomeDir()` and `os.UserCacheDir()` — never hardcode `%AppData%`, etc.
 - The `--sandbox` flag redirects `$HOME` via `os.Setenv("HOME", dir)` — all new code must honour this automatically.
 - The `--verbose` flag switches the global `slog` level to `DEBUG` — no other mechanism exists for verbosity.
 
@@ -74,5 +74,5 @@ All tests must pass before the task is considered complete.
 - Use `filepath.Join`, `filepath.IsAbs`, `filepath.ToSlash` — never string concatenation for paths.
 - `~` expansion must handle both `~/` (POSIX) and `~\` (Windows): use `expandHome(p, home)` from `internal/skill/agents.go`.
 - Global config: use `globalConfigFilePath()` from `internal/config/config.go`.
-- User config: use `os.UserConfigDir()`.
+- User config: use `userConfigFilePath()` from `internal/config/config.go`. On macOS this returns `$XDG_CONFIG_HOME/gaal/` when set, otherwise `~/.config/gaal/` — do not call `os.UserConfigDir()` directly for user-scoped gaal paths.
 - Cache: use `os.UserCacheDir()`.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ gaal merges up to three configuration files in order:
 | Priority | File |
 |----------|------|
 | 1 — lowest | `/etc/gaal/config.yaml` (global) |
-| 2 | `~/.config/gaal/config.yaml` (user) |
+| 2 | `$XDG_CONFIG_HOME/gaal/config.yaml` (user, defaults to `~/.config/gaal/config.yaml` on Linux and macOS) |
 | 3 — highest | `gaal.yaml` in CWD, or `--config` path |
 
 ### Agent registry customization
@@ -225,7 +225,7 @@ gaal ships with a built-in registry of supported coding agents (claude-code, git
 | OS | Path |
 |----|------|
 | Linux | `$XDG_CONFIG_HOME/gaal/agents.yaml` (defaults to `~/.config/gaal/agents.yaml`) |
-| macOS | `~/Library/Application Support/gaal/agents.yaml` |
+| macOS | `$XDG_CONFIG_HOME/gaal/agents.yaml` (defaults to `~/.config/gaal/agents.yaml`) |
 | Windows | `%AppData%\gaal\agents.yaml` |
 
 Custom entries **extend** the built-in list — they cannot override built-in entries. Each entry follows the same format as the built-in registry:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,8 +81,8 @@ func init() {
 }
 
 // applyOptions builds engine.Options, applying sandbox mode when requested.
-// When --sandbox is set, $HOME is redirected to the sandbox directory so that
-// all ~/... path expansions (config loading, skill dirs, MCP targets) stay
+// When --sandbox is set, gaal rewrites the relevant user-directory environment
+// variables so that config loading, skill dirs, caches and MCP targets stay
 // inside the sandbox. Nothing outside the sandbox directory is touched.
 func applyOptions() (engine.Options, error) {
 	if sandboxDir == "" {
@@ -90,15 +90,22 @@ func applyOptions() (engine.Options, error) {
 	}
 
 	workDir := filepath.Join(sandboxDir, "workspace")
-	for _, d := range []string{sandboxDir, workDir} {
+	configDir := filepath.Join(sandboxDir, ".config")
+	cacheDir := filepath.Join(sandboxDir, ".cache")
+	roamingAppDataDir := filepath.Join(sandboxDir, "AppData", "Roaming")
+	localAppDataDir := filepath.Join(sandboxDir, "AppData", "Local")
+	dirs := []string{sandboxDir, workDir, configDir, cacheDir}
+	if runtime.GOOS == "windows" {
+		dirs = append(dirs, roamingAppDataDir, localAppDataDir)
+	}
+	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o755); err != nil {
 			return engine.Options{}, fmt.Errorf("creating sandbox directory %q: %w", d, err)
 		}
 	}
 
-	// Redirect $HOME / $USERPROFILE so that os.UserHomeDir() and all ~/...
-	// expansions (including inside config.Load) point into the sandbox.
-	// On Windows, os.UserHomeDir() reads USERPROFILE first, so both must be set.
+	// Redirect the OS-specific user directory environment variables so that all
+	// gaal-managed paths resolve inside the sandbox.
 	if err := os.Setenv("HOME", sandboxDir); err != nil {
 		return engine.Options{}, fmt.Errorf("setting sandbox HOME: %w", err)
 	}
@@ -106,9 +113,22 @@ func applyOptions() (engine.Options, error) {
 		if err := os.Setenv("USERPROFILE", sandboxDir); err != nil {
 			return engine.Options{}, fmt.Errorf("setting sandbox USERPROFILE: %w", err)
 		}
+		if err := os.Setenv("APPDATA", roamingAppDataDir); err != nil {
+			return engine.Options{}, fmt.Errorf("setting sandbox APPDATA: %w", err)
+		}
+		if err := os.Setenv("LOCALAPPDATA", localAppDataDir); err != nil {
+			return engine.Options{}, fmt.Errorf("setting sandbox LOCALAPPDATA: %w", err)
+		}
+	} else {
+		if err := os.Setenv("XDG_CONFIG_HOME", configDir); err != nil {
+			return engine.Options{}, fmt.Errorf("setting sandbox XDG_CONFIG_HOME: %w", err)
+		}
+		if err := os.Setenv("XDG_CACHE_HOME", cacheDir); err != nil {
+			return engine.Options{}, fmt.Errorf("setting sandbox XDG_CACHE_HOME: %w", err)
+		}
 	}
 
-	slog.Info("sandbox mode active", "home", sandboxDir, "workspace", workDir)
+	slog.Info("sandbox mode active", "home", sandboxDir, "workspace", workDir, "configDir", configDir, "cacheDir", cacheDir)
 	return engine.Options{WorkDir: workDir}, nil
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestApplyOptions_SandboxRedirectsUserDirs(t *testing.T) {
+	originalSandboxDir := sandboxDir
+	t.Cleanup(func() {
+		sandboxDir = originalSandboxDir
+	})
+
+	sandboxDir = t.TempDir()
+	t.Setenv("HOME", filepath.Join(t.TempDir(), "home-outside-sandbox"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "config-outside-sandbox"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(t.TempDir(), "cache-outside-sandbox"))
+	t.Setenv("USERPROFILE", filepath.Join(t.TempDir(), "userprofile-outside-sandbox"))
+	t.Setenv("APPDATA", filepath.Join(t.TempDir(), "appdata-outside-sandbox"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(t.TempDir(), "localappdata-outside-sandbox"))
+
+	opts, err := applyOptions()
+	if err != nil {
+		t.Fatalf("applyOptions: %v", err)
+	}
+
+	if got, want := opts.WorkDir, filepath.Join(sandboxDir, "workspace"); got != want {
+		t.Fatalf("WorkDir = %q, want %q", got, want)
+	}
+	if got := os.Getenv("HOME"); got != sandboxDir {
+		t.Fatalf("HOME = %q, want %q", got, sandboxDir)
+	}
+
+	if runtime.GOOS == "windows" {
+		if got, want := os.Getenv("USERPROFILE"), sandboxDir; got != want {
+			t.Fatalf("USERPROFILE = %q, want %q", got, want)
+		}
+		if got, want := os.Getenv("APPDATA"), filepath.Join(sandboxDir, "AppData", "Roaming"); got != want {
+			t.Fatalf("APPDATA = %q, want %q", got, want)
+		}
+		if got, want := os.Getenv("LOCALAPPDATA"), filepath.Join(sandboxDir, "AppData", "Local"); got != want {
+			t.Fatalf("LOCALAPPDATA = %q, want %q", got, want)
+		}
+		return
+	}
+
+	if got, want := os.Getenv("XDG_CONFIG_HOME"), filepath.Join(sandboxDir, ".config"); got != want {
+		t.Fatalf("XDG_CONFIG_HOME = %q, want %q", got, want)
+	}
+	if got, want := os.Getenv("XDG_CACHE_HOME"), filepath.Join(sandboxDir, ".cache"); got != want {
+		t.Fatalf("XDG_CACHE_HOME = %q, want %q", got, want)
+	}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,7 +111,7 @@ In `--service` mode, `engine.RunService()` wraps `RunOnce()` in a `time.Ticker` 
 | Priority | Level | Linux | macOS | Windows |
 |----------|-------|-------|-------|---------|
 | 1 (lowest) | **Global** | `/etc/gaal/config.yaml` | `/etc/gaal/config.yaml` | `%PROGRAMDATA%\gaal\config.yaml` |
-| 2 | **User** | `$XDG_CONFIG_HOME/gaal/config.yaml` | `~/Library/Application Support/gaal/config.yaml` | `%AppData%\gaal\config.yaml` |
+| 2 | **User** | `$XDG_CONFIG_HOME/gaal/config.yaml` | `$XDG_CONFIG_HOME/gaal/config.yaml` (defaults to `~/.config/gaal/config.yaml`) | `%AppData%\gaal\config.yaml` |
 | 3 (highest) | **Workspace** | `--config` value (default `gaal.yaml` in CWD) | ← same | ← same |
 
 Missing files are silently skipped. At least one file must be present.
@@ -345,7 +345,7 @@ The agent registry is loaded from an embedded `agents.yaml` file. Custom agents 
 | OS | Path |
 |----|------|
 | Linux | `$XDG_CONFIG_HOME/gaal/agents.yaml` |
-| macOS | `~/Library/Application Support/gaal/agents.yaml` |
+| macOS | `$XDG_CONFIG_HOME/gaal/agents.yaml` (defaults to `~/.config/gaal/agents.yaml`) |
 | Windows | `%AppData%\gaal\agents.yaml` |
 
 Custom entries extend the built-in list; they cannot override built-in entries.
@@ -363,13 +363,13 @@ Custom entries extend the built-in list; they cannot override built-in entries.
 
 ## Sandbox Mode (`--sandbox <dir>`)
 
-A single primitive — `os.Setenv("HOME", sandboxDir)` — redirects all OS-standard directory lookups:
+`applyOptions()` rewrites the relevant user-directory environment variables so gaal-managed paths resolve inside the sandbox:
 
 | Lookup | Redirected to |
 |--------|--------------|
 | `os.UserHomeDir()` | `sandboxDir` |
-| `os.UserConfigDir()` | `sandboxDir/.config/` (Linux) |
-| `os.UserCacheDir()` → skill cache | `sandboxDir/.cache/gaal/skills/` (Linux) |
+| gaal user config (`userConfigDir()`) | `sandboxDir/.config/gaal/` on Linux/macOS, `%sandboxDir%\AppData\Roaming\gaal\` on Windows |
+| `os.UserCacheDir()` → skill cache | sandbox-scoped cache root (`sandboxDir/.cache/gaal/skills/` on Linux, `sandboxDir/Library/Caches/gaal/skills/` on macOS, `%sandboxDir%\AppData\Local\gaal\skills\` on Windows) |
 | `global: true` skill paths | `sandboxDir/.<agent>/skills/` |
 | MCP targets (`~/...`) | `sandboxDir/...` |
 | `WorkDir` | `sandboxDir/workspace/` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,7 @@ type MCPInlineConfig struct {
 //                  Windows     : %PROGRAMDATA%\gaal\config.yaml
 //  2. User     — per-user customisation
 //                  Linux       : $XDG_CONFIG_HOME/gaal/config.yaml  (~/.config/gaal/config.yaml)
-//                  macOS       : ~/Library/Application Support/gaal/config.yaml
+//                  macOS       : $XDG_CONFIG_HOME/gaal/config.yaml  (~/.config/gaal/config.yaml)
 //                  Windows     : %AppData%\gaal\config.yaml
 //  3. Workspace — project-specific, value of the --config flag (default: gaal.yaml in CWD)
 //
@@ -80,11 +80,31 @@ func globalConfigFilePath() string {
 	return "/etc/gaal/config.yaml"
 }
 
+// userConfigDir returns the directory in which gaal stores per-user config.
+// On macOS we intentionally diverge from os.UserConfigDir() (which would return
+// ~/Library/Application Support) and prefer XDG_CONFIG_HOME when it is set,
+// otherwise ~/.config to match the conventions of other CLI tools. Linux and
+// Windows fall through to os.UserConfigDir().
+func userConfigDir() (string, error) {
+	if runtime.GOOS == "darwin" {
+		if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+			return xdg, nil
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".config"), nil
+	}
+	return os.UserConfigDir()
+}
+
 // userConfigFilePath returns the per-user config path for the current OS.
-// It delegates to os.UserConfigDir() which respects XDG_CONFIG_HOME on Linux,
-// ~/Library/Application Support on macOS, and %AppData% on Windows.
+// It respects XDG_CONFIG_HOME on Linux and macOS when set, otherwise ~/.config
+// on macOS (see userConfigDir), and %AppData% on Windows.
 func userConfigFilePath() string {
-	dir, err := os.UserConfigDir()
+	slog.Debug("resolving user config file path")
+	dir, err := userConfigDir()
 	if err != nil {
 		// Fallback: XDG default.
 		home, _ := os.UserHomeDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,37 @@ func TestUserConfigFilePath(t *testing.T) {
 	}
 }
 
+func TestUserConfigFilePath_Darwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	got := userConfigFilePath()
+	want := filepath.Join(home, ".config", "gaal", "config.yaml")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestUserConfigFilePath_DarwinUsesXDGConfigHome(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only test")
+	}
+	home := t.TempDir()
+	xdg := filepath.Join(t.TempDir(), "xdg-config")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	got := userConfigFilePath()
+	want := filepath.Join(xdg, "gaal", "config.yaml")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Load
 // ---------------------------------------------------------------------------

--- a/internal/core/agent/agents.yaml
+++ b/internal/core/agent/agents.yaml
@@ -13,7 +13,7 @@
 #
 # Custom agents can be added by creating a file at:
 #   $XDG_CONFIG_HOME/gaal/agents.yaml   (Linux)
-#   ~/Library/Application Support/gaal/agents.yaml  (macOS)
+#   $XDG_CONFIG_HOME/gaal/agents.yaml   (macOS, defaults to ~/.config/gaal/agents.yaml)
 #   %AppData%\gaal\agents.yaml          (Windows)
 # Custom entries extend the built-in list. They cannot override built-in entries.
 

--- a/internal/core/agent/registry.go
+++ b/internal/core/agent/registry.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -182,7 +183,20 @@ func isAbsPath(p string) bool {
 }
 
 // userAgentsPath returns the path to the optional user agents config file.
+// On macOS it intentionally diverges from os.UserConfigDir() and prefers
+// XDG_CONFIG_HOME when it is set, otherwise ~/.config/gaal/agents.yaml.
 func userAgentsPath() (string, bool) {
+	slog.Debug("resolving user agents path")
+	if runtime.GOOS == "darwin" {
+		if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+			return filepath.Join(xdg, "gaal", "agents.yaml"), true
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", false
+		}
+		return filepath.Join(home, ".config", "gaal", "agents.yaml"), true
+	}
 	dir, err := os.UserConfigDir()
 	if err != nil {
 		return "", false

--- a/internal/core/agent/registry_internal_test.go
+++ b/internal/core/agent/registry_internal_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -217,5 +218,44 @@ agents:
 `)
 	if err := loadInto(data, dst, false); err == nil {
 		t.Error("expected error when attempting to override built-in agent")
+	}
+}
+
+// ── userAgentsPath ────────────────────────────────────────────────────────────
+
+func TestUserAgentsPath_Darwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	got, ok := userAgentsPath()
+	if !ok {
+		t.Fatal("userAgentsPath returned ok=false")
+	}
+	want := filepath.Join(home, ".config", "gaal", "agents.yaml")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestUserAgentsPath_DarwinUsesXDGConfigHome(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only test")
+	}
+	home := t.TempDir()
+	xdg := filepath.Join(t.TempDir(), "xdg-config")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	got, ok := userAgentsPath()
+	if !ok {
+		t.Fatal("userAgentsPath returned ok=false")
+	}
+	want := filepath.Join(xdg, "gaal", "agents.yaml")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Switch macOS user-level config/agents resolution from `~/Library/Application Support/gaal/` to `$XDG_CONFIG_HOME/gaal/`, falling back to `~/.config/gaal/`. Matches CLI conventions and Linux behaviour.
- Extend `--sandbox` mode to also redirect `XDG_CONFIG_HOME`, `XDG_CACHE_HOME` (and `APPDATA`/`LOCALAPPDATA` on Windows) so the new lookup path still resolves inside the sandbox directory.
- Update `AGENTS.md`, `README.md`, `docs/architecture.md` and the embedded `agents.yaml` header comment to reflect the new path.

## Breaking change
macOS users who already have files under `~/Library/Application Support/gaal/` must move them manually to `~/.config/gaal/`. There is no auto-migration.

## Test plan
- [x] `make build` — clean
- [x] `make test` — all packages green
- [x] New darwin-gated unit tests:
  - `TestUserConfigFilePath_Darwin` / `TestUserConfigFilePath_DarwinUsesXDGConfigHome`
  - `TestUserAgentsPath_Darwin` / `TestUserAgentsPath_DarwinUsesXDGConfigHome`
- [x] New sandbox unit test: `TestApplyOptions_SandboxRedirectsUserDirs`
- [x] Reviewer manually verifies `gaal sync --verbose` picks up `~/.config/gaal/config.yaml` on macOS

Closes #4