### PR TITLE
fix(config): accept scalar and nested-list shapes for skill agents

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,70 @@ type SkillConfig struct {
 	Select []string `yaml:"select,omitempty" json:"select,omitempty" jsonschema:"description=Specific skill names to include; empty list installs all skills from the source"`
 }
 
+// UnmarshalYAML accepts the `agents` field in several hand-written shapes:
+//   - scalar:       `agents: "*"`
+//   - flat list:    `agents: ["*", "claude"]`
+//   - nested list:  `agents: [["*"]]` — flattened one level
+//
+// The nested form is a common mistake when users mentally copy the canonical
+// `agents: ["*"]` under a list bullet. We normalise all accepted shapes to
+// []string so downstream code doesn't need to care.
+func (s *SkillConfig) UnmarshalYAML(node *yaml.Node) error {
+	type rawSkill struct {
+		Source string    `yaml:"source"`
+		Agents yaml.Node `yaml:"agents,omitempty"`
+		Global bool      `yaml:"global,omitempty"`
+		Select []string  `yaml:"select,omitempty"`
+	}
+	var raw rawSkill
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+
+	s.Source = raw.Source
+	s.Global = raw.Global
+	s.Select = raw.Select
+
+	agents, err := decodeAgents(&raw.Agents)
+	if err != nil {
+		return fmt.Errorf("skill %q: agents: %w", raw.Source, err)
+	}
+	s.Agents = agents
+	return nil
+}
+
+// decodeAgents normalises the `agents` node into []string. See
+// [SkillConfig.UnmarshalYAML] for accepted shapes.
+func decodeAgents(n *yaml.Node) ([]string, error) {
+	if n == nil || n.Kind == 0 {
+		return nil, nil
+	}
+	switch n.Kind {
+	case yaml.ScalarNode:
+		return []string{n.Value}, nil
+	case yaml.SequenceNode:
+		out := make([]string, 0, len(n.Content))
+		for _, item := range n.Content {
+			switch item.Kind {
+			case yaml.ScalarNode:
+				out = append(out, item.Value)
+			case yaml.SequenceNode:
+				for _, inner := range item.Content {
+					if inner.Kind != yaml.ScalarNode {
+						return nil, fmt.Errorf("line %d: nesting deeper than one level is not supported", inner.Line)
+					}
+					out = append(out, inner.Value)
+				}
+			default:
+				return nil, fmt.Errorf("line %d: expected a string or list of strings", item.Line)
+			}
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("line %d: expected a string or list of strings", n.Line)
+	}
+}
+
 // MCPConfig defines an MCP server configuration entry.
 type MCPConfig struct {
 	Name   string           `yaml:"name"             json:"name"              jsonschema:"description=Unique name identifying this MCP server entry"                validate:"required"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -158,6 +158,119 @@ repositories:
 	}
 }
 
+func TestLoad_SkillAgents_FlatList(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    agents: ["*"]
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Skills) != 1 || len(cfg.Skills[0].Agents) != 1 || cfg.Skills[0].Agents[0] != "*" {
+		t.Errorf("got agents %v, want [\"*\"]", cfg.Skills[0].Agents)
+	}
+}
+
+func TestLoad_SkillAgents_Scalar(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    agents: "*"
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Skills) != 1 || len(cfg.Skills[0].Agents) != 1 || cfg.Skills[0].Agents[0] != "*" {
+		t.Errorf("got agents %v, want [\"*\"]", cfg.Skills[0].Agents)
+	}
+}
+
+func TestLoad_SkillAgents_NestedListIsFlattened(t *testing.T) {
+	// Regression for https://github.com/gmg-inc/gaal-lite/issues/13
+	// A list-of-lists is a common hand-written mistake (mentally copying the
+	// canonical `agents: ["*"]` example under a list bullet).
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    agents:
+      - ["*", "claude"]
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{"*", "claude"}
+	got := cfg.Skills[0].Agents
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("agents[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLoad_SkillAgents_MixedFlatAndNested(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    agents:
+      - claude
+      - ["codex", "cursor"]
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{"claude", "codex", "cursor"}
+	got := cfg.Skills[0].Agents
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("agents[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLoad_SkillAgents_DoubleNestedRejected(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    agents:
+      - [["*"]]
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected error for doubly-nested agents list")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "agents") {
+		t.Errorf("error should mention 'agents', got: %v", err)
+	}
+	if !strings.Contains(msg, "owner/repo") {
+		t.Errorf("error should name the skill source for context, got: %v", err)
+	}
+}
+
+func TestLoad_SkillAgents_MapRejected(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    agents:
+      key: value
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected error for map-shaped agents field")
+	}
+}
+
 func TestLoad_ValidationError_SkillNoSource(t *testing.T) {
 	p := writeYAML(t, `
 skills:
@@ -227,7 +340,13 @@ repositories:
 }
 
 func TestLoadChain_AllMissing(t *testing.T) {
-	_, err := LoadChain("/no/such/file/gaal.yaml")
+	// Isolate from the host's real global/user configs so this test passes on
+	// dev machines that happen to have a ~/.config/gaal/config.yaml.
+	empty := t.TempDir()
+	t.Setenv("HOME", empty)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(empty, "xdg"))
+
+	_, err := LoadChain(filepath.Join(empty, "no-such-workspace.yaml"))
 	if err == nil {
 		t.Fatal("expected error when no config file found")
 	}


### PR DESCRIPTION
Closes #13.

## Summary

- `SkillConfig.UnmarshalYAML` now accepts `agents` as a scalar (`"*"`), a flat list (`["*", "claude"]`), or a single-level-nested list (`[["*"]]`), normalising every accepted shape to `[]string`. The nested form is the exact bug reported in #13 — easy to hand-write by mentally copying `agents: ["*"]` under a list bullet, and previously it killed every gaal command with a raw `yaml.v3` line-number error.
- Invalid shapes (deeper nesting, maps, non-strings) now return an error that names the offending skill source, so users can find the broken entry without grepping their config by line number.
- Tests cover scalar, flat, nested, mixed flat+nested, double-nested rejection, and map rejection.
- Fixes `TestLoadChain_AllMissing` which was only passing on dev machines whose real `~/.config/gaal/config.yaml` happened to be unparsable — the test now pins `HOME`/`XDG_CONFIG_HOME` at a temp dir so it's independent of host state.

## Test plan

- [x] `go test ./...` — 438 passed
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] End-to-end: ran `go run . --config repro.yaml status` with the exact reproducer from #13; config loads and the `*` wildcard fans out to all detected agents.