### PR TITLE
chore: run make lint via pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Run linters before allowing a commit.
+exec make lint

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOOS      ?= $(shell go env GOOS)
 GOARCH    ?= $(shell go env GOARCH)
 BIN_CROSS ?= $(DIST_DIR)/gaal-$(GOOS)-$(GOARCH)
 
-.PHONY: all build build-cross run run-service test test-race coverage coverage-ci lint clean tidy sandbox sandbox-service sandbox-status
+.PHONY: all build build-cross run run-service test test-race coverage coverage-ci lint hooks clean tidy sandbox sandbox-service sandbox-status
 
 all: build
 
@@ -93,6 +93,11 @@ lint:
 		exit 1; \
 	fi
 	go vet ./...
+
+## hooks: install repo git hooks (.githooks/) as core.hooksPath
+hooks:
+	git config core.hooksPath .githooks
+	@echo "git hooks installed from .githooks/"
 
 ## tidy: tidy dependencies
 tidy:


### PR DESCRIPTION
## Summary
- Add versioned `.githooks/pre-commit` that runs `make lint` before every commit.
- Add `make hooks` target to install the hooks via `git config core.hooksPath .githooks`.

## Test plan
- [x] `make lint` passes
- [x] `make hooks` sets `core.hooksPath` to `.githooks`
- [x] A dummy commit on this branch triggered the hook and ran `make lint`