### PR TITLE
fix(audit): attribute .agents/skills to a new generic agent (#2)

### DIFF
--- a/internal/core/agent/agents.yaml
+++ b/internal/core/agent/agents.yaml
@@ -20,8 +20,8 @@
 # YAML anchors for shared path literals.
 # The "defaults" mapping is ignored by the struct decoder (only "agents" is mapped).
 defaults:
-  project_skills_dir: &psd .agents/skills           # shared convention (~half of agents)
-  global_agents_skills: &gas ~/.agents/skills        # cline, warp
+  project_skills_dir: &psd .agents/skills           # owned by the "generic" built-in
+  global_agents_skills: &gas ~/.agents/skills        # owned by the "generic" built-in
   vscode_mcp_config: &vmc ~/.vscode/settings.json    # cline, github-copilot, roo
 
 # Shared search lists (anchors for re-use across agents).
@@ -39,7 +39,8 @@ search_defaults:
 
 agents:
   amp:
-    project_skills_dir: *psd
+    supports_generic_project: true
+    project_skills_dir: ""
     global_skills_dir: ~/.config/agents/skills
     project_mcp_config_file: ~/.config/amp/settings.json
     project_skills_search: *cps
@@ -51,7 +52,8 @@ agents:
     pm_skills_search: []
 
   antigravity:
-    project_skills_dir: *psd
+    supports_generic_project: true
+    project_skills_dir: ""
     global_skills_dir: ~/.gemini/antigravity/skills
     project_mcp_config_file: ""
     project_skills_search: *cps
@@ -92,15 +94,18 @@ agents:
       - ~/.claude/plugins/cache
 
   cline:
-    project_skills_dir: *psd
-    global_skills_dir: *gas
+    supports_generic_project: true
+    supports_generic_global: true
+    project_skills_dir: ""
+    global_skills_dir: ""
     project_mcp_config_file: *vmc
     project_skills_search: *cps
     global_skills_search: *cgs
     pm_skills_search: []
 
   codex:
-    project_skills_dir: *psd
+    supports_generic_project: true
+    project_skills_dir: ""
     global_skills_dir: ~/.codex/skills
     project_mcp_config_file: ~/.codex/mcp.json
     project_skills_search: *cps
@@ -126,7 +131,8 @@ agents:
     pm_skills_search: []
 
   cursor:
-    project_skills_dir: *psd
+    supports_generic_project: true
+    project_skills_dir: ""
     global_skills_dir: ~/.cursor/skills
     project_mcp_config_file: ~/.cursor/mcp.json
     project_skills_search: *cps
@@ -139,7 +145,8 @@ agents:
       - ~/.cursor/extensions
 
   gemini-cli:
-    project_skills_dir: *psd
+    supports_generic_project: true
+    project_skills_dir: ""
     global_skills_dir: ~/.gemini/skills
     project_mcp_config_file: ~/.gemini/settings.json
     project_skills_search: *cps
@@ -149,6 +156,21 @@ agents:
       - ~/.copilot/skills
     pm_skills_search:
       - ~/.gemini/extensions
+
+  generic:
+    # Shared-convention agent. Owns .agents/skills (project) and
+    # ~/.agents/skills (global) so audit attributes skills placed under
+    # these vendor-neutral paths to `generic`. Also the sync target used
+    # by any agent that sets supports_generic_project /
+    # supports_generic_global: true.
+    project_skills_dir: *psd
+    global_skills_dir: *gas
+    project_mcp_config_file: ""
+    project_skills_search:
+      - .agents/skills
+    global_skills_search:
+      - ~/.agents/skills
+    pm_skills_search: []
 
   github-copilot:
     # https://code.visualstudio.com/docs/copilot/customization/agent-skills#_create-a-skill
@@ -211,7 +233,8 @@ agents:
       - ~/.kiro/extensions
 
   opencode:
-    project_skills_dir: *psd
+    supports_generic_project: true
+    project_skills_dir: ""
     global_skills_dir: ~/.config/opencode/skills
     project_mcp_config_file: ~/.config/opencode/config.json
     project_skills_search: *cps
@@ -266,8 +289,10 @@ agents:
       - ~/.trae/extensions
 
   warp:
-    project_skills_dir: *psd
-    global_skills_dir: *gas
+    supports_generic_project: true
+    supports_generic_global: true
+    project_skills_dir: ""
+    global_skills_dir: ""
     project_mcp_config_file: ~/.warp/launch_configurations/mcp.json
     project_skills_search: *cps
     global_skills_search:

--- a/internal/core/agent/registry.go
+++ b/internal/core/agent/registry.go
@@ -42,16 +42,31 @@ type Info struct {
 	// installed by the agent's package manager. Scanned recursively for
 	// sub-trees containing a "skills/" folder with SKILL.md files.
 	PmSkillsSearch []string
+
+	// SupportsGenericProject reports whether the agent natively reads
+	// project-level skills from the shared .agents/skills convention
+	// owned by the "generic" built-in agent. When true, the agent's own
+	// ProjectSkillsDir may be empty; sync and audit transparently
+	// delegate to generic's project path.
+	SupportsGenericProject bool
+	// SupportsGenericGlobal reports whether the agent natively reads
+	// global skills from the shared ~/.agents/skills convention owned by
+	// the "generic" built-in agent. When true, the agent's own
+	// GlobalSkillsDir may be empty; sync and audit transparently
+	// delegate to generic's global path.
+	SupportsGenericGlobal bool
 }
 
 // agentEntry is the YAML-decodable shape for a single agent.
 type agentEntry struct {
-	ProjectSkillsDir     string   `yaml:"project_skills_dir"`
-	GlobalSkillsDir      string   `yaml:"global_skills_dir"`
-	ProjectMCPConfigFile string   `yaml:"project_mcp_config_file"`
-	ProjectSkillsSearch  []string `yaml:"project_skills_search"`
-	GlobalSkillsSearch   []string `yaml:"global_skills_search"`
-	PmSkillsSearch       []string `yaml:"pm_skills_search"`
+	ProjectSkillsDir       string   `yaml:"project_skills_dir"`
+	GlobalSkillsDir        string   `yaml:"global_skills_dir"`
+	ProjectMCPConfigFile   string   `yaml:"project_mcp_config_file"`
+	ProjectSkillsSearch    []string `yaml:"project_skills_search"`
+	GlobalSkillsSearch     []string `yaml:"global_skills_search"`
+	PmSkillsSearch         []string `yaml:"pm_skills_search"`
+	SupportsGenericProject bool     `yaml:"supports_generic_project"`
+	SupportsGenericGlobal  bool     `yaml:"supports_generic_global"`
 }
 
 // agentsFile is the top-level structure of agents.yaml.
@@ -109,12 +124,14 @@ func loadInto(data []byte, dst map[string]Info, allowOverride bool) error {
 			return fmt.Errorf("duplicate agent name %q", name)
 		}
 		dst[name] = Info{
-			ProjectSkillsDir:     e.ProjectSkillsDir,
-			GlobalSkillsDir:      e.GlobalSkillsDir,
-			ProjectMCPConfigFile: e.ProjectMCPConfigFile,
-			ProjectSkillsSearch:  e.ProjectSkillsSearch,
-			GlobalSkillsSearch:   e.GlobalSkillsSearch,
-			PmSkillsSearch:       e.PmSkillsSearch,
+			ProjectSkillsDir:       e.ProjectSkillsDir,
+			GlobalSkillsDir:        e.GlobalSkillsDir,
+			ProjectMCPConfigFile:   e.ProjectMCPConfigFile,
+			ProjectSkillsSearch:    e.ProjectSkillsSearch,
+			GlobalSkillsSearch:     e.GlobalSkillsSearch,
+			PmSkillsSearch:         e.PmSkillsSearch,
+			SupportsGenericProject: e.SupportsGenericProject,
+			SupportsGenericGlobal:  e.SupportsGenericGlobal,
 		}
 	}
 	return nil
@@ -129,13 +146,28 @@ func loadInto(data []byte, dst map[string]Info, allowOverride bool) error {
 func validateEntry(name string, e agentEntry) error {
 	slog.Debug("validating agent entry", "name", name)
 
-	if isAbsPath(e.ProjectSkillsDir) {
-		return fmt.Errorf("agent %q: project_skills_dir must be relative, got %q", name, e.ProjectSkillsDir)
+	// project_skills_dir: may be empty when the agent delegates project
+	// skills to the "generic" convention; otherwise must be relative.
+	if e.ProjectSkillsDir == "" {
+		if !e.SupportsGenericProject {
+			return fmt.Errorf("agent %q: project_skills_dir must be set unless supports_generic_project is true", name)
+		}
+	} else {
+		if isAbsPath(e.ProjectSkillsDir) {
+			return fmt.Errorf("agent %q: project_skills_dir must be relative, got %q", name, e.ProjectSkillsDir)
+		}
+		if containsDotDot(e.ProjectSkillsDir) {
+			return fmt.Errorf("agent %q: project_skills_dir must not contain '..', got %q", name, e.ProjectSkillsDir)
+		}
 	}
-	if containsDotDot(e.ProjectSkillsDir) {
-		return fmt.Errorf("agent %q: project_skills_dir must not contain '..', got %q", name, e.ProjectSkillsDir)
-	}
-	if !strings.HasPrefix(e.GlobalSkillsDir, "~/") && !strings.HasPrefix(e.GlobalSkillsDir, `~\`) {
+
+	// global_skills_dir: may be empty when the agent delegates global
+	// skills to the "generic" convention; otherwise must be ~/-prefixed.
+	if e.GlobalSkillsDir == "" {
+		if !e.SupportsGenericGlobal {
+			return fmt.Errorf("agent %q: global_skills_dir must be set unless supports_generic_global is true", name)
+		}
+	} else if !strings.HasPrefix(e.GlobalSkillsDir, "~/") && !strings.HasPrefix(e.GlobalSkillsDir, `~\`) {
 		return fmt.Errorf("agent %q: global_skills_dir must start with '~/', got %q", name, e.GlobalSkillsDir)
 	}
 	if e.ProjectMCPConfigFile != "" &&
@@ -238,13 +270,31 @@ func Lookup(name string) (Info, bool) {
 
 // SkillDir returns the target skills directory for the given agent.
 // If global is true the user-home directory is returned (~ expanded).
+//
+// Agents that support the generic convention for the requested scope
+// delegate to the "generic" built-in, so sync lands skills in the
+// shared .agents/skills tree instead of an agent-specific fork.
 func SkillDir(name string, global bool, home string) (string, bool) {
 	info, ok := registry[name]
 	if !ok {
 		return "", false
 	}
 	if global {
+		if info.SupportsGenericGlobal {
+			gen, ok := registry["generic"]
+			if !ok {
+				return "", false
+			}
+			return ExpandHome(gen.GlobalSkillsDir, home), true
+		}
 		return ExpandHome(info.GlobalSkillsDir, home), true
+	}
+	if info.SupportsGenericProject {
+		gen, ok := registry["generic"]
+		if !ok {
+			return "", false
+		}
+		return gen.ProjectSkillsDir, true
 	}
 	return info.ProjectSkillsDir, true
 }

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -133,12 +133,14 @@ func TestAllAgents_HaveNonEmptySkillDirs(t *testing.T) {
 	home := "/home/testuser"
 	for _, name := range agent.Names() {
 		info, _ := agent.Lookup(name)
-		if info.ProjectSkillsDir == "" {
-			t.Errorf("agent %q: empty ProjectSkillsDir", name)
+		if info.ProjectSkillsDir == "" && !info.SupportsGenericProject {
+			t.Errorf("agent %q: empty ProjectSkillsDir without supports_generic_project", name)
 		}
-		if info.GlobalSkillsDir == "" {
-			t.Errorf("agent %q: empty GlobalSkillsDir", name)
+		if info.GlobalSkillsDir == "" && !info.SupportsGenericGlobal {
+			t.Errorf("agent %q: empty GlobalSkillsDir without supports_generic_global", name)
 		}
+		// SkillDir must always resolve to a non-empty path: flagged
+		// agents transparently redirect to generic's canonical paths.
 		projDir, ok := agent.SkillDir(name, false, home)
 		if !ok || projDir == "" {
 			t.Errorf("agent %q: SkillDir(false) returned empty or not-ok", name)
@@ -199,5 +201,111 @@ func TestList_InfoMatchesLookup(t *testing.T) {
 			e.Info.ProjectMCPConfigFile != info.ProjectMCPConfigFile {
 			t.Errorf("List() entry %q Info mismatch: got %+v, want %+v", e.Name, e.Info, info)
 		}
+	}
+}
+
+// ── Generic convention ──────────────────────────────────────────────────────
+
+func TestGenericAgentRegistered(t *testing.T) {
+	info, ok := agent.Lookup("generic")
+	if !ok {
+		t.Fatal("generic agent not registered")
+	}
+	if info.ProjectSkillsDir != ".agents/skills" {
+		t.Errorf("generic ProjectSkillsDir = %q, want .agents/skills", info.ProjectSkillsDir)
+	}
+	if info.GlobalSkillsDir != "~/.agents/skills" {
+		t.Errorf("generic GlobalSkillsDir = %q, want ~/.agents/skills", info.GlobalSkillsDir)
+	}
+	if info.SupportsGenericProject || info.SupportsGenericGlobal {
+		t.Error("generic itself must not set supports_generic_{project,global}=true")
+	}
+}
+
+func TestGenericProjectFlaggedAgents(t *testing.T) {
+	// Every agent that previously pointed its project_skills_dir at
+	// .agents/skills must now delegate to generic.
+	want := []string{"amp", "antigravity", "cline", "codex", "cursor", "gemini-cli", "opencode", "warp"}
+	for _, name := range want {
+		info, ok := agent.Lookup(name)
+		if !ok {
+			t.Errorf("agent %q not registered", name)
+			continue
+		}
+		if !info.SupportsGenericProject {
+			t.Errorf("agent %q: expected SupportsGenericProject=true", name)
+		}
+		if info.ProjectSkillsDir != "" {
+			t.Errorf("agent %q: expected empty ProjectSkillsDir, got %q", name, info.ProjectSkillsDir)
+		}
+	}
+}
+
+func TestGenericGlobalFlaggedAgents(t *testing.T) {
+	// Only cline and warp previously pointed their global_skills_dir at
+	// ~/.agents/skills.
+	want := []string{"cline", "warp"}
+	for _, name := range want {
+		info, ok := agent.Lookup(name)
+		if !ok {
+			t.Errorf("agent %q not registered", name)
+			continue
+		}
+		if !info.SupportsGenericGlobal {
+			t.Errorf("agent %q: expected SupportsGenericGlobal=true", name)
+		}
+		if info.GlobalSkillsDir != "" {
+			t.Errorf("agent %q: expected empty GlobalSkillsDir, got %q", name, info.GlobalSkillsDir)
+		}
+	}
+}
+
+func TestSkillDir_RedirectsProjectFlaggedToGeneric(t *testing.T) {
+	// amp is project-only flagged: project dir must redirect, but
+	// global dir must still resolve to amp's own canonical path.
+	home := "/tmp/fake-home"
+
+	proj, ok := agent.SkillDir("amp", false, home)
+	if !ok {
+		t.Fatal("SkillDir(amp, project) returned false")
+	}
+	if proj != ".agents/skills" {
+		t.Errorf("SkillDir(amp, project) = %q, want .agents/skills", proj)
+	}
+
+	global, ok := agent.SkillDir("amp", true, home)
+	if !ok {
+		t.Fatal("SkillDir(amp, global) returned false")
+	}
+	if global != filepath.Join(home, ".config/agents/skills") {
+		t.Errorf("SkillDir(amp, global) = %q, want amp's canonical global dir", global)
+	}
+}
+
+func TestSkillDir_RedirectsBothScopesForCline(t *testing.T) {
+	home := "/tmp/fake-home"
+
+	proj, ok := agent.SkillDir("cline", false, home)
+	if !ok {
+		t.Fatal("SkillDir(cline, project) returned false")
+	}
+	if proj != ".agents/skills" {
+		t.Errorf("SkillDir(cline, project) = %q, want .agents/skills", proj)
+	}
+
+	global, ok := agent.SkillDir("cline", true, home)
+	if !ok {
+		t.Fatal("SkillDir(cline, global) returned false")
+	}
+	if global != filepath.Join(home, ".agents/skills") {
+		t.Errorf("SkillDir(cline, global) = %q, want %q", global, filepath.Join(home, ".agents/skills"))
+	}
+
+	warpGlobal, ok := agent.SkillDir("warp", true, home)
+	if !ok {
+		t.Fatal("SkillDir(warp, global) returned false")
+	}
+	if warpGlobal != filepath.Join(home, ".agents/skills") {
+		t.Errorf("SkillDir(warp, global) = %q, want %q", warpGlobal, filepath.Join(home, ".agents/skills"))
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -234,13 +234,13 @@ func TestCollect_IncludesAgents(t *testing.T) {
 	if len(report.Agents) == 0 {
 		t.Fatal("expected at least one agent entry in status report")
 	}
-	// All entries must have non-empty Name and ProjectSkillsDir.
+	// Every entry must have a non-empty Name. ProjectSkillsDir may be
+	// empty for agents that delegate project skills to the shared
+	// "generic" convention (e.g. cline, amp, warp); audit and sync
+	// redirect those through agent.SkillDir.
 	for _, a := range report.Agents {
 		if a.Name == "" {
 			t.Error("agent entry has empty Name")
-		}
-		if a.ProjectSkillsDir == "" {
-			t.Errorf("agent %q: empty ProjectSkillsDir", a.Name)
 		}
 	}
 }

--- a/internal/engine/info_test.go
+++ b/internal/engine/info_test.go
@@ -48,6 +48,27 @@ func TestInfo_JSON_Agent(t *testing.T) {
 	if len(result.Agents) == 0 {
 		t.Error("expected at least one agent in JSON output")
 	}
+
+	for _, agent := range result.Agents {
+		if agent.Name != "cline" {
+			continue
+		}
+		if agent.ProjectSkillsDir != ".agents/skills" {
+			t.Errorf("cline project_skills_dir = %q, want .agents/skills", agent.ProjectSkillsDir)
+		}
+		if agent.GlobalSkillsDir == "" {
+			t.Fatal("cline global_skills_dir is empty")
+		}
+		if !agent.ProjectSkillsViaGeneric {
+			t.Error("cline project_skills_via_generic = false, want true")
+		}
+		if !agent.GlobalSkillsViaGeneric {
+			t.Error("cline global_skills_via_generic = false, want true")
+		}
+		return
+	}
+
+	t.Fatal("cline agent not found in JSON output")
 }
 
 func TestInfo_JSON_Agent_Filter(t *testing.T) {

--- a/internal/engine/ops/audit_test.go
+++ b/internal/engine/ops/audit_test.go
@@ -132,6 +132,67 @@ func TestAudit_TwoPass_NoProjectDuplicate(t *testing.T) {
 	}
 }
 
+// TestAudit_Generic_ProjectSkills verifies a skill in .agents/skills is
+// attributed to the `generic` agent (issue #2 — previously tagged `amp`,
+// the alphabetically first agent that co-opted the path as canonical).
+func TestAudit_Generic_ProjectSkills(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	makeSkill(t, workDir, ".agents/skills", "generic-proj-skill", "Generic project skill")
+
+	out := captureStdout(t, func() {
+		if err := Audit(context.Background(), home, workDir, render.FormatJSON); err != nil {
+			t.Errorf("Audit json (generic project): %v", err)
+		}
+	})
+	var report render.AuditReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out)
+	}
+	for _, s := range report.Skills {
+		if s.Name == "generic-proj-skill" {
+			if s.Agent != "generic" {
+				t.Errorf("expected agent=generic, got %q", s.Agent)
+			}
+			if s.Source != "project" {
+				t.Errorf("expected source=project, got %q", s.Source)
+			}
+			return
+		}
+	}
+	t.Error("'generic-proj-skill' not found in JSON skills list")
+}
+
+// TestAudit_Generic_GlobalSkills verifies a skill in ~/.agents/skills is
+// attributed to the `generic` agent (issue #2 — previously tagged `cline`).
+func TestAudit_Generic_GlobalSkills(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	makeSkill(t, home, ".agents/skills", "generic-global-skill", "Generic global skill")
+
+	out := captureStdout(t, func() {
+		if err := Audit(context.Background(), home, workDir, render.FormatJSON); err != nil {
+			t.Errorf("Audit json (generic global): %v", err)
+		}
+	})
+	var report render.AuditReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out)
+	}
+	for _, s := range report.Skills {
+		if s.Name == "generic-global-skill" {
+			if s.Agent != "generic" {
+				t.Errorf("expected agent=generic, got %q", s.Agent)
+			}
+			if s.Source != "global" {
+				t.Errorf("expected source=global, got %q", s.Source)
+			}
+			return
+		}
+	}
+	t.Error("'generic-global-skill' not found in JSON skills list")
+}
+
 func TestAudit_TwoPass_CanonicalAgent(t *testing.T) {
 	home := t.TempDir()
 	workDir := t.TempDir()

--- a/internal/engine/ops/info.go
+++ b/internal/engine/ops/info.go
@@ -400,9 +400,16 @@ func renderAgentInfo(w io.Writer, entries []render.AgentEntry, filter string) er
 		if !matchFilter(e.Name, filter) {
 			continue
 		}
-		lines := []string{
-			kvLine("Project", pterm.FgCyan.Sprint(e.ProjectSkillsDir)),
-			kvLine("Global", pterm.FgCyan.Sprint(e.GlobalSkillsDir)),
+		lines := []string{}
+		if e.ProjectSkillsDir != "" {
+			lines = append(lines, kvLine("Project", pterm.FgCyan.Sprint(e.ProjectSkillsDir)))
+		} else {
+			lines = append(lines, kvLine("Project", pterm.FgDarkGray.Sprint("via generic convention")))
+		}
+		if e.GlobalSkillsDir != "" {
+			lines = append(lines, kvLine("Global", pterm.FgCyan.Sprint(e.GlobalSkillsDir)))
+		} else {
+			lines = append(lines, kvLine("Global", pterm.FgDarkGray.Sprint("via generic convention")))
 		}
 		if e.ProjectMCPConfigFile != "" {
 			lines = append(lines, kvLine("MCP cfg", pterm.FgGreen.Sprint(e.ProjectMCPConfigFile)))

--- a/internal/engine/ops/info.go
+++ b/internal/engine/ops/info.go
@@ -401,12 +401,16 @@ func renderAgentInfo(w io.Writer, entries []render.AgentEntry, filter string) er
 			continue
 		}
 		lines := []string{}
-		if e.ProjectSkillsDir != "" {
+		if e.ProjectSkillsViaGeneric {
+			lines = append(lines, kvLine("Project", pterm.FgDarkGray.Sprintf("via generic convention (%s)", e.ProjectSkillsDir)))
+		} else if e.ProjectSkillsDir != "" {
 			lines = append(lines, kvLine("Project", pterm.FgCyan.Sprint(e.ProjectSkillsDir)))
 		} else {
 			lines = append(lines, kvLine("Project", pterm.FgDarkGray.Sprint("via generic convention")))
 		}
-		if e.GlobalSkillsDir != "" {
+		if e.GlobalSkillsViaGeneric {
+			lines = append(lines, kvLine("Global", pterm.FgDarkGray.Sprintf("via generic convention (%s)", e.GlobalSkillsDir)))
+		} else if e.GlobalSkillsDir != "" {
 			lines = append(lines, kvLine("Global", pterm.FgCyan.Sprint(e.GlobalSkillsDir)))
 		} else {
 			lines = append(lines, kvLine("Global", pterm.FgDarkGray.Sprint("via generic convention")))

--- a/internal/engine/ops/info_test.go
+++ b/internal/engine/ops/info_test.go
@@ -380,7 +380,10 @@ func TestRenderAgentInfo_EmptyWithFilter(t *testing.T) {
 }
 
 func TestRenderAgentInfo_ContainsKnownAgents(t *testing.T) {
-	entries := collectAgents()
+	entries, err := collectAgents()
+	if err != nil {
+		t.Fatalf("collectAgents: %v", err)
+	}
 	var buf bytes.Buffer
 	if err := renderAgentInfo(&buf, entries, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -394,7 +397,10 @@ func TestRenderAgentInfo_ContainsKnownAgents(t *testing.T) {
 }
 
 func TestRenderAgentInfo_Filter(t *testing.T) {
-	entries := collectAgents()
+	entries, err := collectAgents()
+	if err != nil {
+		t.Fatalf("collectAgents: %v", err)
+	}
 	var buf bytes.Buffer
 	if err := renderAgentInfo(&buf, entries, "cursor"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -419,5 +425,32 @@ func TestRenderAgentInfo_NoMCPShownAsDash(t *testing.T) {
 	out := pterm.RemoveColorFromString(buf.String())
 	if !strings.Contains(out, "not supported") {
 		t.Error("expected 'not supported' for empty ProjectMCPConfigFile")
+	}
+}
+
+func TestRenderAgentInfo_GenericConventionShowsResolvedDir(t *testing.T) {
+	entries := []render.AgentEntry{
+		{
+			Name:                    "cline",
+			ProjectSkillsDir:        ".agents/skills",
+			GlobalSkillsDir:         "/tmp/home/.agents/skills",
+			ProjectSkillsViaGeneric: true,
+			GlobalSkillsViaGeneric:  true,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderAgentInfo(&buf, entries, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := pterm.RemoveColorFromString(buf.String())
+	for _, want := range []string{
+		"via generic convention (.agents/skills)",
+		"via generic convention (/tmp/home/.agents/skills)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
 	}
 }

--- a/internal/engine/ops/status.go
+++ b/internal/engine/ops/status.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -15,11 +16,16 @@ import (
 // Collect gathers the current status of all resources without side effects.
 func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager) (*render.StatusReport, error) {
 	slog.DebugContext(ctx, "collecting status")
+	agents, err := collectAgents()
+	if err != nil {
+		return nil, err
+	}
+
 	return &render.StatusReport{
 		Repositories: collectRepos(repos.Status(ctx)),
 		Skills:       collectSkills(skills.Status(ctx)),
 		MCPs:         collectMCPs(mcps.Status(ctx)),
-		Agents:       collectAgents(),
+		Agents:       agents,
 	}, nil
 }
 
@@ -113,18 +119,37 @@ func collectMCPs(stats []mcp.Status) []render.MCPEntry {
 	return entries
 }
 
-func collectAgents() []render.AgentEntry {
+func collectAgents() ([]render.AgentEntry, error) {
+	slog.Debug("collecting agent entries")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving user home dir: %w", err)
+	}
+
 	list := agent.List()
 	entries := make([]render.AgentEntry, len(list))
 	for i, a := range list {
+		projectDir, ok := agent.SkillDir(a.Name, false, home)
+		if !ok {
+			return nil, fmt.Errorf("resolving project skills dir for agent %q", a.Name)
+		}
+
+		globalDir, ok := agent.SkillDir(a.Name, true, home)
+		if !ok {
+			return nil, fmt.Errorf("resolving global skills dir for agent %q", a.Name)
+		}
+
 		entries[i] = render.AgentEntry{
-			Name:                 a.Name,
-			ProjectSkillsDir:     a.Info.ProjectSkillsDir,
-			GlobalSkillsDir:      a.Info.GlobalSkillsDir,
-			ProjectMCPConfigFile: a.Info.ProjectMCPConfigFile,
+			Name:                    a.Name,
+			ProjectSkillsDir:        projectDir,
+			GlobalSkillsDir:         globalDir,
+			ProjectMCPConfigFile:    a.Info.ProjectMCPConfigFile,
+			ProjectSkillsViaGeneric: a.Info.SupportsGenericProject,
+			GlobalSkillsViaGeneric:  a.Info.SupportsGenericGlobal,
 		}
 	}
-	return entries
+	return entries, nil
 }
 
 // orDefault returns s if non-empty, otherwise def.

--- a/internal/engine/ops/status_test.go
+++ b/internal/engine/ops/status_test.go
@@ -1,6 +1,9 @@
 package ops
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestOrDefault verifies the orDefault helper.
 func TestOrDefault(t *testing.T) {
@@ -20,4 +23,35 @@ func TestNonNil(t *testing.T) {
 	if got := nonNil([]string{"a"}); len(got) != 1 || got[0] != "a" {
 		t.Errorf("nonNil non-nil: unexpected %v", got)
 	}
+}
+
+func TestCollectAgents_ResolvesGenericDirs(t *testing.T) {
+	entries, err := collectAgents()
+	if err != nil {
+		t.Fatalf("collectAgents: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.Name != "cline" {
+			continue
+		}
+		if entry.ProjectSkillsDir != ".agents/skills" {
+			t.Errorf("cline ProjectSkillsDir = %q, want .agents/skills", entry.ProjectSkillsDir)
+		}
+		if entry.GlobalSkillsDir == "" {
+			t.Fatal("cline GlobalSkillsDir is empty")
+		}
+		if strings.HasPrefix(entry.GlobalSkillsDir, "~") {
+			t.Errorf("cline GlobalSkillsDir should be expanded, got %q", entry.GlobalSkillsDir)
+		}
+		if !entry.ProjectSkillsViaGeneric {
+			t.Error("cline ProjectSkillsViaGeneric = false, want true")
+		}
+		if !entry.GlobalSkillsViaGeneric {
+			t.Error("cline GlobalSkillsViaGeneric = false, want true")
+		}
+		return
+	}
+
+	t.Fatal("cline agent not found")
 }

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -38,10 +38,12 @@ type SkillEntry struct {
 
 // AgentEntry holds the registry information for a supported agent.
 type AgentEntry struct {
-	Name                 string `json:"name"`
-	ProjectSkillsDir     string `json:"project_skills_dir"`
-	GlobalSkillsDir      string `json:"global_skills_dir"`
-	ProjectMCPConfigFile string `json:"project_mcp_config_file,omitempty"`
+	Name                    string `json:"name"`
+	ProjectSkillsDir        string `json:"project_skills_dir"`
+	GlobalSkillsDir         string `json:"global_skills_dir"`
+	ProjectMCPConfigFile    string `json:"project_mcp_config_file,omitempty"`
+	ProjectSkillsViaGeneric bool   `json:"project_skills_via_generic,omitempty"`
+	GlobalSkillsViaGeneric  bool   `json:"global_skills_via_generic,omitempty"`
 }
 
 // MCPEntry holds the status of a single MCP server entry.

--- a/internal/engine/render/table_test.go
+++ b/internal/engine/render/table_test.go
@@ -110,12 +110,15 @@ func TestTableRenderer_WithData(t *testing.T) {
 		MCPs: []MCPEntry{
 			{Name: "filesystem", Status: StatusPresent, Target: "/home/user/.config/claude.json"},
 		},
+		Agents: []AgentEntry{
+			{Name: "cline", ProjectSkillsDir: ".agents/skills", GlobalSkillsDir: "/home/user/.agents/skills", ProjectSkillsViaGeneric: true, GlobalSkillsViaGeneric: true},
+		},
 	}
 	if err := r.Render(&buf, report); err != nil {
 		t.Fatalf("tableRenderer.Render with data: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"myrepo", "git", "other", "filesystem"} {
+	for _, want := range []string{"myrepo", "git", "other", "filesystem", "cline", ".agents/skills"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("table output missing %q", want)
 		}


### PR DESCRIPTION
Fixes #2.

## Problem

`gaal audit` attributed skills in the vendor-neutral `.agents/skills` convention to whichever agent came first alphabetically in the Pass 1 scan:

- `./.agents/skills/*` → **amp**
- `~/.agents/skills/*` → **cline**

`.agents/` is a shared convention, not any one agent's home, so this was misleading.

## Fix

Introduce a `generic` built-in agent that owns both shared paths, and two per-scope opt-in flags — `supports_generic_project` and `supports_generic_global` — so an agent can delegate one scope without losing its own canonical directory for the other.

Flagged agents:

| Agent        | Project | Global |
|--------------|---------|--------|
| amp          | ✓       |        |
| antigravity  | ✓       |        |
| cline        | ✓       | ✓      |
| codex        | ✓       |        |
| cursor       | ✓       |        |
| gemini-cli   | ✓       |        |
| opencode     | ✓       |        |
| warp         | ✓       | ✓      |

Sync behaviour is preserved: `agent.SkillDir` transparently redirects flagged scopes to `generic`'s paths, so `gaal sync --agent cline` still lands skills in `~/.agents/skills`.

`gaal info agent <name>` shows `via generic convention` in place of the blank path for flagged scopes.

## Test plan

- [x] `go test ./...` — 395 passed
- [x] New unit tests for generic registration, per-agent flag state, and per-scope `SkillDir` redirect
- [x] New audit tests asserting `.agents/skills` (project & global) → `generic`
- [x] Manual probe: built binary, placed skills in both paths, audit reports `agent=generic` for both
- [x] Manual probe: `gaal info agent cline` shows "via generic convention" for Project + Global; `gaal info agent amp` shows it for Project only and keeps its own `~/.config/agents/skills` for Global
- [x] `make lint` clean (also ran via pre-commit hook)