### PR TITLE
feat(init): audit-driven wizard for bootstrapping gaal.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,44 @@
 
 ## Quick start
 
-Create a `gaal.yaml` in your project (or copy `example.gaal.yaml`):
+The fastest way to get a working `gaal.yaml` is to run the interactive init
+wizard. It scans your machine for installed skills and MCP servers, asks you
+a few questions, and writes a configuration you can sync right away.
+
+```bash
+gaal init
+```
+
+The wizard asks two questions before doing anything:
+
+1. **How** to create the file — start from an empty documented skeleton, or
+   import the skills and MCP servers detected on this machine.
+2. **Where** the configuration applies — project-scoped (`./gaal.yaml`) or
+   global-scoped (`~/.config/gaal/config.yaml`).
+
+When you pick the import mode, gaal runs an audit under the selected scope
+and presents a multi-select list grouped by agent. Everything is preselected
+by default; press Enter to confirm, or Space to toggle individual entries.
+
+### Non-interactive (CI / scripts)
+
+The wizard prompts are bypassable via flags:
+
+```bash
+# Empty skeleton, project-scoped
+gaal init --empty --scope project
+
+# Import everything detected, global-scoped, overwrite existing file
+gaal init --import-all --scope global --force
+```
+
+`--empty` and `--import-all` are mutually exclusive; one of them is required
+when stdin is not a TTY.
+
+### Manual setup
+
+If you would rather hand-write your configuration, copy `example.gaal.yaml`
+and edit it. A minimal file looks like this:
 
 ```yaml
 repositories:

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,39 +1,270 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"log/slog"
+	"os"
+	"strings"
 
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
+	"gaal/cmd/internal/wizard"
 	"gaal/internal/config"
 	"gaal/internal/engine"
+	"gaal/internal/engine/ops"
 )
 
-var forceInit bool
+var (
+	forceInit     bool
+	initScopeFlag string
+	initImportAll bool
+	initEmpty     bool
+)
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Bootstrap a gaal.yaml in the current directory",
-	Long: `Creates a documented gaal.yaml skeleton in the current directory (or at
-the path specified by --config).
+	Short: "Bootstrap a gaal.yaml from the results of audit",
+	Long: `Creates a gaal.yaml populated from the skills and MCP servers discovered on
+this machine.
 
-All three resource sections (repositories, skills, mcps) are present with
-inline field descriptions and usage examples so you can fill them in right away.
+The command first asks whether the new configuration is project-scoped
+(./gaal.yaml) or global-scoped (~/.config/gaal/config.yaml). It then runs an
+audit and presents an interactive multi-select list, grouped by agent, of
+everything it found under that scope. The generated file reflects your
+selection and is ready for "gaal sync".
 
-Use --force to overwrite an existing file.`,
+Use --scope and --import-all to run non-interactively (for CI or scripts).
+Use --force to overwrite an existing configuration file.`,
 	SilenceUsage: true,
 	RunE:         runInit,
 }
 
 func init() {
 	initCmd.Flags().BoolVarP(&forceInit, "force", "f", false, "overwrite an existing configuration file")
+	initCmd.Flags().StringVar(&initScopeFlag, "scope", "", `pre-select the scope without prompting ("project" or "global")`)
+	initCmd.Flags().BoolVar(&initImportAll, "import-all", false, "non-interactive: import every detected skill and MCP")
+	initCmd.Flags().BoolVar(&initEmpty, "empty", false, "non-interactive: write the documented empty skeleton")
+	initCmd.MarkFlagsMutuallyExclusive("import-all", "empty")
 	rootCmd.AddCommand(initCmd)
 }
 
-func runInit(_ *cobra.Command, _ []string) error {
-	if err := engine.NewWithOptions(&config.Config{}, engineOpts).Init(cfgFile, forceInit); err != nil {
+func runInit(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	isTTY := term.IsTerminal(int(os.Stdin.Fd()))
+
+	mode, err := resolveInitMode(initEmpty, initImportAll, isTTY)
+	if err != nil {
 		return err
 	}
-	fmt.Printf("Created %s\n\nNext steps:\n  1. Edit %s to describe your repositories, skills and MCP servers.\n  2. Run: gaal sync\n  3. Run: gaal status\n", cfgFile, cfgFile)
+
+	scope, err := resolveInitScope(initScopeFlag, isTTY)
+	if err != nil {
+		return err
+	}
+
+	dest, err := resolveInitDestination(scope)
+	if err != nil {
+		return err
+	}
+
+	if err := preflightDestination(dest, forceInit); err != nil {
+		return err
+	}
+
+	eng := engine.NewWithOptions(&config.Config{}, engineOpts)
+
+	if mode == wizard.ModeEmpty {
+		if err := eng.Init(dest, forceInit); err != nil {
+			return err
+		}
+		pterm.Success.Printfln("Created %s", dest)
+		printNextSteps(dest)
+		return nil
+	}
+
+	candidates, err := eng.BuildImportCandidates(ctx, scope)
+	if err != nil {
+		return fmt.Errorf("building import candidates: %w", err)
+	}
+
+	if len(candidates.Sections) == 0 {
+		if err := eng.Init(dest, forceInit); err != nil {
+			return err
+		}
+		pterm.Info.Printfln("No installed skills or MCP servers detected under %s scope.", scope)
+		pterm.Info.Printfln("Wrote empty skeleton to %s", dest)
+		printNextSteps(dest)
+		return nil
+	}
+
+	plan, err := selectPlan(candidates, scope, isTTY, initImportAll)
+	if err != nil {
+		return err
+	}
+
+	pterm.DefaultBox.WithTitle("Preview").Println(previewText(dest, plan))
+
+	if isTTY && !initImportAll {
+		confirmed, err := pterm.DefaultInteractiveConfirm.
+			WithDefaultValue(true).
+			WithDefaultText("Proceed?").
+			Show()
+		if err != nil {
+			return fmt.Errorf("confirmation prompt: %w", err)
+		}
+		if !confirmed {
+			pterm.Warning.Println("init cancelled")
+			return errors.New("init cancelled")
+		}
+	}
+
+	if err := eng.InitFromPlan(dest, plan, forceInit); err != nil {
+		return err
+	}
+	pterm.Success.Printfln("Created %s", dest)
+	if len(plan.Skills) > 0 {
+		pterm.Info.Println(`Tip: each skill entry targets a single agent. To sync a skill to every installed agent, edit its "agents:" field to ["*"].`)
+	}
+	printNextSteps(dest)
 	return nil
+}
+
+// resolveInitMode decides whether the wizard imports the audit result or
+// writes an empty skeleton.
+//
+// Precedence: explicit flag (--empty or --import-all) > interactive prompt >
+// error (non-TTY without a flag).
+func resolveInitMode(empty, importAll, isTTY bool) (wizard.Mode, error) {
+	switch {
+	case empty:
+		return wizard.ModeEmpty, nil
+	case importAll:
+		return wizard.ModeImport, nil
+	}
+	if !isTTY {
+		return "", errors.New("init requires an interactive terminal, --empty, or --import-all")
+	}
+	return wizard.SelectMode()
+}
+
+// resolveInitScope decides which scope the wizard runs under.
+//
+// Precedence: --scope flag > interactive prompt > error.
+func resolveInitScope(flagValue string, isTTY bool) (ops.Scope, error) {
+	if flagValue != "" {
+		switch strings.ToLower(flagValue) {
+		case "project":
+			return ops.ScopeProject, nil
+		case "global":
+			return ops.ScopeGlobal, nil
+		default:
+			return "", fmt.Errorf(`invalid --scope %q: must be "project" or "global"`, flagValue)
+		}
+	}
+	if !isTTY {
+		return "", errors.New("init requires an interactive terminal or --scope")
+	}
+	return wizard.SelectScope("./gaal.yaml", config.UserConfigFilePath())
+}
+
+// resolveInitDestination returns the file path to write.
+//
+// Precedence: explicit -c/--config (when the user passed it) > scope-specific
+// default. When the user supplied an explicit config path, it is honoured as
+// is, but a warning is logged if it looks inconsistent with the chosen scope.
+func resolveInitDestination(scope ops.Scope) (string, error) {
+	if cfgFile == "gaal.yaml" {
+		if scope == ops.ScopeGlobal {
+			return config.UserConfigFilePath(), nil
+		}
+		return "gaal.yaml", nil
+	}
+
+	switch scope {
+	case ops.ScopeProject:
+		if strings.HasPrefix(cfgFile, "~/") || strings.HasPrefix(cfgFile, `~\`) {
+			slog.Warn("config path looks home-relative but scope is project", "path", cfgFile)
+		}
+	case ops.ScopeGlobal:
+		if !strings.Contains(cfgFile, string(os.PathSeparator)) {
+			slog.Warn("config path looks project-relative but scope is global", "path", cfgFile)
+		}
+	}
+	return cfgFile, nil
+}
+
+func preflightDestination(dest string, force bool) error {
+	if force {
+		return nil
+	}
+	if _, err := os.Stat(dest); err == nil {
+		return fmt.Errorf("%s already exists — use --force to overwrite", dest)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking %s: %w", dest, err)
+	}
+	return nil
+}
+
+func selectPlan(c ops.Candidates, scope ops.Scope, isTTY, importAll bool) (ops.Plan, error) {
+	if importAll {
+		flat := flattenAll(c)
+		return ops.BuildPlan(flat, scope), nil
+	}
+	if !isTTY {
+		return ops.Plan{}, errors.New("init requires --import-all in non-interactive mode")
+	}
+	plan, err := wizard.SelectSections(c, scope)
+	if err != nil {
+		if errors.Is(err, wizard.ErrCancelled) {
+			return ops.Plan{}, errors.New("init cancelled")
+		}
+		return ops.Plan{}, err
+	}
+	return plan, nil
+}
+
+func flattenAll(c ops.Candidates) []ops.Candidate {
+	var out []ops.Candidate
+	for _, sec := range c.Sections {
+		out = append(out, sec.Skills...)
+		out = append(out, sec.MCPs...)
+	}
+	return out
+}
+
+func previewText(dest string, plan ops.Plan) string {
+	agents := map[string]struct{}{}
+	for _, s := range plan.Skills {
+		for _, a := range s.Agents {
+			agents[a] = struct{}{}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Will write %s with:\n", dest)
+	fmt.Fprintf(&sb, "  skills: %d %s (%d %s)\n",
+		len(plan.Skills), pluralize(len(plan.Skills), "entry", "entries"),
+		len(agents), pluralize(len(agents), "agent", "agents"))
+	fmt.Fprintf(&sb, "  mcps:   %d %s\n",
+		len(plan.MCPs), pluralize(len(plan.MCPs), "entry", "entries"))
+	sb.WriteString("  repositories: empty")
+	return sb.String()
+}
+
+func pluralize(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+func printNextSteps(dest string) {
+	fmt.Printf("\nNext steps:\n  1. Review %s\n  2. Run: gaal sync\n  3. Run: gaal status\n", dest)
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gaal/internal/config"
+	"gaal/internal/engine"
+)
+
+// resetInitFlags restores the package-level flag state between cases.
+func resetInitFlags(t *testing.T) {
+	t.Helper()
+	originalCfgFile := cfgFile
+	originalForce := forceInit
+	originalScope := initScopeFlag
+	originalAll := initImportAll
+	originalEmpty := initEmpty
+	originalOpts := engineOpts
+	t.Cleanup(func() {
+		cfgFile = originalCfgFile
+		forceInit = originalForce
+		initScopeFlag = originalScope
+		initImportAll = originalAll
+		initEmpty = originalEmpty
+		engineOpts = originalOpts
+	})
+	// Start every test from a clean slate regardless of leftover state.
+	forceInit = false
+	initScopeFlag = ""
+	initImportAll = false
+	initEmpty = false
+}
+
+func writeSkillMD(t *testing.T, dir, name string) {
+	t.Helper()
+	full := filepath.Join(dir, name)
+	if err := os.MkdirAll(full, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: " + name + "\ndescription: test\n---\n"
+	if err := os.WriteFile(filepath.Join(full, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInit_NonInteractive_ImportAllProject(t *testing.T) {
+	resetInitFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Drop a project-level claude-code skill under workDir.
+	writeSkillMD(t, filepath.Join(workDir, ".claude", "skills"), "frontend-design")
+
+	dest := filepath.Join(workDir, "gaal.yaml")
+	cfgFile = dest
+	forceInit = true
+	initScopeFlag = "project"
+	initImportAll = true
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	if err := runInit(initCmd, nil); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	cfg, err := config.Load(dest)
+	if err != nil {
+		t.Fatalf("generated file does not parse: %v", err)
+	}
+	if len(cfg.Skills) != 1 {
+		t.Fatalf("expected 1 skill entry, got %d: %+v", len(cfg.Skills), cfg.Skills)
+	}
+	if cfg.Skills[0].Global {
+		t.Error("project scope must set Global=false")
+	}
+	if len(cfg.Skills[0].Select) != 1 || cfg.Skills[0].Select[0] != "frontend-design" {
+		t.Errorf("unexpected Select: %v", cfg.Skills[0].Select)
+	}
+}
+
+func TestInit_NonInteractive_InvalidScope(t *testing.T) {
+	resetInitFlags(t)
+
+	initScopeFlag = "bogus"
+	forceInit = true
+	initImportAll = true
+	cfgFile = filepath.Join(t.TempDir(), "gaal.yaml")
+
+	err := runInit(initCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid --scope")
+	}
+	if !strings.Contains(err.Error(), `must be "project" or "global"`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestInit_NonInteractive_EmptyFlagWritesSkeleton(t *testing.T) {
+	resetInitFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dest := filepath.Join(workDir, "gaal.yaml")
+	cfgFile = dest
+	forceInit = true
+	initScopeFlag = "project"
+	initEmpty = true
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	if err := runInit(initCmd, nil); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"repositories:", "skills:", "mcps:"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+func TestInit_NonInteractive_RequiresModeFlag(t *testing.T) {
+	resetInitFlags(t)
+
+	initScopeFlag = "project"
+	cfgFile = filepath.Join(t.TempDir(), "gaal.yaml")
+	forceInit = true
+
+	err := runInit(initCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when neither --empty nor --import-all is set in non-interactive mode")
+	}
+	if !strings.Contains(err.Error(), "--empty") && !strings.Contains(err.Error(), "--import-all") {
+		t.Errorf("error should mention the required flags: %v", err)
+	}
+}
+
+func TestInit_NonInteractive_GlobalImportAll(t *testing.T) {
+	resetInitFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Drop a global-level claude-code skill.
+	writeSkillMD(t, filepath.Join(home, ".claude", "skills"), "global-skill")
+
+	dest := filepath.Join(t.TempDir(), "out.yaml")
+	cfgFile = dest
+	forceInit = true
+	initScopeFlag = "global"
+	initImportAll = true
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	if err := runInit(initCmd, nil); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	cfg, err := config.Load(dest)
+	if err != nil {
+		t.Fatalf("generated file does not parse: %v", err)
+	}
+	if len(cfg.Skills) != 1 || !cfg.Skills[0].Global {
+		t.Errorf("expected 1 global skill entry, got %+v", cfg.Skills)
+	}
+}
+
+func TestInit_BuildPlanGroupsSkills(t *testing.T) {
+	// Verifies that the end-to-end flow groups multiple skills from the same
+	// source into a single SkillConfig via ops.BuildPlan.
+	resetInitFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(workDir, ".claude", "skills")
+	writeSkillMD(t, dir, "frontend-design")
+	writeSkillMD(t, dir, "code-reviewer")
+
+	dest := filepath.Join(workDir, "gaal.yaml")
+	cfgFile = dest
+	forceInit = true
+	initScopeFlag = "project"
+	initImportAll = true
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	if err := runInit(initCmd, nil); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	cfg, err := config.Load(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Each skill lives in its own directory so ResolveSkillSource falls back
+	// to SourceKindPath with distinct source paths — BuildPlan emits one
+	// entry per skill.
+	if len(cfg.Skills) != 2 {
+		t.Errorf("expected 2 entries, got %d: %+v", len(cfg.Skills), cfg.Skills)
+	}
+}

--- a/cmd/internal/wizard/scope.go
+++ b/cmd/internal/wizard/scope.go
@@ -1,0 +1,62 @@
+// Package wizard hosts the interactive TUI helpers used by the gaal init
+// command. Nothing in this package owns business logic: every piece of data
+// it renders comes from internal/engine/ops.
+package wizard
+
+import (
+	"fmt"
+
+	"github.com/pterm/pterm"
+
+	"gaal/internal/engine/ops"
+)
+
+// Mode is the high-level init strategy chosen by the user.
+type Mode string
+
+const (
+	// ModeEmpty writes the documented empty template.
+	ModeEmpty Mode = "empty"
+	// ModeImport runs the audit-driven selection wizard.
+	ModeImport Mode = "import"
+)
+
+// SelectMode prompts the user to choose between starting from an empty
+// template or importing detected skills and MCP servers.
+func SelectMode() (Mode, error) {
+	emptyLabel := "empty — start from a documented skeleton"
+	importLabel := "import — select from skills and MCP servers detected on this machine"
+
+	choice, err := pterm.DefaultInteractiveSelect.
+		WithOptions([]string{importLabel, emptyLabel}).
+		WithDefaultText("How would you like to create gaal.yaml?").
+		Show()
+	if err != nil {
+		return "", fmt.Errorf("mode prompt: %w", err)
+	}
+	if choice == emptyLabel {
+		return ModeEmpty, nil
+	}
+	return ModeImport, nil
+}
+
+// SelectScope prompts the user to choose between a project-scoped and a
+// global-scoped gaal configuration. The returned scope is guaranteed to be
+// one of ops.ScopeProject / ops.ScopeGlobal.
+func SelectScope(projectPath, globalPath string) (ops.Scope, error) {
+	projectLabel := fmt.Sprintf("project — writes %s", projectPath)
+	globalLabel := fmt.Sprintf("global  — writes %s", globalPath)
+
+	choice, err := pterm.DefaultInteractiveSelect.
+		WithOptions([]string{projectLabel, globalLabel}).
+		WithDefaultText("Where should this configuration apply?").
+		Show()
+	if err != nil {
+		return "", fmt.Errorf("scope prompt: %w", err)
+	}
+
+	if choice == projectLabel {
+		return ops.ScopeProject, nil
+	}
+	return ops.ScopeGlobal, nil
+}

--- a/cmd/internal/wizard/select_sections.go
+++ b/cmd/internal/wizard/select_sections.go
@@ -1,0 +1,115 @@
+package wizard
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/pterm/pterm"
+
+	"gaal/internal/engine/ops"
+)
+
+// ErrCancelled is returned by SelectSections when the user aborts the prompt.
+var ErrCancelled = errors.New("wizard cancelled")
+
+// SelectSections presents the candidates as a flat pterm interactive
+// multiselect. Section grouping is preserved visually by prefixing every
+// option with its owning agent name, and by printing a static "info header"
+// above the prompt that lists detected agents (plus delegators for generic).
+//
+// Everything is preselected by default so the user can confirm with Enter.
+func SelectSections(candidates ops.Candidates, scope ops.Scope) (ops.Plan, error) {
+	// Print a compact info header above the prompt.
+	printHeader(candidates)
+
+	options, byLabel := buildOptionList(candidates)
+	if len(options) == 0 {
+		return ops.Plan{}, nil
+	}
+
+	selected, err := pterm.DefaultInteractiveMultiselect.
+		WithOptions(options).
+		WithDefaultOptions(options).
+		WithFilter(false).
+		WithDefaultText("Select the agent configuration to import").
+		WithCheckmark(&pterm.Checkmark{Checked: pterm.Green("✓"), Unchecked: " "}).
+		Show()
+	if err != nil {
+		return ops.Plan{}, fmt.Errorf("multiselect: %w", err)
+	}
+
+	if len(selected) == 0 {
+		return ops.Plan{}, ErrCancelled
+	}
+
+	chosen := make([]ops.Candidate, 0, len(selected))
+	for _, label := range selected {
+		if c, ok := byLabel[label]; ok {
+			chosen = append(chosen, c)
+		}
+	}
+	return ops.BuildPlan(chosen, scope), nil
+}
+
+// printHeader renders a compact summary of what was detected: one line per
+// agent with a counter. It is purely informational and never accepts input.
+func printHeader(c ops.Candidates) {
+	pterm.DefaultBasicText.Println()
+	pterm.DefaultBasicText.Println(pterm.Bold.Sprint("Detected configuration"))
+	for _, sec := range c.Sections {
+		line := fmt.Sprintf("  %s  %s",
+			pterm.Bold.Sprint(sec.AgentName),
+			pterm.Gray(fmt.Sprintf("(%d skill%s, %d mcp%s)",
+				len(sec.Skills), plural(len(sec.Skills)),
+				len(sec.MCPs), plural(len(sec.MCPs)))))
+		pterm.DefaultBasicText.Println(line)
+		if len(sec.GenericDelegators) > 0 {
+			pterm.DefaultBasicText.Println("    " +
+				pterm.Gray("delegated by: "+strings.Join(sec.GenericDelegators, ", ")))
+		}
+	}
+	pterm.DefaultBasicText.Println()
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// buildOptionList returns the ordered option labels for the multiselect and
+// a lookup table mapping each label back to its Candidate.
+//
+// Labels are made unique by prefixing them with "<agent> · " and suffixing
+// with a fingerprint when needed, so pterm can round-trip selection → label.
+func buildOptionList(c ops.Candidates) ([]string, map[string]ops.Candidate) {
+	options := []string{}
+	byLabel := map[string]ops.Candidate{}
+
+	add := func(base string, cand ops.Candidate) {
+		label := base
+		// Guarantee uniqueness even if two candidates share everything.
+		for suffix := 2; ; suffix++ {
+			if _, clash := byLabel[label]; !clash {
+				break
+			}
+			label = fmt.Sprintf("%s (#%d)", base, suffix)
+		}
+		options = append(options, label)
+		byLabel[label] = cand
+	}
+
+	for _, sec := range c.Sections {
+		for _, s := range sec.Skills {
+			base := fmt.Sprintf("%s · skill %s", sec.AgentName, s.SkillName)
+			add(base, s)
+		}
+		for _, m := range sec.MCPs {
+			base := fmt.Sprintf("%s · mcp   %s", sec.AgentName, m.MCPName)
+			add(base, m)
+		}
+	}
+	return options, byLabel
+}

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,18 @@ module gaal
 go 1.26
 
 require (
+	atomicgo.dev/keyboard v0.2.9
 	github.com/go-git/go-git/v5 v5.17.2
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/invopop/jsonschema v0.13.0
 	github.com/pterm/pterm v0.12.83
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.41.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	atomicgo.dev/cursor v0.2.0 // indirect
-	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -49,7 +50,6 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,6 +99,13 @@ func userConfigDir() (string, error) {
 	return os.UserConfigDir()
 }
 
+// UserConfigFilePath is the exported accessor for userConfigFilePath. It is
+// used by callers outside this package (e.g. the init wizard) that need to
+// resolve the per-user config destination before a Config is loaded.
+func UserConfigFilePath() string {
+	return userConfigFilePath()
+}
+
 // userConfigFilePath returns the per-user config path for the current OS.
 // It respects XDG_CONFIG_HOME on Linux and macOS when set, otherwise ~/.config
 // on macOS (see userConfigDir), and %AppData% on Windows.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -72,6 +72,14 @@ func TestUserConfigFilePath_Darwin(t *testing.T) {
 	}
 }
 
+func TestUserConfigFilePath_Exported(t *testing.T) {
+	got := UserConfigFilePath()
+	want := userConfigFilePath()
+	if got != want {
+		t.Errorf("exported UserConfigFilePath returned %q, want %q", got, want)
+	}
+}
+
 func TestUserConfigFilePath_DarwinUsesXDGConfigHome(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("darwin-only test")

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -54,12 +54,13 @@ type Options struct {
 
 // Engine orchestrates repository, skill and MCP synchronisation.
 type Engine struct {
-	cfg     *config.Config
-	repos   *repo.Manager
-	skills  *skill.Manager
-	mcps    *mcp.Manager
-	home    string
-	workDir string
+	cfg       *config.Config
+	repos     *repo.Manager
+	skills    *skill.Manager
+	mcps      *mcp.Manager
+	home      string
+	workDir   string
+	cacheRoot string
 }
 
 // New creates an Engine from the given configuration using default directories.
@@ -88,12 +89,13 @@ func NewWithOptions(cfg *config.Config, opts Options) *Engine {
 	slog.Debug("engine initialised", "home", home, "workDir", workDir, "cacheDir", cacheDir)
 
 	return &Engine{
-		cfg:     cfg,
-		repos:   repo.NewManager(cfg.Repositories),
-		skills:  skill.NewManager(cfg.Skills, cacheDir, home, workDir),
-		mcps:    mcp.NewManager(cfg.MCPs),
-		home:    home,
-		workDir: workDir,
+		cfg:       cfg,
+		repos:     repo.NewManager(cfg.Repositories),
+		skills:    skill.NewManager(cfg.Skills, cacheDir, home, workDir),
+		mcps:      mcp.NewManager(cfg.MCPs),
+		home:      home,
+		workDir:   workDir,
+		cacheRoot: cacheRoot,
 	}
 }
 
@@ -183,4 +185,15 @@ func (e *Engine) Info(ctx context.Context, pkg, filter string, format OutputForm
 // Init writes the documented gaal.yaml skeleton to dest.
 func (e *Engine) Init(dest string, force bool) error {
 	return ops.Init(dest, force)
+}
+
+// BuildImportCandidates scans the machine for installed skills and MCP servers
+// filtered by the given scope. The result is intended for the init wizard.
+func (e *Engine) BuildImportCandidates(ctx context.Context, scope ops.Scope) (ops.Candidates, error) {
+	return ops.BuildImportCandidates(ctx, scope, e.home, e.workDir, e.cacheRoot)
+}
+
+// InitFromPlan writes a gaal.yaml populated from the user-selected plan.
+func (e *Engine) InitFromPlan(dest string, plan ops.Plan, force bool) error {
+	return ops.InitFromPlan(dest, plan, force)
 }

--- a/internal/engine/ops/init.go
+++ b/internal/engine/ops/init.go
@@ -1,11 +1,17 @@
 package ops
 
 import (
+	"bytes"
 	_ "embed"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"gaal/internal/config"
 )
 
 //go:embed init_template.yaml
@@ -17,12 +23,12 @@ var InitTemplate []byte
 func Init(dest string, force bool) error {
 	slog.Debug("init", "dest", dest, "force", force)
 
-	if !force {
-		if _, err := os.Stat(dest); err == nil {
-			return fmt.Errorf("%s already exists — use --force to overwrite", dest)
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("checking %s: %w", dest, err)
-		}
+	if err := checkDestination(dest, force); err != nil {
+		return err
+	}
+
+	if err := ensureParentDir(dest); err != nil {
+		return err
 	}
 
 	if err := os.WriteFile(dest, InitTemplate, 0o644); err != nil {
@@ -31,4 +37,174 @@ func Init(dest string, force bool) error {
 
 	slog.Info("config file created", "path", dest)
 	return nil
+}
+
+// InitFromPlan writes a gaal.yaml that reuses the documented comment headers
+// of the embedded template but replaces the empty skills: / mcps: blocks
+// with the entries carried by plan. repositories: remains empty.
+//
+// The force and dest-existence rules are identical to Init.
+func InitFromPlan(dest string, plan Plan, force bool) error {
+	slog.Debug("init from plan", "dest", dest, "force", force,
+		"skills", len(plan.Skills), "mcps", len(plan.MCPs))
+
+	if err := checkDestination(dest, force); err != nil {
+		return err
+	}
+
+	content, err := renderPlanYAML(plan)
+	if err != nil {
+		return fmt.Errorf("rendering plan: %w", err)
+	}
+
+	if err := ensureParentDir(dest); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(dest, content, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", dest, err)
+	}
+
+	slog.Info("config file created from audit plan", "path", dest,
+		"skills", len(plan.Skills), "mcps", len(plan.MCPs))
+	return nil
+}
+
+// ensureParentDir creates the parent directory of dest if it does not yet
+// exist. This is safe for both project- and user-scope destinations: the
+// user-scope path (e.g. ~/.config/gaal/config.yaml) may legitimately not
+// exist yet on a fresh install.
+func ensureParentDir(dest string) error {
+	parent := filepath.Dir(dest)
+	if parent == "" || parent == "." {
+		return nil
+	}
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("creating parent directory %s: %w", parent, err)
+	}
+	return nil
+}
+
+func checkDestination(dest string, force bool) error {
+	if force {
+		return nil
+	}
+	if _, err := os.Stat(dest); err == nil {
+		return fmt.Errorf("%s already exists — use --force to overwrite", dest)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("checking %s: %w", dest, err)
+	}
+	return nil
+}
+
+// renderPlanYAML keeps the three commented headers from init_template.yaml and
+// replaces the empty "repositories: {}", "skills: [...]", "mcps: [...]" blocks
+// with the plan content serialised via yaml.v3 for safety.
+func renderPlanYAML(plan Plan) ([]byte, error) {
+	headers, err := splitTemplateHeaders(InitTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	buf.Write(headers.intro)
+
+	buf.Write(headers.repositories)
+	buf.WriteString("repositories: {}\n\n")
+
+	buf.Write(headers.skills)
+	if err := writeSkillsBlock(&buf, plan.Skills); err != nil {
+		return nil, err
+	}
+	buf.WriteString("\n")
+
+	buf.Write(headers.mcps)
+	if err := writeMCPsBlock(&buf, plan.MCPs); err != nil {
+		return nil, err
+	}
+	buf.WriteString("\n")
+
+	return buf.Bytes(), nil
+}
+
+func writeSkillsBlock(buf *bytes.Buffer, skills []config.SkillConfig) error {
+	if len(skills) == 0 {
+		buf.WriteString("skills: []\n")
+		return nil
+	}
+	raw, err := yaml.Marshal(map[string]any{"skills": skills})
+	if err != nil {
+		return err
+	}
+	buf.Write(raw)
+	return nil
+}
+
+func writeMCPsBlock(buf *bytes.Buffer, mcps []config.MCPConfig) error {
+	if len(mcps) == 0 {
+		buf.WriteString("mcps: []\n")
+		return nil
+	}
+	raw, err := yaml.Marshal(map[string]any{"mcps": mcps})
+	if err != nil {
+		return err
+	}
+	buf.Write(raw)
+	return nil
+}
+
+// templateHeaders holds the comment blocks extracted from init_template.yaml.
+type templateHeaders struct {
+	intro        []byte // top-of-file comments before the first section
+	repositories []byte // "# ── repositories ──" block
+	skills       []byte // "# ── skills ──" block
+	mcps         []byte // "# ── mcps ──" block
+}
+
+// splitTemplateHeaders parses init_template.yaml and returns its comment
+// blocks. The YAML keys themselves are excluded from each block so the
+// caller can re-emit them with real content.
+func splitTemplateHeaders(tmpl []byte) (templateHeaders, error) {
+	idxRepos := bytes.Index(tmpl, []byte("repositories:"))
+	idxSkills := bytes.Index(tmpl, []byte("skills:"))
+	idxMcps := bytes.Index(tmpl, []byte("mcps:"))
+	if idxRepos < 0 || idxSkills < 0 || idxMcps < 0 {
+		return templateHeaders{}, fmt.Errorf("init template missing a required section key")
+	}
+	return templateHeaders{
+		intro:        tmpl[:commentBlockStart(tmpl, idxRepos)],
+		repositories: extractHeaderBlock(tmpl, idxRepos),
+		skills:       extractHeaderBlock(tmpl, idxSkills),
+		mcps:         extractHeaderBlock(tmpl, idxMcps),
+	}, nil
+}
+
+// commentBlockStart walks backwards from keyIdx over consecutive comment /
+// blank lines, returning the byte offset where the comment block starts.
+func commentBlockStart(tmpl []byte, keyIdx int) int {
+	lines := bytes.Split(tmpl[:keyIdx], []byte("\n"))
+	start := keyIdx
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := bytes.TrimSpace(lines[i])
+		if len(trimmed) == 0 || bytes.HasPrefix(trimmed, []byte("#")) {
+			// Subtract this line plus its newline.
+			start -= len(lines[i]) + 1
+			continue
+		}
+		break
+	}
+	if start < 0 {
+		start = 0
+	}
+	return start
+}
+
+// extractHeaderBlock returns the comment block immediately preceding keyIdx,
+// ending right before the key itself.
+func extractHeaderBlock(tmpl []byte, keyIdx int) []byte {
+	start := commentBlockStart(tmpl, keyIdx)
+	if start < 0 {
+		start = 0
+	}
+	return tmpl[start:keyIdx]
 }

--- a/internal/engine/ops/init_build.go
+++ b/internal/engine/ops/init_build.go
@@ -1,0 +1,231 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"gaal/internal/config"
+	"gaal/internal/core/agent"
+	"gaal/internal/engine/render"
+	"gaal/internal/mcp"
+)
+
+// BuildImportCandidates runs the same discovery passes as Audit, filters them
+// by scope, resolves best-effort source strings for skills, and loads the full
+// inline definition of every detected MCP server.
+//
+// The returned Candidates list is grouped by agent and sorted by agent name.
+// Sections with no skill AND no MCP are omitted, so the caller only ever sees
+// agents that actually have importable content.
+func BuildImportCandidates(ctx context.Context, scope Scope, home, workDir, cacheRoot string) (Candidates, error) {
+	slog.DebugContext(ctx, "building import candidates",
+		"scope", scope, "home", home, "workDir", workDir, "cacheRoot", cacheRoot)
+
+	skills, err := collectAuditSkills(ctx, home, workDir)
+	if err != nil {
+		return Candidates{}, fmt.Errorf("collecting audit skills: %w", err)
+	}
+
+	filteredSkills := filterSkillsByScope(skills, scope)
+
+	mcps, err := collectInitMCPs(ctx, home)
+	if err != nil {
+		return Candidates{}, fmt.Errorf("collecting mcps: %w", err)
+	}
+
+	byAgent := map[string]*AgentSection{}
+
+	// Dedupe skills by (agent, skillName), keeping the candidate with the
+	// best-ranked source (git > cache > path). When the same skill shows up
+	// via several search paths — which is common when an agent overlays a
+	// package-manager plugin over a user-installed skill — the user only
+	// sees it once.
+	type skillKey struct{ agent, name string }
+	bestSkill := map[skillKey]Candidate{}
+
+	for _, s := range filteredSkills {
+		src, kind := ResolveSkillSource(s.Path, cacheRoot)
+		cand := Candidate{
+			Kind:            CandidateSkill,
+			AgentName:       s.Agent,
+			Label:           fmt.Sprintf("skill: %s", s.Name),
+			Detail:          detailForSkill(src, s.Path),
+			SkillName:       s.Name,
+			SkillDesc:       s.Desc,
+			SkillPath:       s.Path,
+			SkillSource:     src,
+			SkillSourceKind: kind,
+		}
+		key := skillKey{agent: s.Agent, name: s.Name}
+		if existing, ok := bestSkill[key]; !ok || sourceKindRank(kind) > sourceKindRank(existing.SkillSourceKind) {
+			bestSkill[key] = cand
+		}
+	}
+
+	for _, cand := range bestSkill {
+		sec := byAgent[cand.AgentName]
+		if sec == nil {
+			sec = &AgentSection{AgentName: cand.AgentName}
+			byAgent[cand.AgentName] = sec
+		}
+		sec.Skills = append(sec.Skills, cand)
+	}
+
+	for _, m := range mcps {
+		sec := byAgent[m.agent]
+		if sec == nil {
+			sec = &AgentSection{AgentName: m.agent}
+			byAgent[m.agent] = sec
+		}
+		for name, inline := range m.servers {
+			inlineCopy := inline
+			sec.MCPs = append(sec.MCPs, Candidate{
+				Kind:      CandidateMCP,
+				AgentName: m.agent,
+				Label:     fmt.Sprintf("mcp:   %s", name),
+				Detail:    m.file,
+				MCPName:   name,
+				MCPTarget: m.file,
+				MCPInline: &inlineCopy,
+			})
+		}
+	}
+
+	for _, sec := range byAgent {
+		sort.Slice(sec.Skills, func(i, j int) bool { return sec.Skills[i].SkillName < sec.Skills[j].SkillName })
+		sort.Slice(sec.MCPs, func(i, j int) bool { return sec.MCPs[i].MCPName < sec.MCPs[j].MCPName })
+	}
+
+	if sec := byAgent["generic"]; sec != nil {
+		sec.GenericDelegators = genericDelegators(scope)
+	}
+
+	names := make([]string, 0, len(byAgent))
+	for name := range byAgent {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	sections := make([]AgentSection, 0, len(names))
+	for _, name := range names {
+		sections = append(sections, *byAgent[name])
+	}
+	return Candidates{Sections: sections}, nil
+}
+
+// filterSkillsByScope keeps only audit skills whose Source matches the chosen
+// gaal scope:
+//
+//   - ScopeProject  → "project"
+//   - ScopeGlobal   → "global" and "package-manager"
+func filterSkillsByScope(in []render.AuditSkillEntry, scope Scope) []render.AuditSkillEntry {
+	out := make([]render.AuditSkillEntry, 0, len(in))
+	for _, s := range in {
+		switch scope {
+		case ScopeProject:
+			if s.Source == "project" {
+				out = append(out, s)
+			}
+		case ScopeGlobal:
+			if s.Source == "global" || s.Source == "package-manager" {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}
+
+// initMCPEntry is a local shape holding the full inline definition loaded
+// from one agent's MCP config file.
+type initMCPEntry struct {
+	agent   string
+	file    string
+	servers map[string]config.MCPInlineConfig
+}
+
+// collectInitMCPs walks every registered agent, resolves its MCP config path,
+// and loads the full set of inline definitions. Agents without a config path
+// or whose file cannot be parsed are skipped (warn-level log). Servers
+// without a command (e.g. URL-based HTTP transports) cannot be round-tripped
+// through gaal.yaml today and are dropped with a debug log.
+func collectInitMCPs(ctx context.Context, home string) ([]initMCPEntry, error) {
+	slog.DebugContext(ctx, "collecting init mcps")
+	var entries []initMCPEntry
+
+	for _, a := range agent.List() {
+		cfgFile, ok := agent.ProjectMCPConfigPath(a.Name, home)
+		if !ok {
+			continue
+		}
+		servers, err := mcp.LoadServers(cfgFile)
+		if err != nil {
+			slog.WarnContext(ctx, "cannot load mcp config file, skipping agent",
+				"agent", a.Name, "file", cfgFile, "err", err)
+			continue
+		}
+		supported := map[string]config.MCPInlineConfig{}
+		for name, inline := range servers {
+			if inline.Command == "" {
+				slog.DebugContext(ctx, "skipping mcp server without command",
+					"agent", a.Name, "server", name, "file", cfgFile)
+				continue
+			}
+			supported[name] = inline
+		}
+		if len(supported) == 0 {
+			continue
+		}
+		entries = append(entries, initMCPEntry{
+			agent:   a.Name,
+			file:    cfgFile,
+			servers: supported,
+		})
+	}
+	return entries, nil
+}
+
+// genericDelegators returns the sorted list of agent names that natively
+// read from the generic project or global convention for the given scope.
+func genericDelegators(scope Scope) []string {
+	var out []string
+	for _, a := range agent.List() {
+		switch scope {
+		case ScopeProject:
+			if a.Info.SupportsGenericProject && a.Name != "generic" {
+				out = append(out, a.Name)
+			}
+		case ScopeGlobal:
+			if a.Info.SupportsGenericGlobal && a.Name != "generic" {
+				out = append(out, a.Name)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// detailForSkill chooses the grey trailing string rendered by the wizard for
+// a skill candidate: we prefer the resolved source when it differs from the
+// raw disk path, otherwise we show the path itself.
+func detailForSkill(source, path string) string {
+	if source == path {
+		return path
+	}
+	return source
+}
+
+// sourceKindRank ranks source resolution outcomes so Dedupe can keep the
+// most informative one per skill. Higher is better.
+func sourceKindRank(k SourceKind) int {
+	switch k {
+	case SourceKindGit:
+		return 3
+	case SourceKindCache:
+		return 2
+	case SourceKindPath:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/engine/ops/init_build_test.go
+++ b/internal/engine/ops/init_build_test.go
@@ -1,0 +1,188 @@
+package ops
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// findSection returns the AgentSection matching name, or nil.
+func findSection(c Candidates, name string) *AgentSection {
+	for i := range c.Sections {
+		if c.Sections[i].AgentName == name {
+			return &c.Sections[i]
+		}
+	}
+	return nil
+}
+
+func TestBuildImportCandidates_Empty(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	cacheRoot := t.TempDir()
+
+	c, err := BuildImportCandidates(context.Background(), ScopeProject, home, workDir, cacheRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(c.Sections) != 0 {
+		t.Errorf("expected no sections, got %d", len(c.Sections))
+	}
+}
+
+func TestBuildImportCandidates_ProjectScope_KeepsProjectSkills(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	cacheRoot := t.TempDir()
+
+	// Project-level skill for claude-code.
+	makeSkill(t, workDir, ".claude/skills", "frontend", "desc")
+
+	c, err := BuildImportCandidates(context.Background(), ScopeProject, home, workDir, cacheRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sec := findSection(c, "claude-code")
+	if sec == nil {
+		t.Fatalf("missing claude-code section: %+v", c)
+	}
+	if len(sec.Skills) != 1 || sec.Skills[0].SkillName != "frontend" {
+		t.Errorf("expected one skill named frontend, got %+v", sec.Skills)
+	}
+	if sec.Skills[0].SkillSourceKind != SourceKindPath {
+		t.Errorf("expected SourceKindPath, got %q", sec.Skills[0].SkillSourceKind)
+	}
+}
+
+func TestBuildImportCandidates_ProjectScope_DropsGlobalSkills(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	cacheRoot := t.TempDir()
+
+	// Global-level skill for claude-code (should be hidden in project scope).
+	makeSkill(t, home, ".claude/skills", "global-one", "")
+
+	c, err := BuildImportCandidates(context.Background(), ScopeProject, home, workDir, cacheRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(c.Sections) != 0 {
+		t.Errorf("expected no sections, got: %+v", c.Sections)
+	}
+}
+
+func TestBuildImportCandidates_GlobalScope_KeepsGlobalSkills(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	cacheRoot := t.TempDir()
+
+	makeSkill(t, home, ".claude/skills", "global-one", "")
+
+	c, err := BuildImportCandidates(context.Background(), ScopeGlobal, home, workDir, cacheRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sec := findSection(c, "claude-code")
+	if sec == nil {
+		t.Fatalf("missing claude-code section: %+v", c)
+	}
+	if len(sec.Skills) != 1 || sec.Skills[0].SkillName != "global-one" {
+		t.Errorf("expected one global skill, got %+v", sec.Skills)
+	}
+}
+
+func TestBuildImportCandidates_GlobalScope_DropsProjectSkills(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	cacheRoot := t.TempDir()
+
+	makeSkill(t, workDir, ".claude/skills", "project-one", "")
+
+	c, err := BuildImportCandidates(context.Background(), ScopeGlobal, home, workDir, cacheRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sec := findSection(c, "claude-code"); sec != nil {
+		t.Errorf("claude-code project skill must not appear in global scope: %+v", sec)
+	}
+}
+
+func TestBuildImportCandidates_GenericSectionWithDelegators(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	cacheRoot := t.TempDir()
+
+	makeSkill(t, workDir, ".agents/skills", "shared", "desc")
+
+	c, err := BuildImportCandidates(context.Background(), ScopeProject, home, workDir, cacheRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sec := findSection(c, "generic")
+	if sec == nil {
+		t.Fatalf("missing generic section: %+v", c)
+	}
+	if len(sec.GenericDelegators) == 0 {
+		t.Error("expected GenericDelegators to be populated in project scope")
+	}
+	if len(sec.Skills) != 1 || sec.Skills[0].SkillName != "shared" {
+		t.Errorf("expected one shared skill, got %+v", sec.Skills)
+	}
+}
+
+func TestBuildImportCandidates_MCPsFromAgentConfig(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	cacheRoot := t.TempDir()
+
+	// claude-code's ProjectMCPConfigFile is ~/.config/claude/claude_desktop_config.json.
+	cfgDir := filepath.Join(home, ".config", "claude")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"mcpServers":{"filesystem":{"command":"uvx","args":["mcp-server-filesystem","/tmp"]}}}`
+	cfgFile := filepath.Join(cfgDir, "claude_desktop_config.json")
+	if err := os.WriteFile(cfgFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := BuildImportCandidates(context.Background(), ScopeProject, home, workDir, cacheRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sec := findSection(c, "claude-code")
+	if sec == nil {
+		t.Fatalf("missing claude-code section: %+v", c)
+	}
+	if len(sec.MCPs) != 1 || sec.MCPs[0].MCPName != "filesystem" {
+		t.Errorf("expected filesystem mcp, got %+v", sec.MCPs)
+	}
+	if sec.MCPs[0].MCPInline == nil || sec.MCPs[0].MCPInline.Command != "uvx" {
+		t.Errorf("expected inline loaded, got %+v", sec.MCPs[0].MCPInline)
+	}
+}
+
+func TestBuildImportCandidates_SectionsSortedByAgent(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	cacheRoot := t.TempDir()
+
+	// Drop one skill in a claude-code dir and one in generic.
+	makeSkill(t, workDir, ".claude/skills", "one", "")
+	makeSkill(t, workDir, ".agents/skills", "two", "")
+
+	c, err := BuildImportCandidates(context.Background(), ScopeProject, home, workDir, cacheRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(c.Sections) < 2 {
+		t.Fatalf("expected at least 2 sections, got %+v", c.Sections)
+	}
+	for i := 1; i < len(c.Sections); i++ {
+		if c.Sections[i-1].AgentName > c.Sections[i].AgentName {
+			t.Errorf("sections not sorted: %q came before %q",
+				c.Sections[i-1].AgentName, c.Sections[i].AgentName)
+		}
+	}
+}

--- a/internal/engine/ops/init_plan.go
+++ b/internal/engine/ops/init_plan.go
@@ -1,0 +1,147 @@
+package ops
+
+import (
+	"sort"
+
+	"gaal/internal/config"
+)
+
+// Scope is the gaal.yaml destination scope selected by the user during init.
+// It drives the output file path, the filter applied to audit results, and
+// the value of the Global flag on generated SkillConfig entries.
+type Scope string
+
+const (
+	ScopeProject Scope = "project"
+	ScopeGlobal  Scope = "global"
+)
+
+// CandidateKind distinguishes skill candidates from MCP candidates inside a
+// flat list rendered by the init wizard.
+type CandidateKind string
+
+const (
+	CandidateSkill CandidateKind = "skill"
+	CandidateMCP   CandidateKind = "mcp"
+)
+
+// Candidate is one importable item surfaced by BuildImportCandidates. The
+// wizard turns a user's selection into a Plan via BuildPlan.
+type Candidate struct {
+	Kind      CandidateKind
+	AgentName string
+	Label     string
+	Detail    string
+
+	// Skill fields (populated when Kind == CandidateSkill).
+	SkillName       string
+	SkillDesc       string
+	SkillPath       string
+	SkillSource     string
+	SkillSourceKind SourceKind
+
+	// MCP fields (populated when Kind == CandidateMCP).
+	MCPName   string
+	MCPTarget string
+	MCPInline *config.MCPInlineConfig
+}
+
+// AgentSection groups candidates by their owning agent. The generic agent
+// carries the list of delegators in GenericDelegators so the wizard can show
+// an info line under its header.
+type AgentSection struct {
+	AgentName         string
+	GenericDelegators []string
+	Skills            []Candidate
+	MCPs              []Candidate
+}
+
+// Candidates is the structured result of BuildImportCandidates, ready for
+// rendering by the wizard.
+type Candidates struct {
+	Sections []AgentSection
+}
+
+// Plan is the resolved set of configuration entries to write to gaal.yaml.
+type Plan struct {
+	Skills []config.SkillConfig
+	MCPs   []config.MCPConfig
+}
+
+// BuildPlan converts a slice of user-selected candidates into a Plan.
+//
+// Skills sharing the same (source, agent, scope) triple are grouped into a
+// single SkillConfig with a sorted, deduplicated Select list. MCPs are never
+// grouped. Output entries are sorted for deterministic YAML.
+func BuildPlan(selected []Candidate, scope Scope) Plan {
+	global := scope == ScopeGlobal
+
+	type skillKey struct {
+		source string
+		agent  string
+	}
+	grouped := map[skillKey][]string{}
+	keys := []skillKey{}
+	var mcps []config.MCPConfig
+
+	for _, c := range selected {
+		switch c.Kind {
+		case CandidateSkill:
+			k := skillKey{source: c.SkillSource, agent: c.AgentName}
+			if _, ok := grouped[k]; !ok {
+				keys = append(keys, k)
+			}
+			grouped[k] = append(grouped[k], c.SkillName)
+		case CandidateMCP:
+			entry := config.MCPConfig{
+				Name:   c.MCPName,
+				Target: c.MCPTarget,
+			}
+			if c.MCPInline != nil {
+				inline := *c.MCPInline
+				entry.Inline = &inline
+			}
+			mcps = append(mcps, entry)
+		}
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].agent != keys[j].agent {
+			return keys[i].agent < keys[j].agent
+		}
+		return keys[i].source < keys[j].source
+	})
+
+	skills := make([]config.SkillConfig, 0, len(keys))
+	for _, k := range keys {
+		names := dedupSorted(grouped[k])
+		skills = append(skills, config.SkillConfig{
+			Source: k.source,
+			Agents: []string{k.agent},
+			Global: global,
+			Select: names,
+		})
+	}
+
+	sort.Slice(mcps, func(i, j int) bool { return mcps[i].Name < mcps[j].Name })
+
+	return Plan{Skills: skills, MCPs: mcps}
+}
+
+func dedupSorted(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	cp := make([]string, len(in))
+	copy(cp, in)
+	sort.Strings(cp)
+	out := cp[:0]
+	var last string
+	for i, s := range cp {
+		if i == 0 || s != last {
+			out = append(out, s)
+		}
+		last = s
+	}
+	return out
+}

--- a/internal/engine/ops/init_plan_test.go
+++ b/internal/engine/ops/init_plan_test.go
@@ -1,0 +1,99 @@
+package ops
+
+import (
+	"reflect"
+	"testing"
+
+	"gaal/internal/config"
+)
+
+func TestBuildPlan_GlobalFlagMatchesScope(t *testing.T) {
+	cand := Candidate{
+		Kind:        CandidateSkill,
+		AgentName:   "claude-code",
+		SkillName:   "frontend-design",
+		SkillSource: "anthropics/skills",
+	}
+	plan := BuildPlan([]Candidate{cand}, ScopeGlobal)
+	if len(plan.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(plan.Skills))
+	}
+	if !plan.Skills[0].Global {
+		t.Error("Global should be true for ScopeGlobal")
+	}
+
+	plan = BuildPlan([]Candidate{cand}, ScopeProject)
+	if plan.Skills[0].Global {
+		t.Error("Global should be false for ScopeProject")
+	}
+}
+
+func TestBuildPlan_GroupSkillsBySourceAndAgent(t *testing.T) {
+	cands := []Candidate{
+		{Kind: CandidateSkill, AgentName: "claude-code", SkillName: "b", SkillSource: "anthropics/skills"},
+		{Kind: CandidateSkill, AgentName: "claude-code", SkillName: "a", SkillSource: "anthropics/skills"},
+		{Kind: CandidateSkill, AgentName: "claude-code", SkillName: "c", SkillSource: "anthropics/skills"},
+	}
+	plan := BuildPlan(cands, ScopeProject)
+	if len(plan.Skills) != 1 {
+		t.Fatalf("expected 1 grouped skill entry, got %d", len(plan.Skills))
+	}
+	got := plan.Skills[0]
+	if got.Source != "anthropics/skills" {
+		t.Errorf("source: got %q", got.Source)
+	}
+	if !reflect.DeepEqual(got.Agents, []string{"claude-code"}) {
+		t.Errorf("agents: got %v", got.Agents)
+	}
+	if !reflect.DeepEqual(got.Select, []string{"a", "b", "c"}) {
+		t.Errorf("select: got %v, want sorted [a b c]", got.Select)
+	}
+}
+
+func TestBuildPlan_DoNotGroupAcrossAgents(t *testing.T) {
+	cands := []Candidate{
+		{Kind: CandidateSkill, AgentName: "claude-code", SkillName: "a", SkillSource: "anthropics/skills"},
+		{Kind: CandidateSkill, AgentName: "cursor", SkillName: "a", SkillSource: "anthropics/skills"},
+	}
+	plan := BuildPlan(cands, ScopeProject)
+	if len(plan.Skills) != 2 {
+		t.Fatalf("expected 2 entries (per agent), got %d", len(plan.Skills))
+	}
+}
+
+func TestBuildPlan_DoNotGroupAcrossSources(t *testing.T) {
+	cands := []Candidate{
+		{Kind: CandidateSkill, AgentName: "claude-code", SkillName: "a", SkillSource: "anthropics/skills"},
+		{Kind: CandidateSkill, AgentName: "claude-code", SkillName: "b", SkillSource: "vercel-labs/agent-skills"},
+	}
+	plan := BuildPlan(cands, ScopeProject)
+	if len(plan.Skills) != 2 {
+		t.Fatalf("expected 2 entries (per source), got %d", len(plan.Skills))
+	}
+}
+
+func TestBuildPlan_MCPsNotGrouped(t *testing.T) {
+	inline := &config.MCPInlineConfig{Command: "uvx", Args: []string{"mcp-server-git"}}
+	cands := []Candidate{
+		{Kind: CandidateMCP, AgentName: "claude-code", MCPName: "a", MCPTarget: "~/.claude.json", MCPInline: inline},
+		{Kind: CandidateMCP, AgentName: "claude-code", MCPName: "b", MCPTarget: "~/.claude.json", MCPInline: inline},
+	}
+	plan := BuildPlan(cands, ScopeProject)
+	if len(plan.MCPs) != 2 {
+		t.Fatalf("expected 2 mcp entries, got %d", len(plan.MCPs))
+	}
+	if plan.MCPs[0].Name != "a" || plan.MCPs[1].Name != "b" {
+		t.Errorf("mcps not sorted by name: %v, %v", plan.MCPs[0].Name, plan.MCPs[1].Name)
+	}
+}
+
+func TestBuildPlan_SkillsSortedForStableOutput(t *testing.T) {
+	cands := []Candidate{
+		{Kind: CandidateSkill, AgentName: "cursor", SkillName: "a", SkillSource: "vercel-labs/agent-skills"},
+		{Kind: CandidateSkill, AgentName: "claude-code", SkillName: "a", SkillSource: "anthropics/skills"},
+	}
+	plan := BuildPlan(cands, ScopeProject)
+	if plan.Skills[0].Agents[0] != "claude-code" {
+		t.Errorf("expected claude-code first (sorted by agent), got %v", plan.Skills[0].Agents)
+	}
+}

--- a/internal/engine/ops/init_source.go
+++ b/internal/engine/ops/init_source.go
@@ -1,0 +1,96 @@
+package ops
+
+import (
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+)
+
+// SourceKind describes how the source of a skill was resolved.
+type SourceKind string
+
+const (
+	// SourceKindCache means the path lives under $UserCacheDir/gaal/skills
+	// and the source was reconstructed as "owner/repo".
+	SourceKindCache SourceKind = "cache"
+	// SourceKindGit means the nearest parent .git directory exposed an
+	// "origin" remote whose URL is used as the source.
+	SourceKindGit SourceKind = "git"
+	// SourceKindPath means no better information was available and the raw
+	// disk path is returned as-is.
+	SourceKindPath SourceKind = "path"
+)
+
+// ResolveSkillSource converts a concrete skill directory into the best
+// "source" string for a gaal.yaml SkillConfig entry.
+//
+// Resolution order, documented in the spec:
+//
+//  1. If skillDir lives under cacheRoot/gaal/skills/<owner>/<repo>/..., return
+//     "owner/repo", kind cache.
+//  2. Otherwise, if a parent directory is a git working copy with an origin
+//     remote, return that origin URL, kind git.
+//  3. Otherwise, return skillDir unchanged, kind path.
+//
+// ResolveSkillSource never returns an error: every failure falls through to
+// the next strategy and ultimately to the path fallback.
+func ResolveSkillSource(skillDir, cacheRoot string) (string, SourceKind) {
+	slog.Debug("resolving skill source", "dir", skillDir, "cacheRoot", cacheRoot)
+
+	if src, ok := reverseLookupCache(skillDir, cacheRoot); ok {
+		return src, SourceKindCache
+	}
+	if src, ok := lookupGitOrigin(skillDir); ok {
+		return src, SourceKindGit
+	}
+	return skillDir, SourceKindPath
+}
+
+// reverseLookupCache returns "owner/repo" when skillDir lives under
+// cacheRoot/gaal/skills/<owner>/<repo>/... — matching the layout written by
+// skill.Manager.
+func reverseLookupCache(skillDir, cacheRoot string) (string, bool) {
+	if cacheRoot == "" {
+		return "", false
+	}
+	skillsRoot := filepath.Join(cacheRoot, "gaal", "skills")
+	rel, err := filepath.Rel(skillsRoot, skillDir)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+	if strings.HasPrefix(rel, "..") || rel == "." {
+		return "", false
+	}
+	parts := strings.Split(rel, "/")
+	if len(parts) < 2 {
+		return "", false
+	}
+	return parts[0] + "/" + parts[1], true
+}
+
+// lookupGitOrigin walks upward from skillDir, opens the first git repository
+// it finds, and returns the URL of the "origin" remote when present.
+func lookupGitOrigin(skillDir string) (string, bool) {
+	dir := skillDir
+	for {
+		if repo, err := git.PlainOpen(dir); err == nil {
+			remote, err := repo.Remote("origin")
+			if err != nil {
+				return "", false
+			}
+			urls := remote.Config().URLs
+			if len(urls) == 0 {
+				return "", false
+			}
+			return urls[0], true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}

--- a/internal/engine/ops/init_source_test.go
+++ b/internal/engine/ops/init_source_test.go
@@ -1,0 +1,117 @@
+package ops
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+)
+
+func TestResolveSkillSource_CacheReverseLookup(t *testing.T) {
+	cacheRoot := t.TempDir()
+	skillsRoot := filepath.Join(cacheRoot, "gaal", "skills")
+	skillDir := filepath.Join(skillsRoot, "anthropics", "skills", "frontend-design")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	src, kind := ResolveSkillSource(skillDir, cacheRoot)
+	if src != "anthropics/skills" {
+		t.Errorf("source: got %q, want anthropics/skills", src)
+	}
+	if kind != SourceKindCache {
+		t.Errorf("kind: got %q, want cache", kind)
+	}
+}
+
+func TestResolveSkillSource_CacheMalformed(t *testing.T) {
+	// A path under the cache root but with fewer than owner/repo segments
+	// must fall through to git/path resolution.
+	cacheRoot := t.TempDir()
+	skillsRoot := filepath.Join(cacheRoot, "gaal", "skills")
+	// only one segment under skills/ — malformed.
+	shallow := filepath.Join(skillsRoot, "orphan")
+	if err := os.MkdirAll(shallow, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	src, kind := ResolveSkillSource(shallow, cacheRoot)
+	if kind == SourceKindCache {
+		t.Errorf("should not report cache for malformed layout, got %q", src)
+	}
+	if src != shallow {
+		t.Errorf("expected raw path fallback, got %q", src)
+	}
+	if kind != SourceKindPath {
+		t.Errorf("kind: got %q, want path", kind)
+	}
+}
+
+func TestResolveSkillSource_GitParent(t *testing.T) {
+	cacheRoot := t.TempDir()
+	repoDir := t.TempDir()
+
+	repo, err := git.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://github.com/example/my-skills.git"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(repoDir, "packs", "lint")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	src, kind := ResolveSkillSource(skillDir, cacheRoot)
+	if kind != SourceKindGit {
+		t.Errorf("kind: got %q, want git", kind)
+	}
+	if src != "https://github.com/example/my-skills.git" {
+		t.Errorf("source: got %q, want the origin URL", src)
+	}
+}
+
+func TestResolveSkillSource_GitNoOrigin(t *testing.T) {
+	cacheRoot := t.TempDir()
+	repoDir := t.TempDir()
+	if _, err := git.PlainInit(repoDir, false); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(repoDir, "skills", "local")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	src, kind := ResolveSkillSource(skillDir, cacheRoot)
+	if kind != SourceKindPath {
+		t.Errorf("kind: got %q, want path", kind)
+	}
+	if src != skillDir {
+		t.Errorf("source: got %q, want %q", src, skillDir)
+	}
+}
+
+func TestResolveSkillSource_OrphanPath(t *testing.T) {
+	cacheRoot := t.TempDir()
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "loose-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	src, kind := ResolveSkillSource(skillDir, cacheRoot)
+	if kind != SourceKindPath {
+		t.Errorf("kind: got %q, want path", kind)
+	}
+	if src != skillDir {
+		t.Errorf("source: got %q, want raw path", src)
+	}
+}

--- a/internal/engine/ops/init_test.go
+++ b/internal/engine/ops/init_test.go
@@ -1,8 +1,12 @@
 package ops
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"gaal/internal/config"
 )
 
 // TestInit_TemplateHasAllSections verifies the embedded template contains
@@ -12,5 +16,124 @@ func TestInit_TemplateHasAllSections(t *testing.T) {
 		if !strings.Contains(string(InitTemplate), section) {
 			t.Errorf("InitTemplate missing section %q", section)
 		}
+	}
+}
+
+func TestInitFromPlan_WritesValidYAMLWithPlanEntries(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "gaal.yaml")
+	plan := Plan{
+		Skills: []config.SkillConfig{
+			{
+				Source: "anthropics/skills",
+				Agents: []string{"claude-code"},
+				Global: false,
+				Select: []string{"frontend-design", "skill-creator"},
+			},
+		},
+		MCPs: []config.MCPConfig{
+			{
+				Name:   "filesystem",
+				Target: "~/.claude/mcp.json",
+				Inline: &config.MCPInlineConfig{
+					Command: "uvx",
+					Args:    []string{"mcp-server-filesystem", "/tmp"},
+				},
+			},
+		},
+	}
+
+	if err := InitFromPlan(dest, plan, false); err != nil {
+		t.Fatalf("InitFromPlan: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"repositories:",
+		"skills:",
+		"mcps:",
+		"anthropics/skills",
+		"frontend-design",
+		"skill-creator",
+		"claude-code",
+		"filesystem",
+		"~/.claude/mcp.json",
+		"uvx",
+		"mcp-server-filesystem",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("output missing %q\n---\n%s\n---", want, content)
+		}
+	}
+
+	cfg, err := config.Load(dest)
+	if err != nil {
+		t.Fatalf("generated file does not parse as valid config: %v\ncontent:\n%s", err, content)
+	}
+	if len(cfg.Skills) != 1 || cfg.Skills[0].Source != "anthropics/skills" {
+		t.Errorf("skills: %+v", cfg.Skills)
+	}
+	if len(cfg.MCPs) != 1 || cfg.MCPs[0].Name != "filesystem" {
+		t.Errorf("mcps: %+v", cfg.MCPs)
+	}
+}
+
+func TestInitFromPlan_EmptyPlanStillValid(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "gaal.yaml")
+	if err := InitFromPlan(dest, Plan{}, false); err != nil {
+		t.Fatalf("InitFromPlan: %v", err)
+	}
+	if _, err := config.Load(dest); err != nil {
+		t.Fatalf("empty plan output does not parse: %v", err)
+	}
+}
+
+func TestInitFromPlan_PreservesCommentHeaders(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "gaal.yaml")
+	if err := InitFromPlan(dest, Plan{}, false); err != nil {
+		t.Fatalf("InitFromPlan: %v", err)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	// A few characteristic comment markers from init_template.yaml.
+	for _, want := range []string{
+		"# gaal.yaml",
+		"# repositories",
+		"# skills",
+		"# mcps",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("output missing header %q", want)
+		}
+	}
+}
+
+func TestInitFromPlan_ErrorWhenDestExistsWithoutForce(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "gaal.yaml")
+	if err := os.WriteFile(dest, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := InitFromPlan(dest, Plan{}, false); err == nil {
+		t.Error("expected error when dest exists without force")
+	}
+}
+
+func TestInitFromPlan_OverwritesWithForce(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "gaal.yaml")
+	if err := os.WriteFile(dest, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := InitFromPlan(dest, Plan{}, true); err != nil {
+		t.Fatalf("InitFromPlan with force: %v", err)
+	}
+	data, _ := os.ReadFile(dest)
+	if string(data) == "existing" {
+		t.Error("file was not overwritten")
 	}
 }

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -245,6 +245,45 @@ func serverEntryEqual(a, b serverEntry) bool {
 	return true
 }
 
+// LoadServers reads the given MCP config file and returns the full inline
+// definition of every server found in the "mcpServers" object, keyed by name.
+// Returns nil, nil when the file does not exist or has no "mcpServers" entry.
+func LoadServers(configFile string) (map[string]config.MCPInlineConfig, error) {
+	slog.Debug("loading mcp servers", "file", configFile)
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", configFile, err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", configFile, err)
+	}
+
+	serversRaw, ok := raw["mcpServers"]
+	if !ok {
+		return nil, nil
+	}
+
+	var servers map[string]serverEntry
+	if err := json.Unmarshal(serversRaw, &servers); err != nil {
+		return nil, fmt.Errorf("parsing mcpServers in %s: %w", configFile, err)
+	}
+
+	out := make(map[string]config.MCPInlineConfig, len(servers))
+	for name, s := range servers {
+		out[name] = config.MCPInlineConfig{
+			Command: s.Command,
+			Args:    s.Args,
+			Env:     s.Env,
+		}
+	}
+	return out, nil
+}
+
 // ListServers reads the given MCP config file and returns a sorted list of
 // server names found in the "mcpServers" object. Returns nil, nil when the
 // file does not exist (the agent is simply not installed on this machine).

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -440,3 +440,94 @@ func TestListServers_InvalidJSON(t *testing.T) {
 		t.Error("expected error for invalid JSON, got nil")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// LoadServers
+// ---------------------------------------------------------------------------
+
+func TestLoadServers_FileNotExist(t *testing.T) {
+	got, err := LoadServers("/no/such/file.json")
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil map for missing file, got %v", got)
+	}
+}
+
+func TestLoadServers_ValidFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "mcp.json")
+	content := `{
+  "mcpServers": {
+    "filesystem": {
+      "command": "uvx",
+      "args": ["mcp-server-filesystem", "/tmp"],
+      "env": {"LOG_LEVEL": "debug"}
+    },
+    "git": {
+      "command": "uvx",
+      "args": ["mcp-server-git"]
+    }
+  }
+}`
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadServers(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	fs, ok := got["filesystem"]
+	if !ok {
+		t.Fatal("filesystem entry missing")
+	}
+	if fs.Command != "uvx" {
+		t.Errorf("filesystem.command: want uvx, got %q", fs.Command)
+	}
+	if len(fs.Args) != 2 || fs.Args[0] != "mcp-server-filesystem" || fs.Args[1] != "/tmp" {
+		t.Errorf("filesystem.args: unexpected %v", fs.Args)
+	}
+	if fs.Env["LOG_LEVEL"] != "debug" {
+		t.Errorf("filesystem.env: unexpected %v", fs.Env)
+	}
+	g, ok := got["git"]
+	if !ok {
+		t.Fatal("git entry missing")
+	}
+	if g.Command != "uvx" || len(g.Args) != 1 || g.Args[0] != "mcp-server-git" {
+		t.Errorf("git entry: unexpected %+v", g)
+	}
+	if g.Env != nil && len(g.Env) != 0 {
+		t.Errorf("git.env should be empty, got %v", g.Env)
+	}
+}
+
+func TestLoadServers_NoMCPServersKey(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(f, []byte(`{"other":"value"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadServers(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil when no mcpServers key, got %v", got)
+	}
+}
+
+func TestLoadServers_InvalidJSON(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(f, []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadServers(f); err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- `gaal init` is now an interactive wizard that builds a `gaal.yaml` from the skills and MCP servers detected on the machine. Closes #5.
- Two prompts precede any work: (1) empty skeleton vs import detected configuration, (2) project scope (`./gaal.yaml`) vs global scope (`~/.config/gaal/config.yaml`).
- In import mode, gaal runs an audit filtered by scope and renders a `pterm` multiselect grouped by agent. Selection becomes a `Plan` which is rendered into YAML while preserving the commented section headers of the existing template.

## Implementation notes

- New package layout under `internal/engine/ops/`:
  - `init_source.go` — `ResolveSkillSource` (cache reverse-lookup → git origin → raw path) with priority ranking used to dedupe skills found via multiple search paths.
  - `init_plan.go` — `Scope`, `Candidate`, `AgentSection`, `Candidates`, `Plan` plus `BuildPlan` which groups skills by `(source, agent)` into a single `SkillConfig` with a sorted `Select` list.
  - `init_build.go` — `BuildImportCandidates` reuses the existing audit collectors, filters by scope, loads full MCP inline definitions via a new `mcp.LoadServers`, and populates `GenericDelegators` for the `generic` section.
  - `init.go` — new `InitFromPlan` reuses the commented headers from `init_template.yaml` and serialises the plan content with `yaml.v3`. Both `Init` and `InitFromPlan` now `mkdir -p` the destination parent.
- New TUI helpers in `cmd/internal/wizard/`:
  - `scope.go` — `SelectMode` (empty/import) and `SelectScope` (project/global).
  - `select_sections.go` — `SelectSections` wraps `pterm.DefaultInteractiveMultiselect` with an info header listing detected agents and their delegators.
- `cmd/init.go` orchestrates flags, TTY detection, and preview rendering. New flags: `--scope`, `--empty`, `--import-all`, plus the existing `--force`. `--empty` and `--import-all` are mutually exclusive and required in non-interactive mode.
- `internal/config/config.go` exposes a new `UserConfigFilePath` wrapper so `cmd/init.go` can resolve the global destination without loading a config first.
- `internal/mcp/manager.go` gains `LoadServers(file)` returning the full `map[string]MCPInlineConfig`; `ListServers` is unchanged.
- MCP servers without a `command` field (URL-based transports) are dropped during collection — gaal cannot round-trip them through the inline schema, and keeping them would produce invalid configs.
- README Quick start section rewritten around `gaal init`.

## Test plan

- [x] `make build` succeeds.
- [x] `make test` — 432 tests pass across 15 packages.
- [x] New unit tests cover `LoadServers`, `ResolveSkillSource` (cache / git / path / orphan branches), `BuildPlan` (grouping + non-grouping rules), `BuildImportCandidates` (scope filtering, generic delegators, MCP surfacing, section sort), and `InitFromPlan` (YAML validity + header preservation + force semantics).
- [x] New `cmd/init_test.go` drives the non-interactive end-to-end flow for project/global scope, empty mode, import-all mode, invalid scope, and the missing-mode-flag error.
- [x] Manual TUI smoke test: `gaal init` → empty + project, empty + global, import + project, import + global. (Interactive multiselect is not covered by automated tests.)