### PR TITLE
feat: add gaal migrate --to community stub command

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,25 @@ Use `gaal agents` to list all registered agents (built-in + custom) and verify y
 
 ---
 
+## Graduation path to gaal Community
+
+When your team outgrows single-user Lite (shared configs, drift detection,
+approval workflows), gaal Community Edition picks up where Lite leaves off.
+
+The migration command validates your current configuration and confirms it is
+ready to push to a Community instance:
+
+```bash
+gaal migrate --to community https://community.example.com
+gaal migrate --to community https://community.example.com --dry-run
+```
+
+Community Edition is not yet publicly available. Running `gaal migrate` today
+validates your YAML and prints what would be migrated. Subscribe at
+<https://getgaal.com> to be notified when Community ships.
+
+---
+
 ## Development
 
 ```bash

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -33,7 +33,7 @@ Examples:
   gaal migrate --to community https://community.example.com --dry-run
   gaal migrate --to community https://community.example.com --yes`,
 	SilenceUsage: true,
-	Args:         cobra.ExactArgs(1),
+	Args:         cobra.MaximumNArgs(1),
 	RunE:         runMigrate,
 }
 
@@ -41,20 +41,33 @@ func init() {
 	migrateCmd.Flags().StringVar(&migrateTarget, "to", "", `migration target (currently only "community" is supported)`)
 	migrateCmd.Flags().BoolVar(&migrateDryRun, "dry-run", false, "validate everything but do not perform the migration")
 	migrateCmd.Flags().BoolVar(&migrateYes, "yes", false, "skip interactive confirmation")
-	_ = migrateCmd.MarkFlagRequired("to")
 	rootCmd.AddCommand(migrateCmd)
+}
+
+func printDisclaimer() {
+	fmt.Println()
+	fmt.Println("gaal Community Edition is not yet available. Your configuration is valid and")
+	fmt.Println("ready to migrate when Community ships. Join the announcement list:")
+	fmt.Println("https://getgaal.com")
 }
 
 func runMigrate(_ *cobra.Command, args []string) error {
 	cfg, err := config.LoadChain(cfgFile)
 	if err != nil {
+		printDisclaimer()
 		return fmt.Errorf("loading config: %w", err)
+	}
+
+	var url string
+	if len(args) > 0 {
+		url = args[0]
 	}
 
 	eng := engine.NewWithOptions(cfg, engineOpts)
 
-	result, err := eng.Migrate(migrateTarget, args[0], migrateDryRun)
+	result, err := eng.Migrate(migrateTarget, url, migrateDryRun)
 	if err != nil {
+		printDisclaimer()
 		return err
 	}
 
@@ -65,10 +78,7 @@ func runMigrate(_ *cobra.Command, args []string) error {
 
 	fmt.Printf("Would migrate %d repositories, %d skills, %d MCP servers to %s\n",
 		result.Repositories, result.Skills, result.MCPs, result.URL)
-	fmt.Println()
-	fmt.Println("gaal Community Edition is not yet available. Your configuration is valid and")
-	fmt.Println("ready to migrate when Community ships. Join the announcement list:")
-	fmt.Println("https://getgaal.com")
+	printDisclaimer()
 
 	return nil
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"gaal/internal/config"
+	"gaal/internal/engine"
+)
+
+var (
+	migrateTarget string
+	migrateDryRun bool
+	migrateYes    bool
+)
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate --to community <url>",
+	Short: "Migrate this Lite configuration to a gaal Community Edition instance",
+	Long: `Migrate this Lite configuration to a gaal Community Edition instance.
+
+Reads the local gaal configuration, validates it, and pushes it to the
+specified Community URL as versioned configs.
+
+Community Edition is not yet publicly available. Running this command
+today validates your configuration and confirms it is ready to migrate.
+Subscribe to the announcement list at https://getgaal.com to be notified
+when migration becomes available.
+
+Examples:
+  gaal migrate --to community https://community.example.com
+  gaal migrate --to community https://community.example.com --dry-run
+  gaal migrate --to community https://community.example.com --yes`,
+	SilenceUsage: true,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runMigrate,
+}
+
+func init() {
+	migrateCmd.Flags().StringVar(&migrateTarget, "to", "", `migration target (currently only "community" is supported)`)
+	migrateCmd.Flags().BoolVar(&migrateDryRun, "dry-run", false, "validate everything but do not perform the migration")
+	migrateCmd.Flags().BoolVar(&migrateYes, "yes", false, "skip interactive confirmation")
+	_ = migrateCmd.MarkFlagRequired("to")
+	rootCmd.AddCommand(migrateCmd)
+}
+
+func runMigrate(_ *cobra.Command, args []string) error {
+	cfg, err := config.LoadChain(cfgFile)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	eng := engine.NewWithOptions(cfg, engineOpts)
+
+	result, err := eng.Migrate(migrateTarget, args[0], migrateDryRun)
+	if err != nil {
+		return err
+	}
+
+	if migrateDryRun {
+		fmt.Println("[dry-run] No changes will be made.")
+		fmt.Println()
+	}
+
+	fmt.Printf("Would migrate %d repositories, %d skills, %d MCP servers to %s\n",
+		result.Repositories, result.Skills, result.MCPs, result.URL)
+	fmt.Println()
+	fmt.Println("gaal Community Edition is not yet available. Your configuration is valid and")
+	fmt.Println("ready to migrate when Community ships. Join the announcement list:")
+	fmt.Println("https://getgaal.com")
+
+	return nil
+}

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gaal/internal/engine"
+)
+
+func resetMigrateFlags(t *testing.T) {
+	t.Helper()
+	origCfg := cfgFile
+	origTarget := migrateTarget
+	origDryRun := migrateDryRun
+	origYes := migrateYes
+	origOpts := engineOpts
+	t.Cleanup(func() {
+		cfgFile = origCfg
+		migrateTarget = origTarget
+		migrateDryRun = origDryRun
+		migrateYes = origYes
+		engineOpts = origOpts
+	})
+	migrateTarget = ""
+	migrateDryRun = false
+	migrateYes = false
+}
+
+func writeMinimalConfig(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "gaal.yaml")
+	data := []byte(`repositories:
+  src/app:
+    type: git
+    url: https://github.com/example/app.git
+skills:
+  - source: example/skills
+    agents: ["*"]
+mcps:
+  - name: filesystem
+    target: ~/.config/claude/config.json
+    inline:
+      command: uvx
+      args: [mcp-server-filesystem]
+`)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestMigrate_ValidConfig(t *testing.T) {
+	resetMigrateFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfgFile = writeMinimalConfig(t, workDir)
+	migrateTarget = "community"
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	out := captureStdout(t, func() {
+		if err := runMigrate(migrateCmd, []string{"https://community.example.com"}); err != nil {
+			t.Fatalf("runMigrate: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "1 repositories") {
+		t.Errorf("expected repo count in output:\n%s", out)
+	}
+	if !strings.Contains(out, "1 skills") {
+		t.Errorf("expected skill count in output:\n%s", out)
+	}
+	if !strings.Contains(out, "1 MCP servers") {
+		t.Errorf("expected MCP count in output:\n%s", out)
+	}
+	if !strings.Contains(out, "community.example.com") {
+		t.Errorf("expected URL in output:\n%s", out)
+	}
+	if !strings.Contains(out, "not yet available") {
+		t.Errorf("expected waiting message in output:\n%s", out)
+	}
+}
+
+func TestMigrate_InvalidConfig(t *testing.T) {
+	resetMigrateFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Write an invalid config (missing required fields).
+	bad := filepath.Join(workDir, "gaal.yaml")
+	if err := os.WriteFile(bad, []byte("skills:\n  - agents: [\"*\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgFile = bad
+	migrateTarget = "community"
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	err := runMigrate(migrateCmd, []string{"https://community.example.com"})
+	if err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+}
+
+func TestMigrate_BadURL(t *testing.T) {
+	resetMigrateFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfgFile = writeMinimalConfig(t, workDir)
+	migrateTarget = "community"
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	err := runMigrate(migrateCmd, []string{"not-a-url"})
+	if err == nil {
+		t.Fatal("expected error for bad URL")
+	}
+	if !strings.Contains(err.Error(), "invalid URL") {
+		t.Errorf("expected 'invalid URL' in error, got: %v", err)
+	}
+}
+
+func TestMigrate_UnknownTarget(t *testing.T) {
+	resetMigrateFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfgFile = writeMinimalConfig(t, workDir)
+	migrateTarget = "saas"
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	err := runMigrate(migrateCmd, []string{"https://example.com"})
+	if err == nil {
+		t.Fatal("expected error for unknown target")
+	}
+	if !strings.Contains(err.Error(), "unknown migration target") {
+		t.Errorf("expected 'unknown migration target' in error, got: %v", err)
+	}
+}
+
+func TestMigrate_DryRun(t *testing.T) {
+	resetMigrateFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfgFile = writeMinimalConfig(t, workDir)
+	migrateTarget = "community"
+	migrateDryRun = true
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	out := captureStdout(t, func() {
+		if err := runMigrate(migrateCmd, []string{"https://community.example.com"}); err != nil {
+			t.Fatalf("runMigrate: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "[dry-run]") {
+		t.Errorf("expected dry-run marker in output:\n%s", out)
+	}
+	if !strings.Contains(out, "not yet available") {
+		t.Errorf("expected waiting message in output:\n%s", out)
+	}
+}

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -102,9 +102,15 @@ func TestMigrate_InvalidConfig(t *testing.T) {
 	migrateTarget = "community"
 	engineOpts = engine.Options{WorkDir: workDir}
 
-	err := runMigrate(migrateCmd, []string{"https://community.example.com"})
-	if err == nil {
+	var gotErr error
+	out := captureStdout(t, func() {
+		gotErr = runMigrate(migrateCmd, []string{"https://community.example.com"})
+	})
+	if gotErr == nil {
 		t.Fatal("expected error for invalid config")
+	}
+	if !strings.Contains(out, "not yet available") {
+		t.Errorf("expected disclaimer even on config error:\n%s", out)
 	}
 }
 
@@ -119,12 +125,18 @@ func TestMigrate_BadURL(t *testing.T) {
 	migrateTarget = "community"
 	engineOpts = engine.Options{WorkDir: workDir}
 
-	err := runMigrate(migrateCmd, []string{"not-a-url"})
-	if err == nil {
+	var gotErr error
+	out := captureStdout(t, func() {
+		gotErr = runMigrate(migrateCmd, []string{"not-a-url"})
+	})
+	if gotErr == nil {
 		t.Fatal("expected error for bad URL")
 	}
-	if !strings.Contains(err.Error(), "invalid URL") {
-		t.Errorf("expected 'invalid URL' in error, got: %v", err)
+	if !strings.Contains(gotErr.Error(), "invalid URL") {
+		t.Errorf("expected 'invalid URL' in error, got: %v", gotErr)
+	}
+	if !strings.Contains(out, "not yet available") {
+		t.Errorf("expected disclaimer even on bad URL:\n%s", out)
 	}
 }
 
@@ -139,12 +151,40 @@ func TestMigrate_UnknownTarget(t *testing.T) {
 	migrateTarget = "saas"
 	engineOpts = engine.Options{WorkDir: workDir}
 
-	err := runMigrate(migrateCmd, []string{"https://example.com"})
-	if err == nil {
+	var gotErr error
+	out := captureStdout(t, func() {
+		gotErr = runMigrate(migrateCmd, []string{"https://example.com"})
+	})
+	if gotErr == nil {
 		t.Fatal("expected error for unknown target")
 	}
-	if !strings.Contains(err.Error(), "unknown migration target") {
-		t.Errorf("expected 'unknown migration target' in error, got: %v", err)
+	if !strings.Contains(gotErr.Error(), "unknown migration target") {
+		t.Errorf("expected 'unknown migration target' in error, got: %v", gotErr)
+	}
+	if !strings.Contains(out, "not yet available") {
+		t.Errorf("expected disclaimer even on unknown target:\n%s", out)
+	}
+}
+
+func TestMigrate_NoArgs(t *testing.T) {
+	resetMigrateFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfgFile = writeMinimalConfig(t, workDir)
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	var gotErr error
+	out := captureStdout(t, func() {
+		gotErr = runMigrate(migrateCmd, nil)
+	})
+	if gotErr == nil {
+		t.Fatal("expected error when no URL or --to provided")
+	}
+	if !strings.Contains(out, "not yet available") {
+		t.Errorf("expected disclaimer even with missing params:\n%s", out)
 	}
 }
 

--- a/cmd/testutil_test.go
+++ b/cmd/testutil_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// captureStdout redirects os.Stdout to an os.Pipe for the duration of fn,
+// then restores it and returns everything that was written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf.ReadFrom(r) //nolint:errcheck
+	}()
+
+	fn()
+	w.Close()
+	os.Stdout = orig
+	<-done
+	r.Close()
+	return buf.String()
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -209,3 +209,10 @@ func (e *Engine) BuildImportCandidates(ctx context.Context, scope ops.Scope) (op
 func (e *Engine) InitFromPlan(dest string, plan ops.Plan, force bool) error {
 	return ops.InitFromPlan(dest, plan, force)
 }
+
+// Migrate validates the configuration and returns a summary of what would be
+// migrated to a Community Edition instance. The actual migration is not yet
+// implemented — this stub reserves the CLI surface.
+func (e *Engine) Migrate(target, url string, dryRun bool) (*ops.MigrateResult, error) {
+	return ops.Migrate(e.cfg, target, url, dryRun)
+}

--- a/internal/engine/ops/migrate.go
+++ b/internal/engine/ops/migrate.go
@@ -1,0 +1,44 @@
+package ops
+
+import (
+	"fmt"
+	"net/url"
+
+	"gaal/internal/config"
+)
+
+// MigrateResult holds the summary of what would be migrated.
+type MigrateResult struct {
+	Target       string
+	URL          string
+	DryRun       bool
+	Repositories int
+	Skills       int
+	MCPs         int
+}
+
+// Migrate validates the configuration and prints a migration summary.
+// Community Edition is not yet available, so this is a stub that reserves
+// the CLI surface and validates readiness.
+func Migrate(cfg *config.Config, target, rawURL string, dryRun bool) (*MigrateResult, error) {
+	if target != "community" {
+		return nil, fmt.Errorf("unknown migration target %q (supported: community)", target)
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("invalid URL %q: must include scheme and host (e.g. https://community.example.com)", rawURL)
+	}
+
+	return &MigrateResult{
+		Target:       target,
+		URL:          rawURL,
+		DryRun:       dryRun,
+		Repositories: len(cfg.Repositories),
+		Skills:       len(cfg.Skills),
+		MCPs:         len(cfg.MCPs),
+	}, nil
+}


### PR DESCRIPTION
## Summary

- Adds `gaal migrate --to community <url>` stub command that validates the config and prints a migration summary with a "Community not yet available" disclaimer
- Flags: `--to` (only `community` accepted), `--dry-run`, `--yes`; URL is an optional positional arg validated for scheme+host
- Disclaimer is always printed, even when params are missing or validation fails — since Community isn't shipping yet, the message is the point
- Adds graduation path section to README documenting the migration command

## Test plan

- [x] `gaal --help` lists `migrate` subcommand
- [x] `gaal migrate --help` shows real prose help text with examples
- [x] Valid config prints resource counts + waiting message, exits 0
- [x] Invalid config prints disclaimer, exits non-zero
- [x] Bad URL prints disclaimer + "invalid URL" error
- [x] Unknown `--to` target prints disclaimer + error
- [x] No args at all prints disclaimer + error
- [x] `--dry-run` prints dry-run marker before summary
- [x] Full test suite passes (473 tests, 0 failures)

Closes #27