### PR TITLE
feat: add gaal agents command, sort info agent installed-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ gaal info agent                          # list all registered agents
 gaal info agent cursor
 ```
 
+### List agents
+
+```bash
+gaal agents                  # all registered agents (installed first)
+gaal agents --installed      # only agents detected on this machine
+gaal agents cursor           # detailed view for one agent
+gaal agents -o json          # machine-readable output
+```
+
+Lists every registered coding agent and whether it is installed on this machine.
+Pass a name for a detailed view with search paths, skill counts, and MCP config.
+
 ### Generate the JSON Schema
 
 ```bash
@@ -275,7 +287,7 @@ agents:
     mcp_config_file: ~/.my-agent/mcp.json  # empty string if unsupported
 ```
 
-Use `gaal info agent` to list all registered agents (built-in + custom) and verify your additions.
+Use `gaal agents` to list all registered agents (built-in + custom) and verify your additions. `gaal info agent` provides the same information in an alternative layout.
 
 ---
 

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"gaal/internal/config"
+	"gaal/internal/engine"
+	"gaal/internal/engine/render"
+)
+
+var (
+	agentsInstalled bool
+)
+
+var agentsCmd = &cobra.Command{
+	Use:   "agents [name]",
+	Short: "List registered coding agents or show details for one",
+	Long: `Lists every registered agent and whether it is installed on this machine.
+
+Pass an agent name to see a detailed view including search paths,
+skill counts, and MCP configuration.
+
+Examples:
+  gaal agents                # all registered agents (installed first)
+  gaal agents --installed    # only agents detected on this machine
+  gaal agents cursor         # detailed view for one agent`,
+	SilenceUsage: true,
+	Args:         cobra.MaximumNArgs(1),
+	RunE:         runAgents,
+}
+
+func init() {
+	agentsCmd.Flags().BoolVarP(&agentsInstalled, "installed", "i", false, "show only installed agents")
+	rootCmd.AddCommand(agentsCmd)
+}
+
+func runAgents(_ *cobra.Command, args []string) error {
+	eng := engine.NewWithOptions(&config.Config{}, engineOpts)
+	w := os.Stdout
+	format := engine.OutputFormat(outputFormat)
+
+	if len(args) == 1 {
+		return runAgentDetail(eng, w, args[0], format)
+	}
+	return runAgentList(eng, w, format)
+}
+
+func runAgentList(eng *engine.Engine, w io.Writer, format engine.OutputFormat) error {
+	entries, err := eng.ListAgents()
+	if err != nil {
+		return err
+	}
+
+	if agentsInstalled {
+		filtered := make([]render.AgentEntry, 0, len(entries))
+		for _, e := range entries {
+			if e.Installed {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	if format == engine.FormatJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(struct {
+			Agents []render.AgentEntry `json:"agents"`
+		}{entries})
+	}
+
+	return renderAgentsTable(w, entries)
+}
+
+func renderAgentsTable(w io.Writer, entries []render.AgentEntry) error {
+	if len(entries) == 0 {
+		fmt.Fprintln(w, pterm.FgDarkGray.Sprint("  no agents found"))
+		return nil
+	}
+
+	styled := pterm.NewStyle(pterm.Bold, pterm.FgCyan).Sprintf("── Agents  (%d) ──", len(entries))
+	fmt.Fprintf(w, "\n%s\n", styled)
+
+	termW := pterm.GetTerminalWidth()
+	if termW < 60 {
+		termW = 120
+	}
+
+	data := pterm.TableData{{"NAME", "INSTALLED", "PROJECT SKILLS", "GLOBAL SKILLS", "MCP CONFIG", "SOURCE"}}
+	for _, e := range entries {
+		installed := pterm.FgDarkGray.Sprint("—")
+		if e.Installed {
+			installed = pterm.FgGreen.Sprint("✓")
+		}
+		mcpCfg := pterm.FgDarkGray.Sprint("—")
+		if e.ProjectMCPConfigFile != "" {
+			mcpCfg = e.ProjectMCPConfigFile
+		}
+		source := pterm.FgGreen.Sprint(e.Source)
+		if e.Source == "user" {
+			source = pterm.FgCyan.Sprint(e.Source)
+		}
+
+		data = append(data, []string{
+			e.Name,
+			installed,
+			e.ProjectSkillsDir,
+			e.GlobalSkillsDir,
+			mcpCfg,
+			source,
+		})
+	}
+
+	s, err := pterm.DefaultTable.
+		WithHasHeader(true).
+		WithSeparator(" │ ").
+		WithHeaderStyle(pterm.NewStyle(pterm.Bold, pterm.FgLightWhite)).
+		WithData(data).
+		Srender()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(w, s)
+	return nil
+}
+
+func runAgentDetail(eng *engine.Engine, w io.Writer, name string, format engine.OutputFormat) error {
+	detail, err := eng.AgentDetail(name)
+	if err != nil {
+		return err
+	}
+
+	if format == engine.FormatJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(struct {
+			Agent *render.AgentDetail `json:"agent"`
+		}{detail})
+	}
+
+	return renderAgentDetailCard(w, detail)
+}
+
+func renderAgentDetailCard(w io.Writer, d *render.AgentDetail) error {
+	styled := pterm.NewStyle(pterm.Bold, pterm.FgCyan).Sprintf("── Agent: %s ──", d.Name)
+	fmt.Fprintf(w, "\n%s\n\n", styled)
+
+	kvPad := 12
+	kv := func(key, val string) string {
+		pad := kvPad - len([]rune(key))
+		if pad < 0 {
+			pad = 0
+		}
+		styledKey := pterm.NewStyle(pterm.Bold, pterm.FgLightWhite).Sprint(key)
+		return fmt.Sprintf(" %s%s  %s", styledKey, strings.Repeat(" ", pad), val)
+	}
+
+	installedStr := pterm.FgDarkGray.Sprint("no")
+	if d.Installed {
+		installedStr = pterm.FgGreen.Sprint("yes")
+	}
+	fmt.Fprintln(w, kv("Installed", installedStr))
+
+	sourceStr := pterm.FgGreen.Sprint(d.Source)
+	if d.Source == "user" {
+		sourceStr = pterm.FgCyan.Sprint(d.Source)
+	}
+	fmt.Fprintln(w, kv("Source", sourceStr))
+
+	mcpStr := pterm.FgDarkGray.Sprint("not supported")
+	if d.MCPSupport {
+		existsMarker := pterm.FgYellow.Sprint("(not found)")
+		if d.MCPExists {
+			existsMarker = pterm.FgGreen.Sprint("(exists)")
+		}
+		mcpStr = fmt.Sprintf("%s  %s", d.MCPConfig, existsMarker)
+	}
+	fmt.Fprintln(w, kv("MCP config", mcpStr))
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, pterm.NewStyle(pterm.Bold, pterm.FgLightWhite).Sprint(" Search paths:"))
+	for _, p := range d.Paths {
+		existsMarker := pterm.FgYellow.Sprint("✗")
+		if p.Exists {
+			existsMarker = pterm.FgGreen.Sprintf("✓ %d skills", p.SkillCount)
+		}
+		labelColor := pterm.FgCyan
+		if p.Label == "global" {
+			labelColor = pterm.FgGreen
+		} else if p.Label == "package-manager" {
+			labelColor = pterm.FgYellow
+		}
+		fmt.Fprintf(w, "   %s  %s  %s\n",
+			labelColor.Sprintf("%-16s", p.Label),
+			p.Path,
+			existsMarker)
+	}
+
+	if len(d.Warnings) > 0 {
+		fmt.Fprintln(w)
+		for _, warn := range d.Warnings {
+			fmt.Fprintf(w, " %s\n", pterm.FgYellow.Sprint("⚠  "+warn))
+		}
+	}
+
+	fmt.Fprintln(w)
+	return nil
+}

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -88,20 +88,11 @@ func renderAgentsTable(w io.Writer, entries []render.AgentEntry) error {
 	styled := pterm.NewStyle(pterm.Bold, pterm.FgCyan).Sprintf("── Agents  (%d) ──", len(entries))
 	fmt.Fprintf(w, "\n%s\n", styled)
 
-	termW := pterm.GetTerminalWidth()
-	if termW < 60 {
-		termW = 120
-	}
-
-	data := pterm.TableData{{"NAME", "INSTALLED", "PROJECT SKILLS", "GLOBAL SKILLS", "MCP CONFIG", "SOURCE"}}
+	data := pterm.TableData{{"NAME", "INSTALLED", "SOURCE"}}
 	for _, e := range entries {
 		installed := pterm.FgDarkGray.Sprint("—")
 		if e.Installed {
 			installed = pterm.FgGreen.Sprint("✓")
-		}
-		mcpCfg := pterm.FgDarkGray.Sprint("—")
-		if e.ProjectMCPConfigFile != "" {
-			mcpCfg = e.ProjectMCPConfigFile
 		}
 		source := pterm.FgGreen.Sprint(e.Source)
 		if e.Source == "user" {
@@ -111,9 +102,6 @@ func renderAgentsTable(w io.Writer, entries []render.AgentEntry) error {
 		data = append(data, []string{
 			e.Name,
 			installed,
-			e.ProjectSkillsDir,
-			e.GlobalSkillsDir,
-			mcpCfg,
 			source,
 		})
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -26,6 +26,8 @@ type (
 	SkillEntry      = render.SkillEntry
 	MCPEntry        = render.MCPEntry
 	AgentEntry      = render.AgentEntry
+	AgentDetail     = render.AgentDetail
+	AgentPath       = render.AgentPath
 	AuditReport     = render.AuditReport
 	AuditSkillEntry = render.AuditSkillEntry
 	AuditMCPEntry   = render.AuditMCPEntry

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -184,6 +184,16 @@ func (e *Engine) Info(ctx context.Context, pkg, filter string, format OutputForm
 	return ops.Info(ctx, e.repos, e.skills, e.mcps, e.cfg, pkg, filter, format)
 }
 
+// ListAgents returns all registered agents with installed-detection.
+func (e *Engine) ListAgents() ([]render.AgentEntry, error) {
+	return ops.ListAgents(e.home, e.workDir)
+}
+
+// AgentDetail returns the full detail view for a single agent.
+func (e *Engine) AgentDetail(name string) (*render.AgentDetail, error) {
+	return ops.AgentDetail(e.home, e.workDir, name)
+}
+
 // Init writes the documented gaal.yaml skeleton to dest.
 func (e *Engine) Init(dest string, force bool) error {
 	return ops.Init(dest, force)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -252,9 +252,28 @@ func TestCollect_AgentsSorted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Collect returned error: %v", err)
 	}
-	for i := 1; i < len(report.Agents); i++ {
-		if report.Agents[i].Name < report.Agents[i-1].Name {
-			t.Errorf("agents not sorted: %q before %q", report.Agents[i-1].Name, report.Agents[i].Name)
+	// Installed agents must precede uninstalled ones.
+	seenUninstalled := false
+	for _, a := range report.Agents {
+		if !a.Installed {
+			seenUninstalled = true
+		} else if seenUninstalled {
+			t.Errorf("installed agent %q appears after uninstalled agents", a.Name)
+		}
+	}
+	// Within each group, names must be sorted alphabetically.
+	var prevInstalled, prevUninstalled string
+	for _, a := range report.Agents {
+		if a.Installed {
+			if a.Name < prevInstalled {
+				t.Errorf("installed agents not sorted: %q after %q", a.Name, prevInstalled)
+			}
+			prevInstalled = a.Name
+		} else {
+			if a.Name < prevUninstalled {
+				t.Errorf("uninstalled agents not sorted: %q after %q", a.Name, prevUninstalled)
+			}
+			prevUninstalled = a.Name
 		}
 	}
 }

--- a/internal/engine/ops/agents.go
+++ b/internal/engine/ops/agents.go
@@ -1,0 +1,153 @@
+package ops
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+
+	"gaal/internal/core/agent"
+	"gaal/internal/engine/render"
+	"gaal/internal/skill"
+)
+
+// ListAgents returns all registered agents with installed-detection,
+// sorted installed-first then alphabetically.
+func ListAgents(home, workDir string) ([]render.AgentEntry, error) {
+	slog.Debug("listing agents", "home", home, "workDir", workDir)
+
+	list := agent.List()
+	builtinSet := make(map[string]struct{}, len(agent.Names()))
+	for _, n := range agent.Names() {
+		builtinSet[n] = struct{}{}
+	}
+
+	entries := make([]render.AgentEntry, 0, len(list))
+	for _, a := range list {
+		projectDir, ok := agent.SkillDir(a.Name, false, home)
+		if !ok {
+			return nil, fmt.Errorf("resolving project skills dir for agent %q", a.Name)
+		}
+		globalDir, ok := agent.SkillDir(a.Name, true, home)
+		if !ok {
+			return nil, fmt.Errorf("resolving global skills dir for agent %q", a.Name)
+		}
+
+		installed := skill.IsAgentInstalled(a.Name, false, home, workDir) ||
+			skill.IsAgentInstalled(a.Name, true, home, workDir)
+
+		source := "builtin"
+		if _, ok := builtinSet[a.Name]; !ok {
+			source = "user"
+		}
+
+		entries = append(entries, render.AgentEntry{
+			Name:                    a.Name,
+			Installed:               installed,
+			Source:                  source,
+			ProjectSkillsDir:        projectDir,
+			GlobalSkillsDir:         globalDir,
+			ProjectMCPConfigFile:    a.Info.ProjectMCPConfigFile,
+			ProjectSkillsViaGeneric: a.Info.SupportsGenericProject,
+			GlobalSkillsViaGeneric:  a.Info.SupportsGenericGlobal,
+		})
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Installed != entries[j].Installed {
+			return entries[i].Installed
+		}
+		return entries[i].Name < entries[j].Name
+	})
+
+	return entries, nil
+}
+
+// AgentDetail returns the full detail view for a single agent identified
+// by name (case-insensitive match).
+func AgentDetail(home, workDir, name string) (*render.AgentDetail, error) {
+	slog.Debug("agent detail", "name", name)
+
+	var match *agent.Entry
+	for _, a := range agent.List() {
+		if strings.EqualFold(a.Name, name) {
+			a := a
+			match = &a
+			break
+		}
+	}
+	if match == nil {
+		return nil, fmt.Errorf("unknown agent %q", name)
+	}
+
+	builtinSet := make(map[string]struct{}, len(agent.Names()))
+	for _, n := range agent.Names() {
+		builtinSet[n] = struct{}{}
+	}
+
+	installed := skill.IsAgentInstalled(match.Name, false, home, workDir) ||
+		skill.IsAgentInstalled(match.Name, true, home, workDir)
+
+	source := "builtin"
+	if _, ok := builtinSet[match.Name]; !ok {
+		source = "user"
+	}
+
+	paths := collectAgentPaths(match.Name, home, workDir)
+
+	mcpCfg, mcpOk := agent.ProjectMCPConfigPath(match.Name, home)
+	var mcpExists bool
+	if mcpOk {
+		_, err := os.Stat(mcpCfg)
+		mcpExists = err == nil
+	}
+
+	return &render.AgentDetail{
+		Name:       match.Name,
+		Installed:  installed,
+		Source:     source,
+		Paths:      paths,
+		MCPSupport: match.Info.ProjectMCPConfigFile != "",
+		MCPConfig:  mcpCfg,
+		MCPExists:  mcpExists,
+	}, nil
+}
+
+// collectAgentPaths gathers all search paths for an agent with existence
+// and skill-count metadata.
+func collectAgentPaths(name, home, workDir string) []render.AgentPath {
+	var paths []render.AgentPath
+
+	addPath := func(label, dir string) {
+		exists := false
+		count := 0
+		if _, err := os.Stat(dir); err == nil {
+			exists = true
+			if metas, err := skill.ScanDir(dir); err == nil {
+				count = len(metas)
+			}
+		}
+		paths = append(paths, render.AgentPath{
+			Label:      label,
+			Path:       dir,
+			Exists:     exists,
+			SkillCount: count,
+		})
+	}
+
+	for _, relDir := range agent.ExpandedProjectSkillsSearch(name) {
+		absDir := workDir + "/" + relDir
+		addPath("project", absDir)
+	}
+
+	for _, absDir := range agent.ExpandedGlobalSkillsSearch(name, home) {
+		addPath("global", absDir)
+	}
+
+	for _, absDir := range agent.ExpandedPmSkillsSearch(name, home) {
+		addPath("package-manager", absDir)
+	}
+
+	return paths
+}

--- a/internal/engine/ops/agents_test.go
+++ b/internal/engine/ops/agents_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"gaal/internal/core/agent"
+	"gaal/internal/engine/render"
 )
 
 func TestListAgents_AllHaveNames(t *testing.T) {
@@ -103,5 +104,80 @@ func TestListAgents_SourceField(t *testing.T) {
 				t.Errorf("agent %q: expected source=builtin, got %q", e.Name, e.Source)
 			}
 		}
+	}
+}
+
+func TestAgentDetail_Found(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	detail, err := AgentDetail(home, workDir, "claude-code")
+	if err != nil {
+		t.Fatalf("AgentDetail: %v", err)
+	}
+	if detail.Name != "claude-code" {
+		t.Errorf("expected name=claude-code, got %q", detail.Name)
+	}
+	if detail.Source != "builtin" {
+		t.Errorf("expected source=builtin, got %q", detail.Source)
+	}
+	if !detail.MCPSupport {
+		t.Error("expected MCPSupport=true for claude-code")
+	}
+	if len(detail.Paths) == 0 {
+		t.Error("expected at least one path entry")
+	}
+}
+
+func TestAgentDetail_CaseInsensitive(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	detail, err := AgentDetail(home, workDir, "Claude-Code")
+	if err != nil {
+		t.Fatalf("AgentDetail: %v", err)
+	}
+	if detail.Name != "claude-code" {
+		t.Errorf("expected canonical name claude-code, got %q", detail.Name)
+	}
+}
+
+func TestAgentDetail_NotFound(t *testing.T) {
+	_, err := AgentDetail(t.TempDir(), t.TempDir(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown agent")
+	}
+}
+
+func TestAgentDetail_SkillCount(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+
+	// Create a fake project skills dir with 2 SKILL.md files.
+	skillsDir := filepath.Join(workDir, ".claude", "skills")
+	for _, name := range []string{"alpha", "beta"} {
+		dir := filepath.Join(skillsDir, name)
+		os.MkdirAll(dir, 0o755)
+		os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: "+name+"\n---\n"), 0o644)
+	}
+
+	detail, err := AgentDetail(home, workDir, "claude-code")
+	if err != nil {
+		t.Fatalf("AgentDetail: %v", err)
+	}
+
+	var projectPath *render.AgentPath
+	for i := range detail.Paths {
+		if detail.Paths[i].Label == "project" {
+			projectPath = &detail.Paths[i]
+			break
+		}
+	}
+	if projectPath == nil {
+		t.Fatal("no project path found in detail")
+	}
+	if !projectPath.Exists {
+		t.Error("expected project path to exist")
+	}
+	if projectPath.SkillCount != 2 {
+		t.Errorf("expected 2 skills, got %d", projectPath.SkillCount)
 	}
 }

--- a/internal/engine/ops/agents_test.go
+++ b/internal/engine/ops/agents_test.go
@@ -1,0 +1,107 @@
+package ops
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gaal/internal/core/agent"
+)
+
+func TestListAgents_AllHaveNames(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	entries, err := ListAgents(home, workDir)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one agent entry")
+	}
+	for _, e := range entries {
+		if e.Name == "" {
+			t.Error("agent entry has empty name")
+		}
+	}
+}
+
+func TestListAgents_InstalledDetection(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	// Create claude-code's global parent dir so it's detected as installed.
+	os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
+
+	entries, err := ListAgents(home, workDir)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	var found bool
+	for _, e := range entries {
+		if e.Name == "claude-code" {
+			found = true
+			if !e.Installed {
+				t.Error("expected claude-code Installed=true")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("claude-code not found in list")
+	}
+}
+
+func TestListAgents_SortOrder(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	// Install only claude-code (global).
+	os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
+
+	entries, err := ListAgents(home, workDir)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	// Find the boundary: installed entries should precede uninstalled.
+	seenUninstalled := false
+	for _, e := range entries {
+		if !e.Installed {
+			seenUninstalled = true
+		} else if seenUninstalled {
+			t.Errorf("installed agent %q appears after uninstalled agents", e.Name)
+		}
+	}
+	// Within installed and uninstalled groups, names should be sorted.
+	var prevInstalled, prevUninstalled string
+	for _, e := range entries {
+		if e.Installed {
+			if e.Name < prevInstalled {
+				t.Errorf("installed agents not sorted: %q after %q", e.Name, prevInstalled)
+			}
+			prevInstalled = e.Name
+		} else {
+			if e.Name < prevUninstalled {
+				t.Errorf("uninstalled agents not sorted: %q after %q", e.Name, prevUninstalled)
+			}
+			prevUninstalled = e.Name
+		}
+	}
+}
+
+func TestListAgents_SourceField(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	entries, err := ListAgents(home, workDir)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	builtinSet := make(map[string]struct{}, len(agent.Names()))
+	for _, n := range agent.Names() {
+		builtinSet[n] = struct{}{}
+	}
+	for _, e := range entries {
+		if _, ok := builtinSet[e.Name]; ok {
+			if e.Source != "builtin" {
+				t.Errorf("agent %q: expected source=builtin, got %q", e.Name, e.Source)
+			}
+		}
+	}
+}

--- a/internal/engine/ops/info.go
+++ b/internal/engine/ops/info.go
@@ -369,7 +369,6 @@ func buildSkillTree(e render.SkillEntry) []string {
 func renderAgentInfo(w io.Writer, entries []render.AgentEntry, filter string) error {
 	slog.Debug("rendering agent info", "count", len(entries), "filter", filter)
 
-	// Apply filter.
 	filtered := make([]render.AgentEntry, 0, len(entries))
 	for _, e := range entries {
 		if matchFilter(e.Name, filter) {
@@ -387,20 +386,30 @@ func renderAgentInfo(w io.Writer, entries []render.AgentEntry, filter string) er
 		return nil
 	}
 
+	sort.SliceStable(filtered, func(i, j int) bool {
+		if filtered[i].Installed != filtered[j].Installed {
+			return filtered[i].Installed
+		}
+		return filtered[i].Name < filtered[j].Name
+	})
+
 	infoSection(w, "Supported Agents", len(filtered), pterm.FgYellow)
 
-	// Source tag: builtin vs user-defined
 	builtinSet := make(map[string]struct{}, len(agent.Names()))
 	for _, n := range agent.Names() {
 		builtinSet[n] = struct{}{}
 	}
 
 	cards := make([]infoCard, 0, len(filtered))
-	for _, e := range entries {
-		if !matchFilter(e.Name, filter) {
-			continue
-		}
+	for _, e := range filtered {
 		lines := []string{}
+
+		installedStr := pterm.FgDarkGray.Sprint("no")
+		if e.Installed {
+			installedStr = pterm.FgGreen.Sprint("yes")
+		}
+		lines = append(lines, kvLine("Installed", installedStr))
+
 		if e.ProjectSkillsViaGeneric {
 			lines = append(lines, kvLine("Project", pterm.FgDarkGray.Sprintf("via generic convention (%s)", e.ProjectSkillsDir)))
 		} else if e.ProjectSkillsDir != "" {
@@ -422,7 +431,11 @@ func renderAgentInfo(w io.Writer, entries []render.AgentEntry, filter string) er
 		}
 
 		source := pterm.FgGreen.Sprint("builtin")
-		if _, ok := builtinSet[e.Name]; !ok {
+		if e.Source != "" {
+			if e.Source == "user" {
+				source = pterm.FgCyan.Sprint("user")
+			}
+		} else if _, ok := builtinSet[e.Name]; !ok {
 			source = pterm.FgCyan.Sprint("user")
 		}
 		lines = append(lines, kvLine("Source", source))

--- a/internal/engine/ops/info_test.go
+++ b/internal/engine/ops/info_test.go
@@ -428,6 +428,45 @@ func TestRenderAgentInfo_NoMCPShownAsDash(t *testing.T) {
 	}
 }
 
+func TestRenderAgentInfo_InstalledFirst(t *testing.T) {
+	entries := []render.AgentEntry{
+		{Name: "alpha", Installed: false, Source: "builtin"},
+		{Name: "beta", Installed: true, Source: "builtin"},
+		{Name: "gamma", Installed: false, Source: "builtin"},
+		{Name: "delta", Installed: true, Source: "builtin"},
+	}
+	var buf bytes.Buffer
+	if err := renderAgentInfo(&buf, entries, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := pterm.RemoveColorFromString(buf.String())
+	// beta and delta (installed) should appear before alpha and gamma.
+	betaIdx := strings.Index(out, "beta")
+	deltaIdx := strings.Index(out, "delta")
+	alphaIdx := strings.Index(out, "alpha")
+	gammaIdx := strings.Index(out, "gamma")
+	if betaIdx < 0 || deltaIdx < 0 || alphaIdx < 0 || gammaIdx < 0 {
+		t.Fatalf("missing agent names in output:\n%s", out)
+	}
+	if betaIdx > alphaIdx || deltaIdx > gammaIdx {
+		t.Error("expected installed agents to appear before uninstalled agents")
+	}
+}
+
+func TestRenderAgentInfo_ShowsInstalledStatus(t *testing.T) {
+	entries := []render.AgentEntry{
+		{Name: "myagent", Installed: true, Source: "builtin", ProjectSkillsDir: ".test/skills", GlobalSkillsDir: "~/.test/skills"},
+	}
+	var buf bytes.Buffer
+	if err := renderAgentInfo(&buf, entries, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := pterm.RemoveColorFromString(buf.String())
+	if !strings.Contains(out, "yes") {
+		t.Error("expected 'yes' for installed agent")
+	}
+}
+
 func TestRenderAgentInfo_GenericConventionShowsResolvedDir(t *testing.T) {
 	entries := []render.AgentEntry{
 		{

--- a/internal/engine/ops/status.go
+++ b/internal/engine/ops/status.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 
-	"gaal/internal/core/agent"
 	"gaal/internal/engine/render"
 	"gaal/internal/mcp"
 	"gaal/internal/repo"
@@ -121,35 +120,15 @@ func collectMCPs(stats []mcp.Status) []render.MCPEntry {
 
 func collectAgents() ([]render.AgentEntry, error) {
 	slog.Debug("collecting agent entries")
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolving user home dir: %w", err)
 	}
-
-	list := agent.List()
-	entries := make([]render.AgentEntry, len(list))
-	for i, a := range list {
-		projectDir, ok := agent.SkillDir(a.Name, false, home)
-		if !ok {
-			return nil, fmt.Errorf("resolving project skills dir for agent %q", a.Name)
-		}
-
-		globalDir, ok := agent.SkillDir(a.Name, true, home)
-		if !ok {
-			return nil, fmt.Errorf("resolving global skills dir for agent %q", a.Name)
-		}
-
-		entries[i] = render.AgentEntry{
-			Name:                    a.Name,
-			ProjectSkillsDir:        projectDir,
-			GlobalSkillsDir:         globalDir,
-			ProjectMCPConfigFile:    a.Info.ProjectMCPConfigFile,
-			ProjectSkillsViaGeneric: a.Info.SupportsGenericProject,
-			GlobalSkillsViaGeneric:  a.Info.SupportsGenericGlobal,
-		}
+	workDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("resolving working dir: %w", err)
 	}
-	return entries, nil
+	return ListAgents(home, workDir)
 }
 
 // orDefault returns s if non-empty, otherwise def.

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -39,11 +39,33 @@ type SkillEntry struct {
 // AgentEntry holds the registry information for a supported agent.
 type AgentEntry struct {
 	Name                    string `json:"name"`
+	Installed               bool   `json:"installed"`
+	Source                  string `json:"source"`
 	ProjectSkillsDir        string `json:"project_skills_dir"`
 	GlobalSkillsDir         string `json:"global_skills_dir"`
 	ProjectMCPConfigFile    string `json:"project_mcp_config_file,omitempty"`
 	ProjectSkillsViaGeneric bool   `json:"project_skills_via_generic,omitempty"`
 	GlobalSkillsViaGeneric  bool   `json:"global_skills_via_generic,omitempty"`
+}
+
+// AgentPath describes a single search path for an agent's skills or config.
+type AgentPath struct {
+	Label      string `json:"label"`
+	Path       string `json:"path"`
+	Exists     bool   `json:"exists"`
+	SkillCount int    `json:"skill_count"`
+}
+
+// AgentDetail holds the full detail view for a single agent.
+type AgentDetail struct {
+	Name       string      `json:"name"`
+	Installed  bool        `json:"installed"`
+	Source     string      `json:"source"`
+	Paths      []AgentPath `json:"paths"`
+	MCPSupport bool        `json:"mcp_support"`
+	MCPConfig  string      `json:"mcp_config,omitempty"`
+	MCPExists  bool        `json:"mcp_exists,omitempty"`
+	Warnings   []string    `json:"warnings,omitempty"`
 }
 
 // MCPEntry holds the status of a single MCP server entry.

--- a/internal/engine/render/table.go
+++ b/internal/engine/render/table.go
@@ -391,20 +391,25 @@ func (tr *tableRenderer) mcpTable(w io.Writer, entries []MCPEntry, termW int) er
 
 func (tr *tableRenderer) agentTable(w io.Writer, entries []AgentEntry, termW int) error {
 	tr.section(w, "Supported Agents", len(entries))
-	// Fixed: AGENT(20) = 20; 3 variable path columns share the rest.
-	vw := varColWidth(termW, 4, 3, 20)
+	// Fixed: AGENT(20) + INSTALLED(11) = 31; 3 variable path columns share the rest.
+	vw := varColWidth(termW, 5, 3, 31)
 	if vw < 14 {
 		vw = 14
 	}
 
-	data := pterm.TableData{{"AGENT", "PROJECT SKILLS DIR", "GLOBAL SKILLS DIR", "PROJECT MCP CONFIG"}}
+	data := pterm.TableData{{"AGENT", "INSTALLED", "PROJECT SKILLS DIR", "GLOBAL SKILLS DIR", "PROJECT MCP CONFIG"}}
 	for _, e := range entries {
+		installed := pterm.FgDarkGray.Sprint("—")
+		if e.Installed {
+			installed = pterm.FgGreen.Sprint("✓")
+		}
 		mcpCfg := e.ProjectMCPConfigFile
 		if mcpCfg == "" {
 			mcpCfg = "—"
 		}
 		data = append(data, []string{
 			e.Name,
+			installed,
 			trunc(e.ProjectSkillsDir, vw),
 			trunc(e.GlobalSkillsDir, vw),
 			trunc(mcpCfg, vw),

--- a/internal/skill/installed.go
+++ b/internal/skill/installed.go
@@ -1,0 +1,25 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// IsAgentInstalled reports whether the directory that would own the agent's
+// skills on this machine already exists. This checks the parent of the
+// agent's skill dir — the same heuristic used by sync to avoid creating
+// agent-owned directories as a side effect.
+func IsAgentInstalled(name string, global bool, home, workDir string) bool {
+	dir, ok := SkillDir(name, global, home)
+	if !ok {
+		return false
+	}
+	var checkDir string
+	if !global && !filepath.IsAbs(dir) {
+		checkDir = filepath.Join(workDir, filepath.Dir(dir))
+	} else {
+		checkDir = filepath.Dir(expandHome(dir, home))
+	}
+	_, err := os.Stat(checkDir)
+	return err == nil
+}

--- a/internal/skill/installed_test.go
+++ b/internal/skill/installed_test.go
@@ -1,0 +1,49 @@
+package skill_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gaal/internal/skill"
+)
+
+func TestIsAgentInstalled_ProjectScope(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	// Create the parent dir of claude-code's project skills dir (.claude/).
+	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
+
+	if !skill.IsAgentInstalled("claude-code", false, home, workDir) {
+		t.Error("expected claude-code to be detected as installed (project scope)")
+	}
+}
+
+func TestIsAgentInstalled_GlobalScope(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	// Create the parent dir of claude-code's global skills dir (~/.claude/).
+	os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
+
+	if !skill.IsAgentInstalled("claude-code", true, home, workDir) {
+		t.Error("expected claude-code to be detected as installed (global scope)")
+	}
+}
+
+func TestIsAgentInstalled_Neither(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+	// Don't create any dirs — should return false.
+	if skill.IsAgentInstalled("claude-code", false, home, workDir) {
+		t.Error("expected claude-code to NOT be detected (project scope)")
+	}
+	if skill.IsAgentInstalled("claude-code", true, home, workDir) {
+		t.Error("expected claude-code to NOT be detected (global scope)")
+	}
+}
+
+func TestIsAgentInstalled_UnknownAgent(t *testing.T) {
+	if skill.IsAgentInstalled("nonexistent-agent", false, t.TempDir(), t.TempDir()) {
+		t.Error("expected unknown agent to not be installed")
+	}
+}

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -235,18 +235,7 @@ func (m *Manager) syncAgents(sc config.SkillConfig) []string {
 // signal used by sync: we never create agent-owned directories as a side
 // effect of a sync run.
 func (m *Manager) isAgentInstalled(name string, global bool) bool {
-	dir, ok := SkillDir(name, global, m.home)
-	if !ok {
-		return false
-	}
-	checkDir := dir
-	if !global && !filepath.IsAbs(dir) {
-		checkDir = filepath.Join(m.workDir, filepath.Dir(dir))
-	} else {
-		checkDir = filepath.Dir(expandHome(dir, m.home))
-	}
-	_, err := os.Stat(checkDir)
-	return err == nil
+	return IsAgentInstalled(name, global, m.home, m.workDir)
 }
 
 // detectInstalledAgents returns every registered agent whose config-owning


### PR DESCRIPTION
## Summary

- Adds top-level `gaal agents` command with list view (NAME/INSTALLED/SOURCE), detail view (`gaal agents <name>` with search paths + skill counts), `--installed` filter, and `--output json` support
- Revamps `info agent` to sort installed agents first and show installed status in each card
- Extracts shared `ListAgents`/`AgentDetail` lister in `ops/agents.go` so both commands stay in sync

Closes #23, closes #19

## Test plan

- [x] `gaal agents` — lists all agents, installed-first
- [x] `gaal agents --installed` — filters to installed only
- [x] `gaal agents claude-code` — detail view with paths and skill counts
- [x] `gaal agents -o json` — JSON list output
- [x] `gaal agents claude-code -o json` — JSON detail output
- [x] `gaal info agent` — cards now sorted installed-first with "Installed" line
- [x] `gaal status` — agent table includes INSTALLED column
- [x] `make test` — all tests pass