### PR TITLE
feat(status): group skills by name with AGENTS column

### DIFF
--- a/internal/engine/render/table.go
+++ b/internal/engine/render/table.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/pterm/pterm"
@@ -227,38 +228,138 @@ func (tr *tableRenderer) repoTable(w io.Writer, entries []RepoEntry, termW int) 
 	return tr.ptermTable(w, data)
 }
 
+// aggregatedSkill rolls up all per-(source, agent) SkillEntry rows for a
+// single skill name. See [aggregateSkillsByName] for semantics.
+type aggregatedSkill struct {
+	Name      string
+	Sources   []string
+	Status    StatusCode
+	Agents    []string
+	AllAgents bool
+	Error     string
+}
+
+// aggregateSkillsByName groups per-(source, agent) skill entries into one
+// row per unique skill name. The result is sorted alphabetically by name.
+//
+// For each skill name, "targeted agents" is the set of agents that list the
+// skill in Installed ∪ Missing ∪ Modified — i.e. agents gaal expected to
+// manage the skill for. AllAgents is true when the skill is installed in
+// every one of those targeted agents (including "installed but dirty"),
+// which the renderer shows as `*` in the AGENTS column.
+func aggregateSkillsByName(entries []SkillEntry) []aggregatedSkill {
+	type bucket struct {
+		sources   map[string]struct{}
+		targeted  map[string]struct{}
+		installed map[string]struct{}
+		dirty     bool
+		errored   bool
+		errMsg    string
+	}
+	byName := map[string]*bucket{}
+
+	get := func(name string) *bucket {
+		b, ok := byName[name]
+		if !ok {
+			b = &bucket{
+				sources:   map[string]struct{}{},
+				targeted:  map[string]struct{}{},
+				installed: map[string]struct{}{},
+			}
+			byName[name] = b
+		}
+		return b
+	}
+
+	markEntry := func(e SkillEntry, name string, installed bool) {
+		b := get(name)
+		b.sources[e.Source] = struct{}{}
+		b.targeted[e.Agent] = struct{}{}
+		if installed {
+			b.installed[e.Agent] = struct{}{}
+		}
+		if e.Status == StatusError {
+			b.errored = true
+			if b.errMsg == "" {
+				b.errMsg = e.Error
+			}
+		}
+	}
+
+	for _, e := range entries {
+		for _, name := range e.Installed {
+			markEntry(e, name, true)
+		}
+		for _, name := range e.Missing {
+			markEntry(e, name, false)
+		}
+		for _, name := range e.Modified {
+			// Modified implies installed, but may not appear in Installed
+			// (status is reported as dirty, not ok). Track it as installed
+			// and flag the bucket as dirty.
+			markEntry(e, name, true)
+			get(name).dirty = true
+		}
+	}
+
+	out := make([]aggregatedSkill, 0, len(byName))
+	for name, b := range byName {
+		s := aggregatedSkill{
+			Name:    name,
+			Sources: keysSorted(b.sources),
+			Agents:  keysSorted(b.installed),
+			Error:   b.errMsg,
+		}
+		s.AllAgents = len(b.installed) > 0 && len(b.installed) == len(b.targeted)
+		switch {
+		case b.errored:
+			s.Status = StatusError
+		case b.dirty:
+			s.Status = StatusDirty
+		case s.AllAgents:
+			s.Status = StatusOK
+		default:
+			s.Status = StatusPartial
+		}
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func keysSorted(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func (tr *tableRenderer) skillTable(w io.Writer, entries []SkillEntry, termW int) error {
-	tr.section(w, "Skills", len(entries))
-	// Fixed cols: AGENT(20) + STATUS(14) = 34
-	// Variable cols: SOURCE, INSTALLED, MISSING, MODIFIED share the rest equally.
-	vw := varColWidth(termW, 6, 4, 34)
+	aggregated := aggregateSkillsByName(entries)
+	tr.section(w, "Skills", len(aggregated))
+
+	// Fixed col: STATUS(14). SKILL, SOURCE, AGENTS share the rest.
+	vw := varColWidth(termW, 4, 3, 14)
 	if vw < 12 {
 		vw = 12
 	}
 
-	data := pterm.TableData{{"SOURCE", "AGENT", "STATUS", "INSTALLED", "MISSING", "MODIFIED"}}
-	for _, e := range entries {
-		installed := strings.Join(e.Installed, ", ")
-		missing := strings.Join(e.Missing, ", ")
-		modified := strings.Join(e.Modified, ", ")
-		if installed == "" {
-			installed = "—"
-		}
-		if missing == "" {
-			missing = "—"
-		}
-		if modified == "" {
-			modified = "—"
-		} else {
-			modified = pterm.FgYellow.Sprint(modified)
+	data := pterm.TableData{{"SKILL", "SOURCE", "STATUS", "AGENTS"}}
+	for _, s := range aggregated {
+		agents := "—"
+		switch {
+		case s.AllAgents:
+			agents = "*"
+		case len(s.Agents) > 0:
+			agents = strings.Join(s.Agents, ", ")
 		}
 		data = append(data, []string{
-			trunc(e.Source, vw),
-			e.Agent,
-			statusCell(e.Status, e.Error),
-			trunc(installed, vw),
-			trunc(missing, vw),
-			trunc(modified, vw),
+			trunc(s.Name, vw),
+			trunc(strings.Join(s.Sources, ", "), vw),
+			statusCell(s.Status, s.Error),
+			trunc(agents, vw),
 		})
 	}
 	return tr.ptermTable(w, data)

--- a/internal/engine/render/table_test.go
+++ b/internal/engine/render/table_test.go
@@ -125,6 +125,174 @@ func TestTableRenderer_WithData(t *testing.T) {
 	}
 }
 
+// ── aggregateSkillsByName ─────────────────────────────────────────────────────
+
+func TestAggregateSkillsByName_InstalledEverywhereYieldsStar(t *testing.T) {
+	in := []SkillEntry{
+		{Source: "owner/repo", Agent: "cursor", Status: StatusOK, Installed: []string{"code-reviewer"}},
+		{Source: "owner/repo", Agent: "codex", Status: StatusOK, Installed: []string{"code-reviewer"}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 aggregated skill, got %d: %+v", len(got), got)
+	}
+	s := got[0]
+	if s.Name != "code-reviewer" {
+		t.Errorf("name: got %q, want %q", s.Name, "code-reviewer")
+	}
+	if !s.AllAgents {
+		t.Errorf("AllAgents: got false, want true (installed in every targeted agent)")
+	}
+	if s.Status != StatusOK {
+		t.Errorf("status: got %q, want %q", s.Status, StatusOK)
+	}
+	if len(s.Sources) != 1 || s.Sources[0] != "owner/repo" {
+		t.Errorf("sources: got %v", s.Sources)
+	}
+}
+
+func TestAggregateSkillsByName_PartialWhenSomeAgentsMissing(t *testing.T) {
+	in := []SkillEntry{
+		{Source: "owner/repo", Agent: "cursor", Status: StatusOK, Installed: []string{"find-skills"}},
+		{Source: "owner/repo", Agent: "codex", Status: StatusPartial, Missing: []string{"find-skills"}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 aggregated skill, got %d", len(got))
+	}
+	s := got[0]
+	if s.AllAgents {
+		t.Error("AllAgents: got true, want false")
+	}
+	if s.Status != StatusPartial {
+		t.Errorf("status: got %q, want %q", s.Status, StatusPartial)
+	}
+	if len(s.Agents) != 1 || s.Agents[0] != "cursor" {
+		t.Errorf("agents: got %v, want [cursor]", s.Agents)
+	}
+}
+
+func TestAggregateSkillsByName_DirtyWhenAnyModified(t *testing.T) {
+	in := []SkillEntry{
+		{Source: "owner/repo", Agent: "cursor", Status: StatusOK, Installed: []string{"add-to-inbox"}},
+		{Source: "owner/repo", Agent: "codex", Status: StatusDirty, Installed: []string{"add-to-inbox"}, Modified: []string{"add-to-inbox"}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 aggregated skill, got %d", len(got))
+	}
+	s := got[0]
+	if s.Status != StatusDirty {
+		t.Errorf("status: got %q, want %q", s.Status, StatusDirty)
+	}
+	// Modified agents are still "installed" — show * when present everywhere.
+	if !s.AllAgents {
+		t.Errorf("AllAgents: dirty-but-installed-everywhere should show *")
+	}
+}
+
+func TestAggregateSkillsByName_MissingEverywhere(t *testing.T) {
+	in := []SkillEntry{
+		{Source: "owner/repo", Agent: "cursor", Status: StatusPartial, Missing: []string{"react-doctor"}},
+		{Source: "owner/repo", Agent: "codex", Status: StatusPartial, Missing: []string{"react-doctor"}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 aggregated skill, got %d", len(got))
+	}
+	s := got[0]
+	if s.Status != StatusPartial {
+		t.Errorf("status: got %q, want %q", s.Status, StatusPartial)
+	}
+	if len(s.Agents) != 0 {
+		t.Errorf("agents: got %v, want empty (installed nowhere)", s.Agents)
+	}
+	if s.AllAgents {
+		t.Error("AllAgents should be false when installed nowhere")
+	}
+}
+
+func TestAggregateSkillsByName_MultipleSourcesMerged(t *testing.T) {
+	in := []SkillEntry{
+		{Source: "owner/repo-a", Agent: "cursor", Status: StatusOK, Installed: []string{"shared-skill"}},
+		{Source: "owner/repo-b", Agent: "codex", Status: StatusOK, Installed: []string{"shared-skill"}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 aggregated skill, got %d", len(got))
+	}
+	s := got[0]
+	if len(s.Sources) != 2 {
+		t.Errorf("sources: got %v, want 2 entries", s.Sources)
+	}
+	// Sources should be sorted for determinism.
+	if s.Sources[0] != "owner/repo-a" || s.Sources[1] != "owner/repo-b" {
+		t.Errorf("sources not sorted: got %v", s.Sources)
+	}
+	if !s.AllAgents {
+		t.Error("AllAgents: skill is installed in every agent that targets it")
+	}
+}
+
+func TestAggregateSkillsByName_ErrorPropagates(t *testing.T) {
+	in := []SkillEntry{
+		{Source: "owner/repo", Agent: "cursor", Status: StatusOK, Installed: []string{"broken"}},
+		{Source: "owner/repo", Agent: "codex", Status: StatusError, Error: "permission denied", Missing: []string{"broken"}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 aggregated skill, got %d", len(got))
+	}
+	s := got[0]
+	if s.Status != StatusError {
+		t.Errorf("status: got %q, want %q", s.Status, StatusError)
+	}
+	if !strings.Contains(s.Error, "permission denied") {
+		t.Errorf("error: got %q, want to contain 'permission denied'", s.Error)
+	}
+}
+
+func TestAggregateSkillsByName_SortedByName(t *testing.T) {
+	in := []SkillEntry{
+		{Source: "owner/repo", Agent: "cursor", Status: StatusOK, Installed: []string{"zebra", "apple", "mango"}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 aggregated skills, got %d", len(got))
+	}
+	want := []string{"apple", "mango", "zebra"}
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Errorf("got[%d].Name = %q, want %q", i, got[i].Name, w)
+		}
+	}
+}
+
+func TestTableRenderer_SkillsByName_RendersStar(t *testing.T) {
+	var buf bytes.Buffer
+	r := &tableRenderer{}
+	report := &StatusReport{
+		Skills: []SkillEntry{
+			{Source: "owner/repo", Agent: "cursor", Status: StatusOK, Installed: []string{"code-reviewer"}},
+			{Source: "owner/repo", Agent: "codex", Status: StatusOK, Installed: []string{"code-reviewer"}},
+		},
+	}
+	if err := r.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "code-reviewer") {
+		t.Error("expected skill name in output")
+	}
+	if !strings.Contains(out, "SKILL") || !strings.Contains(out, "AGENTS") {
+		t.Errorf("expected new column headers SKILL and AGENTS, got:\n%s", out)
+	}
+	// Exactly one data row (not one per agent).
+	if strings.Count(out, "code-reviewer") != 1 {
+		t.Errorf("expected code-reviewer to appear exactly once, got %d occurrences", strings.Count(out, "code-reviewer"))
+	}
+}
+
 // ── jsonRenderer ─────────────────────────────────────────────────────────────
 
 func TestJSONRenderer_ValidJSON(t *testing.T) {


### PR DESCRIPTION
Closes #15.

## Summary

- Rewrites the `gaal status` skills table from one-row-per-(source, agent) to one-row-per-skill-name. New layout: `SKILL | SOURCE | STATUS | AGENTS`.
- `AGENTS` shows `*` when the skill is installed in every agent the config targeted it at, otherwise the explicit agent list. Answers the common user question ("is this installed everywhere?") at a glance.
- Aggregation lives in a new `render.aggregateSkillsByName` helper. `StatusReport.Skills` stays one entry per `(source, agent)`, so JSON output, `sync`, and `audit` are untouched.
- Status buckets aggregate across all targeted agents for a given skill:
  - `✓ synced` — installed everywhere, no modifications
  - `⚠ dirty` — any targeted agent has local modifications
  - `~ partial` — installed in some targeted agents but not all
  - `✗ error` — any targeted agent errored (error message propagated)
- Skills are sorted alphabetically for determinism.
- Empty repositories section still renders; only the skills section changes shape.

## Before / after

Before (20 skills × 20 agents → 400 rows):

\`\`\`
── Skills  (400) ──
│ SOURCE             │ AGENT          │ STATUS   │ INSTALLED     │ MISSING │ MODIFIED │
│ git@github.com:…   │ cursor         │ ✓ synced │ add-to-inbox… │ —       │ —        │
│ git@github.com:…   │ codex          │ ✓ synced │ add-to-inbox… │ —       │ —        │
...
\`\`\`

After (20 skills → 20 rows):

\`\`\`
── Skills  (20) ──
│ SKILL         │ SOURCE           │ STATUS   │ AGENTS │
│ add-to-inbox  │ git@github.com:… │ ✓ synced │ *      │
│ code-reviewer │ git@github.com:… │ ✓ synced │ *      │
│ find-skills   │ git@github.com:… │ ~ partial │ cursor │
\`\`\`

## Test plan

- [x] `go test ./...` — 446 passed
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] 8 new tests in `internal/engine/render/table_test.go` covering: everywhere → `*`, partial, dirty, missing-everywhere, multi-source merge, error propagation, alphabetical sort, and full renderer smoke.
- [x] End-to-end: rebuilt `dist/gaal` and ran against the live user config — 26 rows, exactly one per skill name, `*` in every AGENTS cell as expected for a user targeting `["*"]`.