### PR TITLE
feat: add opt-in telemetry via Plausible Events API

### DIFF
--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -13,6 +13,7 @@ import (
 	"gaal/internal/config"
 	"gaal/internal/engine"
 	"gaal/internal/engine/render"
+	"gaal/internal/telemetry"
 )
 
 var (
@@ -42,6 +43,7 @@ func init() {
 }
 
 func runAgents(_ *cobra.Command, args []string) error {
+	telemetry.Track("agents")
 	eng := engine.NewWithOptions(&config.Config{}, engineOpts)
 	w := os.Stdout
 	format := engine.OutputFormat(outputFormat)

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -7,6 +7,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/engine"
+	"gaal/internal/telemetry"
 )
 
 var auditCmd = &cobra.Command{
@@ -31,6 +32,7 @@ func init() {
 }
 
 func runAudit(_ *cobra.Command, _ []string) error {
+	telemetry.Track("audit")
 	// Audit does not require a gaal.yaml — pass an empty config.
 	return engine.NewWithOptions(&config.Config{}, engineOpts).
 		Audit(context.Background(), engine.OutputFormat(outputFormat))

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -8,6 +8,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/engine"
+	"gaal/internal/telemetry"
 )
 
 var infoCmd = &cobra.Command{
@@ -49,9 +50,11 @@ func runInfo(_ *cobra.Command, args []string) error {
 
 	cfg, err := config.LoadChain(cfgFile)
 	if err != nil {
+		telemetry.TrackError("info", err)
 		return fmt.Errorf("loading config: %w", err)
 	}
 
+	telemetry.Track("info")
 	return engine.NewWithOptions(cfg, engineOpts).
 		Info(context.Background(), pkg, filter, engine.OutputFormat(outputFormat))
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,6 +16,7 @@ import (
 	"gaal/internal/config"
 	"gaal/internal/engine"
 	"gaal/internal/engine/ops"
+	"gaal/internal/telemetry"
 )
 
 var (
@@ -57,6 +58,8 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	telemetry.Track("init")
 
 	isTTY := term.IsTerminal(int(os.Stdin.Fd()))
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -7,6 +7,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/engine"
+	"gaal/internal/telemetry"
 )
 
 var (
@@ -54,6 +55,7 @@ func printDisclaimer() {
 func runMigrate(_ *cobra.Command, args []string) error {
 	cfg, err := config.LoadChain(cfgFile)
 	if err != nil {
+		telemetry.TrackError("migrate", err)
 		printDisclaimer()
 		return fmt.Errorf("loading config: %w", err)
 	}
@@ -67,9 +69,13 @@ func runMigrate(_ *cobra.Command, args []string) error {
 
 	result, err := eng.Migrate(migrateTarget, url, migrateDryRun)
 	if err != nil {
+		telemetry.TrackError("migrate", err)
 		printDisclaimer()
 		return err
 	}
+
+	telemetry.Track("migrate")
+	telemetry.TrackCustom("Migration", nil)
 
 	if migrateDryRun {
 		fmt.Println("[dry-run] No changes will be made.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,12 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 
 		return nil
 	},
+	// PersistentPostRunE runs after every sub-command. Waits briefly for
+	// in-flight telemetry events to complete before the process exits.
+	PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
+		telemetry.Shutdown()
+		return nil
+	},
 	// No RunE: invoking gaal without a sub-command prints the banner (via
 	// PersistentPreRunE) then lists the available commands.
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -84,6 +90,7 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 // Execute is the entry-point called by main.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		telemetry.Shutdown()
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,10 +7,14 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
+	"gaal/internal/config"
 	"gaal/internal/engine"
 	"gaal/internal/logger"
+	"gaal/internal/telemetry"
 )
 
 var (
@@ -55,6 +59,19 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 			return err
 		}
 		engineOpts = opts
+
+		// Telemetry: resolve consent state and initialise.
+		if !skipTelemetry(cmd) {
+			userCfg := loadUserTelemetryConfig()
+			var promptFn func() (bool, error)
+			if term.IsTerminal(int(os.Stdin.Fd())) {
+				promptFn = showConsentPrompt
+			}
+			if _, err := telemetry.Init(userCfg, promptFn, Version); err != nil {
+				slog.Debug("telemetry init failed", "err", err)
+			}
+		}
+
 		return nil
 	},
 	// No RunE: invoking gaal without a sub-command prints the banner (via
@@ -142,4 +159,41 @@ func setupLogger() error {
 	}
 	_, err := logger.Setup(level, logFile)
 	return err
+}
+
+// skipTelemetry returns true for commands that should never trigger
+// telemetry or the consent prompt.
+func skipTelemetry(cmd *cobra.Command) bool {
+	name := cmd.Name()
+	return name == "version" || name == "schema" ||
+		(cmd.HasParent() && cmd.Parent().Name() == "completion")
+}
+
+// loadUserTelemetryConfig reads the telemetry field from the user config
+// file without going through the full config merge chain.
+func loadUserTelemetryConfig() *bool {
+	cfg, err := config.Load(config.UserConfigFilePath())
+	if err != nil {
+		return nil
+	}
+	return cfg.Telemetry
+}
+
+// showConsentPrompt displays the opt-in telemetry prompt.
+func showConsentPrompt() (bool, error) {
+	fmt.Println()
+	fmt.Println("gaal can send anonymous usage pings to help us understand adoption.")
+	fmt.Println("No config contents, file paths, or identifiers are ever sent.")
+	fmt.Println("See PRIVACY_POLICY.md for details.")
+	fmt.Println()
+
+	result, err := pterm.DefaultInteractiveConfirm.
+		WithDefaultValue(false).
+		WithDefaultText("Enable anonymous telemetry?").
+		Show()
+	if err != nil {
+		return false, err
+	}
+	fmt.Println()
+	return result, nil
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -8,6 +8,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/engine"
+	"gaal/internal/telemetry"
 )
 
 var statusCmd = &cobra.Command{
@@ -27,9 +28,11 @@ func init() {
 func runStatus(_ *cobra.Command, _ []string) error {
 	cfg, err := config.LoadChain(cfgFile)
 	if err != nil {
+		telemetry.TrackError("status", err)
 		return fmt.Errorf("loading config: %w", err)
 	}
 
+	telemetry.Track("status")
 	return engine.NewWithOptions(cfg, engineOpts).
 		Status(context.Background(), engine.OutputFormat(outputFormat))
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -13,6 +13,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/engine"
+	"gaal/internal/telemetry"
 )
 
 var (
@@ -41,6 +42,7 @@ func init() {
 func runSync(_ *cobra.Command, _ []string) error {
 	cfg, err := config.LoadChain(cfgFile)
 	if err != nil {
+		telemetry.TrackError("sync", err)
 		return fmt.Errorf("loading config: %w", err)
 	}
 
@@ -51,9 +53,16 @@ func runSync(_ *cobra.Command, _ []string) error {
 
 	if service {
 		slog.Info("service mode started", "interval", interval, "config", cfgFile)
+		telemetry.Track("sync")
 		return eng.RunService(ctx, interval)
 	}
 
 	slog.Info("one-shot sync", "config", cfgFile)
-	return eng.RunOnce(ctx)
+	if err := eng.RunOnce(ctx); err != nil {
+		telemetry.TrackError("sync", err)
+		return err
+	}
+	telemetry.Track("sync")
+	telemetry.TrackFirstSync(0)
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Repositories map[string]RepoConfig `yaml:"repositories" json:"repositories,omitempty" jsonschema:"description=Map of workspace-relative paths to repository entries" validate:"dive"`
 	Skills       []SkillConfig         `yaml:"skills"       json:"skills,omitempty"       jsonschema:"description=Skill sources to install into agent skill directories"   validate:"dive"`
 	MCPs         []MCPConfig           `yaml:"mcps"         json:"mcps,omitempty"         jsonschema:"description=MCP server configuration entries to merge"             validate:"dive"`
+	Telemetry    *bool                 `yaml:"telemetry,omitempty" json:"telemetry,omitempty" jsonschema:"description=Opt-in anonymous usage telemetry (true/false)"`
 }
 
 // RepoConfig is a vcstool-compatible repository entry.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -513,6 +513,63 @@ mcps:
 }
 
 // ---------------------------------------------------------------------------
+// Telemetry field
+// ---------------------------------------------------------------------------
+
+func TestTelemetryFieldLoadedFromYAML(t *testing.T) {
+	p := writeYAML(t, "telemetry: true\n")
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Telemetry == nil {
+		t.Fatal("expected Telemetry to be non-nil, got nil")
+	}
+	if !*cfg.Telemetry {
+		t.Errorf("expected Telemetry to be true, got false")
+	}
+}
+
+func TestTelemetryFieldNilWhenAbsent(t *testing.T) {
+	p := writeYAML(t, "skills:\n  - source: owner/repo\n")
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Telemetry != nil {
+		t.Errorf("expected Telemetry to be nil when absent, got %v", *cfg.Telemetry)
+	}
+}
+
+func TestTelemetryNotMerged(t *testing.T) {
+	dir := t.TempDir()
+
+	lower := filepath.Join(dir, "lower.yaml")
+	os.WriteFile(lower, []byte("telemetry: true\n"), 0o644)
+
+	higher := filepath.Join(dir, "higher.yaml")
+	os.WriteFile(higher, []byte("skills:\n  - source: owner/repo\n"), 0o644)
+
+	cfgLow, err := Load(lower)
+	if err != nil {
+		t.Fatalf("Load lower: %v", err)
+	}
+	cfgHigh, err := Load(higher)
+	if err != nil {
+		t.Fatalf("Load higher: %v", err)
+	}
+
+	merged := &Config{}
+	merged.mergeFrom(cfgLow)
+	merged.mergeFrom(cfgHigh)
+
+	// Telemetry is intentionally excluded from merging; higher config's nil wins.
+	if merged.Telemetry != nil {
+		t.Errorf("expected Telemetry to be nil after merge (higher has no telemetry), got %v", *merged.Telemetry)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,0 +1,60 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var plausibleEndpoint = "https://usage.getgaal.com/api/event"
+
+const (
+	plausibleDomain = "gaal-lite"
+	sendTimeout     = 5 * time.Second
+)
+
+// plausiblePayload is the JSON body sent to the Plausible Events API.
+type plausiblePayload struct {
+	Name   string            `json:"name"`
+	URL    string            `json:"url"`
+	Domain string            `json:"domain"`
+	Props  map[string]string `json:"props,omitempty"`
+}
+
+// client sends events to the Plausible Events API.
+type client struct {
+	endpoint  string // overridable for tests
+	userAgent string
+}
+
+// send posts a single event payload to the Plausible endpoint.
+func (c *client) send(p plausiblePayload) error {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send event: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,0 +1,131 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSendPageview(t *testing.T) {
+	var capturedReq *http.Request
+	var capturedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := &client{
+		endpoint:  srv.URL,
+		userAgent: "gaal-lite/test",
+	}
+
+	p := plausiblePayload{
+		Name:   "pageview",
+		URL:    "app://gaal-lite/cmd/install",
+		Domain: plausibleDomain,
+		Props:  map[string]string{"version": "1.2.3"},
+	}
+
+	if err := c.send(p); err != nil {
+		t.Fatalf("send returned error: %v", err)
+	}
+
+	// Verify User-Agent header
+	if got := capturedReq.Header.Get("User-Agent"); got != "gaal-lite/test" {
+		t.Errorf("User-Agent = %q, want %q", got, "gaal-lite/test")
+	}
+
+	// Verify Content-Type header
+	if got := capturedReq.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+
+	// Verify payload JSON fields
+	var got plausiblePayload
+	if err := json.Unmarshal(capturedBody, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+
+	if got.Name != "pageview" {
+		t.Errorf("Name = %q, want %q", got.Name, "pageview")
+	}
+	if got.URL != "app://gaal-lite/cmd/install" {
+		t.Errorf("URL = %q, want %q", got.URL, "app://gaal-lite/cmd/install")
+	}
+	if got.Domain != plausibleDomain {
+		t.Errorf("Domain = %q, want %q", got.Domain, plausibleDomain)
+	}
+	if got.Props["version"] != "1.2.3" {
+		t.Errorf("Props[version] = %q, want %q", got.Props["version"], "1.2.3")
+	}
+}
+
+func TestSendCustomEvent(t *testing.T) {
+	var capturedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := &client{
+		endpoint:  srv.URL,
+		userAgent: "gaal-lite/test",
+	}
+
+	p := plausiblePayload{
+		Name:   "Install",
+		URL:    "app://gaal-lite/cmd/install",
+		Domain: plausibleDomain,
+	}
+
+	if err := c.send(p); err != nil {
+		t.Fatalf("send returned error: %v", err)
+	}
+
+	var got plausiblePayload
+	if err := json.Unmarshal(capturedBody, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+
+	if got.Name != "Install" {
+		t.Errorf("Name = %q, want %q", got.Name, "Install")
+	}
+}
+
+func TestSendHandlesServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := &client{
+		endpoint:  srv.URL,
+		userAgent: "gaal-lite/test",
+	}
+
+	p := plausiblePayload{
+		Name:   "pageview",
+		URL:    "app://gaal-lite/cmd/install",
+		Domain: plausibleDomain,
+	}
+
+	err := c.send(p)
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+}

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -1,0 +1,64 @@
+package telemetry
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// consentState represents the resolved telemetry consent.
+type consentState struct {
+	Enabled     bool
+	Source      string // "GAAL_TELEMETRY=0", "DO_NOT_TRACK=1", "config", "unconfigured"
+	NeedsPrompt bool
+}
+
+// resolveState checks env vars and config to determine telemetry state.
+// Precedence: GAAL_TELEMETRY > DO_NOT_TRACK > config value > unconfigured.
+func resolveState(cfgValue *bool) consentState {
+	if v, ok := os.LookupEnv("GAAL_TELEMETRY"); ok {
+		switch strings.ToLower(v) {
+		case "0", "false":
+			return consentState{Enabled: false, Source: "GAAL_TELEMETRY=0"}
+		case "1", "true":
+			return consentState{Enabled: true, Source: "GAAL_TELEMETRY=1"}
+		}
+	}
+
+	if v, ok := os.LookupEnv("DO_NOT_TRACK"); ok && v == "1" {
+		return consentState{Enabled: false, Source: "DO_NOT_TRACK=1"}
+	}
+
+	if cfgValue != nil {
+		return consentState{Enabled: *cfgValue, Source: "config"}
+	}
+
+	return consentState{Enabled: false, Source: "unconfigured", NeedsPrompt: true}
+}
+
+// persistConsent writes or updates the telemetry field in the user config file.
+func persistConsent(cfgPath string, enabled bool) error {
+	slog.Debug("persisting telemetry consent", "path", cfgPath, "enabled", enabled)
+
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	existing := make(map[string]any)
+	data, err := os.ReadFile(cfgPath)
+	if err == nil {
+		_ = yaml.Unmarshal(data, &existing)
+	}
+
+	existing["telemetry"] = enabled
+	out, err := yaml.Marshal(existing)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	return os.WriteFile(cfgPath, out, 0o644)
+}

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -1,0 +1,159 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestResolveStateEnvGaalTelemetryDisabled(t *testing.T) {
+	t.Setenv("GAAL_TELEMETRY", "0")
+	s := resolveState(nil)
+	if s.Enabled {
+		t.Error("expected Enabled=false")
+	}
+	if s.Source != "GAAL_TELEMETRY=0" {
+		t.Errorf("expected source GAAL_TELEMETRY=0, got %q", s.Source)
+	}
+	if s.NeedsPrompt {
+		t.Error("expected NeedsPrompt=false")
+	}
+}
+
+func TestResolveStateEnvGaalTelemetryEnabled(t *testing.T) {
+	t.Setenv("GAAL_TELEMETRY", "1")
+	s := resolveState(nil)
+	if !s.Enabled {
+		t.Error("expected Enabled=true")
+	}
+	if s.Source != "GAAL_TELEMETRY=1" {
+		t.Errorf("expected source GAAL_TELEMETRY=1, got %q", s.Source)
+	}
+}
+
+func TestResolveStateEnvDoNotTrack(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+	s := resolveState(nil)
+	if s.Enabled {
+		t.Error("expected Enabled=false")
+	}
+	if s.Source != "DO_NOT_TRACK=1" {
+		t.Errorf("expected source DO_NOT_TRACK=1, got %q", s.Source)
+	}
+}
+
+func TestResolveStateConfigTrue(t *testing.T) {
+	s := resolveState(boolPtr(true))
+	if !s.Enabled {
+		t.Error("expected Enabled=true")
+	}
+	if s.Source != "config" {
+		t.Errorf("expected source config, got %q", s.Source)
+	}
+}
+
+func TestResolveStateConfigFalse(t *testing.T) {
+	s := resolveState(boolPtr(false))
+	if s.Enabled {
+		t.Error("expected Enabled=false")
+	}
+	if s.Source != "config" {
+		t.Errorf("expected source config, got %q", s.Source)
+	}
+}
+
+func TestResolveStateUnconfigured(t *testing.T) {
+	s := resolveState(nil)
+	if s.Enabled {
+		t.Error("expected Enabled=false")
+	}
+	if s.Source != "unconfigured" {
+		t.Errorf("expected source unconfigured, got %q", s.Source)
+	}
+	if !s.NeedsPrompt {
+		t.Error("expected NeedsPrompt=true")
+	}
+}
+
+func TestEnvOverridesConfig(t *testing.T) {
+	t.Setenv("GAAL_TELEMETRY", "0")
+	s := resolveState(boolPtr(true))
+	if s.Enabled {
+		t.Error("expected Enabled=false: env should override config")
+	}
+	if s.Source != "GAAL_TELEMETRY=0" {
+		t.Errorf("expected source GAAL_TELEMETRY=0, got %q", s.Source)
+	}
+}
+
+func TestDoNotTrackOverridesConfig(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+	s := resolveState(boolPtr(true))
+	if s.Enabled {
+		t.Error("expected Enabled=false: DO_NOT_TRACK should override config")
+	}
+	if s.Source != "DO_NOT_TRACK=1" {
+		t.Errorf("expected source DO_NOT_TRACK=1, got %q", s.Source)
+	}
+}
+
+func TestPersistConsent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	if err := persistConsent(cfgPath, true); err != nil {
+		t.Fatalf("persistConsent failed: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	got := string(data)
+	if got != "telemetry: true\n" {
+		t.Errorf("expected %q, got %q", "telemetry: true\n", got)
+	}
+}
+
+func TestPersistConsentPreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	existing := []byte("some_key: some_value\n")
+	if err := os.WriteFile(cfgPath, existing, 0o644); err != nil {
+		t.Fatalf("writing existing config: %v", err)
+	}
+
+	if err := persistConsent(cfgPath, true); err != nil {
+		t.Fatalf("persistConsent failed: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	got := string(data)
+	if !contains(got, "telemetry: true") {
+		t.Errorf("expected telemetry: true in output, got %q", got)
+	}
+	if !contains(got, "some_key: some_value") {
+		t.Errorf("expected some_key: some_value preserved in output, got %q", got)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -101,10 +101,12 @@ func Track(command string) {
 		return
 	}
 	props := copyProps(baseProps)
+	url := "app://gaal-lite/cmd/" + command
+	slog.Debug("telemetry", "event", "pageview", "url", url, "props", props)
 	go func() {
 		p := plausiblePayload{
 			Name:   "pageview",
-			URL:    "app://gaal-lite/cmd/" + command,
+			URL:    url,
 			Domain: plausibleDomain,
 			Props:  props,
 		}
@@ -124,10 +126,12 @@ func TrackCustom(name string, extra map[string]string) {
 	for k, v := range extra {
 		props[k] = v
 	}
+	url := "app://gaal-lite/custom/" + name
+	slog.Debug("telemetry", "event", name, "url", url, "props", props)
 	go func() {
 		p := plausiblePayload{
 			Name:   name,
-			URL:    "app://gaal-lite/custom/" + name,
+			URL:    url,
 			Domain: plausibleDomain,
 			Props:  props,
 		}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,258 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"gaal/internal/config"
+	"gaal/internal/core/agent"
+	"gaal/internal/skill"
+)
+
+// Package-level state, set once by Init.
+var (
+	enabled    bool
+	httpClient *client
+	baseProps  map[string]string
+	statePath  string
+	appVersion string
+)
+
+// milestoneState tracks which one-time events have already been sent.
+type milestoneState struct {
+	InstallSent   bool `json:"install_sent"`
+	FirstSyncSent bool `json:"first_sync_sent"`
+}
+
+// Init resolves consent state and initialises the telemetry client.
+// version is the gaal binary version string (passed from cmd.Version to avoid
+// circular import).
+func Init(cfgTelemetry *bool, promptFn func() (bool, error), version string) (bool, error) {
+	appVersion = version
+
+	state := resolveState(cfgTelemetry)
+	slog.Debug("telemetry state resolved", "enabled", state.Enabled, "source", state.Source, "needsPrompt", state.NeedsPrompt)
+
+	if state.NeedsPrompt && promptFn != nil {
+		consent, err := promptFn()
+		if err != nil {
+			return false, fmt.Errorf("telemetry prompt: %w", err)
+		}
+		if err := persistConsent(config.UserConfigFilePath(), consent); err != nil {
+			slog.Warn("failed to persist telemetry consent", "err", err)
+		}
+		state.Enabled = consent
+
+		// Fire consent event regardless of the answer so we can track
+		// opt-in vs opt-out rates (Plausible will only receive this if
+		// consent == true since we check enabled below).
+		if consent {
+			// Temporarily enable so we can send the Consent event.
+			enabled = true
+			httpClient = newClient(version)
+			baseProps = buildBaseProps()
+			TrackCustom("Consent", map[string]string{"answer": "yes"})
+		}
+	}
+
+	enabled = state.Enabled
+	if !enabled {
+		return false, nil
+	}
+
+	if httpClient == nil {
+		httpClient = newClient(version)
+	}
+	if baseProps == nil {
+		baseProps = buildBaseProps()
+	}
+
+	statePath = telemetryStatePath()
+
+	// Fire Install milestone if not already sent.
+	ms := loadMilestoneState(statePath)
+	if !ms.InstallSent {
+		TrackCustom("Install", nil)
+		ms.InstallSent = true
+		saveMilestoneState(statePath, ms)
+	}
+
+	return true, nil
+}
+
+// newClient creates an HTTP client with an appropriate user-agent string.
+func newClient(version string) *client {
+	ua := fmt.Sprintf("gaal/%s (%s; %s)", version, runtime.GOOS, runtime.GOARCH)
+	return &client{
+		endpoint:  plausibleEndpoint,
+		userAgent: ua,
+	}
+}
+
+// Track sends a pageview event for the given command in a fire-and-forget
+// goroutine.
+func Track(command string) {
+	if !enabled {
+		return
+	}
+	props := copyProps(baseProps)
+	go func() {
+		p := plausiblePayload{
+			Name:   "pageview",
+			URL:    "app://gaal-lite/cmd/" + command,
+			Domain: plausibleDomain,
+			Props:  props,
+		}
+		if err := httpClient.send(p); err != nil {
+			slog.Debug("telemetry pageview failed", "command", command, "err", err)
+		}
+	}()
+}
+
+// TrackCustom sends a named custom event with optional extra properties in a
+// fire-and-forget goroutine.
+func TrackCustom(name string, extra map[string]string) {
+	if !enabled {
+		return
+	}
+	props := copyProps(baseProps)
+	for k, v := range extra {
+		props[k] = v
+	}
+	go func() {
+		p := plausiblePayload{
+			Name:   name,
+			URL:    "app://gaal-lite/custom/" + name,
+			Domain: plausibleDomain,
+			Props:  props,
+		}
+		if err := httpClient.send(p); err != nil {
+			slog.Debug("telemetry custom event failed", "name", name, "err", err)
+		}
+	}()
+}
+
+// TrackError sends a categorised error event.
+func TrackError(command string, err error) {
+	category := categorizeError(err)
+	TrackCustom("Error", map[string]string{
+		"command":  command,
+		"category": category,
+		"message":  err.Error(),
+	})
+}
+
+// TrackFirstSync sends the FirstSync milestone event once per installation.
+func TrackFirstSync(agentCount int) {
+	if !enabled {
+		return
+	}
+	ms := loadMilestoneState(statePath)
+	if ms.FirstSyncSent {
+		return
+	}
+	TrackCustom("FirstSync", map[string]string{
+		"agent_count": fmt.Sprintf("%d", agentCount),
+	})
+	ms.FirstSyncSent = true
+	saveMilestoneState(statePath, ms)
+}
+
+// categorizeError returns a human-readable category for the error.
+func categorizeError(err error) string {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "parsing yaml") || strings.Contains(msg, "invalid config"):
+		return "yaml_parse_error"
+	case strings.Contains(msg, "agent") && strings.Contains(msg, "not found"):
+		return "agent_not_found"
+	case strings.Contains(msg, "sync"):
+		return "sync_failed"
+	case strings.Contains(msg, "permission"):
+		return "permission_denied"
+	case strings.Contains(msg, "dial") ||
+		strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "network"):
+		return "network_error"
+	default:
+		return "unknown"
+	}
+}
+
+// buildBaseProps returns the default properties attached to every event.
+func buildBaseProps() map[string]string {
+	agents := installedAgentNames()
+	return map[string]string{
+		"version": appVersion,
+		"os":      runtime.GOOS,
+		"arch":    runtime.GOARCH,
+		"agents":  strings.Join(agents, ","),
+	}
+}
+
+// installedAgentNames returns the names of agents currently installed on this
+// machine. It uses agent.Names() for the full registry and
+// skill.IsAgentInstalled() to check presence.
+func installedAgentNames() []string {
+	home, _ := os.UserHomeDir()
+	wd, _ := os.Getwd()
+
+	var installed []string
+	for _, name := range agent.Names() {
+		if skill.IsAgentInstalled(name, true, home, wd) ||
+			skill.IsAgentInstalled(name, false, home, wd) {
+			installed = append(installed, name)
+		}
+	}
+	return installed
+}
+
+// copyProps returns a shallow copy of the given map.
+func copyProps(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+// telemetryStatePath returns the path to the telemetry milestone state file,
+// respecting XDG_CONFIG_HOME on darwin.
+func telemetryStatePath() string {
+	cfgPath := config.UserConfigFilePath()
+	return filepath.Join(filepath.Dir(cfgPath), ".telemetry-state")
+}
+
+// loadMilestoneState reads the milestone state from disk. Returns a zero-value
+// milestoneState if the file does not exist or is invalid.
+func loadMilestoneState(path string) milestoneState {
+	var ms milestoneState
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ms
+	}
+	_ = json.Unmarshal(data, &ms)
+	return ms
+}
+
+// saveMilestoneState writes the milestone state to disk.
+func saveMilestoneState(path string, ms milestoneState) {
+	data, err := json.Marshal(ms)
+	if err != nil {
+		slog.Warn("failed to marshal milestone state", "err", err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		slog.Warn("failed to create milestone state directory", "err", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		slog.Warn("failed to write milestone state", "err", err)
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"time"
 
 	"gaal/internal/config"
 	"gaal/internal/core/agent"
@@ -21,6 +23,7 @@ var (
 	baseProps  map[string]string
 	statePath  string
 	appVersion string
+	pending    sync.WaitGroup
 )
 
 // milestoneState tracks which one-time events have already been sent.
@@ -94,6 +97,24 @@ func newClient(version string) *client {
 	}
 }
 
+// Shutdown waits up to 2 seconds for in-flight telemetry events to complete.
+// Call from the root command before exiting.
+func Shutdown() {
+	if !enabled {
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		pending.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		slog.Debug("telemetry shutdown timed out, some events may be lost")
+	}
+}
+
 // Track sends a pageview event for the given command in a fire-and-forget
 // goroutine.
 func Track(command string) {
@@ -103,7 +124,9 @@ func Track(command string) {
 	props := copyProps(baseProps)
 	url := "app://gaal-lite/cmd/" + command
 	slog.Debug("telemetry", "event", "pageview", "url", url, "props", props)
+	pending.Add(1)
 	go func() {
+		defer pending.Done()
 		p := plausiblePayload{
 			Name:   "pageview",
 			URL:    url,
@@ -128,7 +151,9 @@ func TrackCustom(name string, extra map[string]string) {
 	}
 	url := "app://gaal-lite/custom/" + name
 	slog.Debug("telemetry", "event", name, "url", url, "props", props)
+	pending.Add(1)
 	go func() {
+		defer pending.Done()
 		p := plausiblePayload{
 			Name:   name,
 			URL:    url,

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,193 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// resetGlobals resets package-level state between tests.
+func resetGlobals() {
+	enabled = false
+	httpClient = nil
+	baseProps = nil
+	statePath = ""
+	appVersion = ""
+}
+
+func TestTrackSendsPageviewWhenEnabled(t *testing.T) {
+	resetGlobals()
+	defer resetGlobals()
+
+	var called atomic.Bool
+	var capturedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = body
+		called.Store(true)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	enabled = true
+	httpClient = &client{endpoint: srv.URL, userAgent: "gaal/test"}
+	baseProps = map[string]string{"version": "1.0.0"}
+
+	Track("install")
+
+	// Give the goroutine time to fire.
+	deadline := time.Now().Add(2 * time.Second)
+	for !called.Load() && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+
+	if !called.Load() {
+		t.Fatal("expected HTTP call, but server was not contacted")
+	}
+
+	var p plausiblePayload
+	if err := json.Unmarshal(capturedBody, &p); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if p.Name != "pageview" {
+		t.Errorf("Name = %q, want %q", p.Name, "pageview")
+	}
+	if p.URL != "app://gaal-lite/cmd/install" {
+		t.Errorf("URL = %q, want %q", p.URL, "app://gaal-lite/cmd/install")
+	}
+	if p.Domain != plausibleDomain {
+		t.Errorf("Domain = %q, want %q", p.Domain, plausibleDomain)
+	}
+	if p.Props["version"] != "1.0.0" {
+		t.Errorf("Props[version] = %q, want %q", p.Props["version"], "1.0.0")
+	}
+}
+
+func TestTrackNoopWhenDisabled(t *testing.T) {
+	resetGlobals()
+	defer resetGlobals()
+
+	var called atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	enabled = false
+	httpClient = &client{endpoint: srv.URL, userAgent: "gaal/test"}
+	baseProps = map[string]string{"version": "1.0.0"}
+
+	Track("install")
+
+	// Give some time to verify no call is made.
+	time.Sleep(100 * time.Millisecond)
+	for i := 0; i < 100; i++ {
+		runtime.Gosched()
+	}
+
+	if called.Load() {
+		t.Error("expected no HTTP call when disabled, but server was contacted")
+	}
+}
+
+func TestCategorizeError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{"yaml parse error with parsing yaml", errors.New("error parsing yaml file"), "yaml_parse_error"},
+		{"yaml parse error with invalid config", errors.New("invalid config format"), "yaml_parse_error"},
+		{"agent not found", errors.New("agent 'foo' not found in registry"), "agent_not_found"},
+		{"sync failed", errors.New("sync failed: timeout"), "sync_failed"},
+		{"permission denied", errors.New("open /etc/config: permission denied"), "permission_denied"},
+		{"network dial error", errors.New("dial tcp 127.0.0.1:443: connection refused"), "network_error"},
+		{"network timeout", errors.New("request timeout after 5s"), "network_error"},
+		{"network connection refused", errors.New("connection refused by server"), "network_error"},
+		{"network generic", errors.New("network unreachable"), "network_error"},
+		{"unknown error", errors.New("something unexpected happened"), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := categorizeError(tt.err)
+			if got != tt.expected {
+				t.Errorf("categorizeError(%q) = %q, want %q", tt.err, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMilestoneState(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".telemetry-state")
+
+	// Load from non-existent file returns zero value.
+	ms := loadMilestoneState(path)
+	if ms.InstallSent || ms.FirstSyncSent {
+		t.Error("expected zero-value milestoneState from non-existent file")
+	}
+
+	// Save and reload.
+	ms.InstallSent = true
+	saveMilestoneState(path, ms)
+
+	ms2 := loadMilestoneState(path)
+	if !ms2.InstallSent {
+		t.Error("expected InstallSent=true after save/load")
+	}
+	if ms2.FirstSyncSent {
+		t.Error("expected FirstSyncSent=false after save/load")
+	}
+
+	// Update and reload.
+	ms2.FirstSyncSent = true
+	saveMilestoneState(path, ms2)
+
+	ms3 := loadMilestoneState(path)
+	if !ms3.InstallSent || !ms3.FirstSyncSent {
+		t.Error("expected both milestones true after second save/load")
+	}
+}
+
+func TestMilestoneStateInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".telemetry-state")
+
+	// Write invalid JSON.
+	if err := os.WriteFile(path, []byte("{invalid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ms := loadMilestoneState(path)
+	if ms.InstallSent || ms.FirstSyncSent {
+		t.Error("expected zero-value milestoneState from invalid JSON")
+	}
+}
+
+func TestCopyProps(t *testing.T) {
+	src := map[string]string{"a": "1", "b": "2"}
+	dst := copyProps(src)
+
+	// Should have same values.
+	if dst["a"] != "1" || dst["b"] != "2" {
+		t.Error("copy did not preserve values")
+	}
+
+	// Should be independent.
+	dst["a"] = "changed"
+	if src["a"] == "changed" {
+		t.Error("copy is not independent of source")
+	}
+}


### PR DESCRIPTION
## Summary

- Add opt-in anonymous telemetry via self-hosted Plausible CE at `https://usage.getgaal.com`
- First-run consent prompt (blocking, default No) with `GAAL_TELEMETRY` and `DO_NOT_TRACK` env var overrides
- Track command invocations as pageviews, plus milestone events (Install, Consent, First Sync, Migration, Error)
- Debug-level logging of telemetry calls with `--verbose` for full transparency

## Details

New `internal/telemetry` package with three files:
- `state.go` — consent resolution (env vars > config > prompt), config persistence
- `client.go` — HTTP POST to Plausible Events API (fire-and-forget)
- `telemetry.go` — public API (Init, Track, TrackCustom, TrackError, TrackFirstSync), error categorization, milestone state

Config changes:
- `Telemetry *bool` field added to Config struct (pointer to distinguish unset from false)
- Excluded from config merge chain — only read from user-level config
- JSON Schema regenerated

Integration:
- Consent check in `PersistentPreRunE` (skipped for `version`, `schema`, `completion`)
- Track calls in all 7 commands (sync, init, status, info, agents, audit, migrate)

Privacy:
- No PII, no config contents, no file paths — see `PRIVACY_POLICY.md`
- Self-hosted Plausible CE on Hetzner Germany (EU data residency)
- Plausible source: https://github.com/getgaal/plausible

Closes #32

## Test plan

- [ ] 505 tests pass with `-race` flag
- [ ] `GAAL_TELEMETRY=0 gaal agents` — no prompt, no telemetry
- [ ] `DO_NOT_TRACK=1 gaal agents` — no prompt, no telemetry
- [ ] First run without config shows consent prompt
- [ ] Answering No persists `telemetry: false` in user config
- [ ] `gaal --verbose agents` with telemetry enabled shows event details in debug output
- [ ] Events appear in Plausible dashboard at `https://usage.getgaal.com/gaal-lite`