### PR TITLE
feat: add gaal doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,24 @@ gaal agents -o json          # machine-readable output
 Lists every registered coding agent and whether it is installed on this machine.
 Pass a name for a detailed view with search paths, skill counts, and MCP config.
 
+### Health check
+
+```bash
+gaal doctor
+```
+
+Runs sanity checks on your configuration: validates gaal.yaml, checks that
+skill sources are reachable, verifies MCP target files, and reports agent
+and telemetry status.
+
+```bash
+gaal doctor --offline     # skip network checks
+gaal doctor --no-upsell   # suppress the Community Edition message
+gaal doctor -o json       # machine-readable JSON output
+```
+
+Exit codes: **0** = all checks passed, **1** = warnings, **2** = errors.
+
 ### Generate the JSON Schema
 
 ```bash

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -56,6 +56,10 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		cfg = &config.Config{}
 	}
 
+	// Telemetry field is excluded from config merging, so read it
+	// directly from the user config file.
+	cfg.Telemetry = loadUserTelemetryConfig()
+
 	eng := engine.NewWithOptions(cfg, engineOpts)
 	report := eng.Doctor(ops.DoctorOptions{Offline: doctorOffline})
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -75,7 +74,13 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 }
 
 func renderDoctorTable(report *ops.DoctorReport) {
-	sections := []string{"config", "telemetry", "skills", "mcps", "agents"}
+	sectionDisplay := map[string]string{
+		"telemetry": "Telemetry",
+		"skills":    "Skills",
+		"mcps":      "MCP",
+		"agents":    "Agents",
+	}
+	sections := []string{"telemetry", "skills", "mcps", "agents"}
 	for _, section := range sections {
 		var sectionFindings []ops.Finding
 		for _, f := range report.Findings {
@@ -87,7 +92,7 @@ func renderDoctorTable(report *ops.DoctorReport) {
 			continue
 		}
 
-		title := strings.ToUpper(section[:1]) + section[1:]
+		title := sectionDisplay[section]
 		styled := pterm.NewStyle(pterm.Bold, pterm.FgCyan).Sprintf("── %s ──", title)
 		fmt.Printf("\n%s\n", styled)
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"gaal/internal/config"
+	"gaal/internal/engine"
+	"gaal/internal/engine/ops"
+	"gaal/internal/telemetry"
+)
+
+var (
+	doctorOffline  bool
+	doctorNoUpsell bool
+)
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check configuration health and agent status",
+	Long: `Runs sanity checks on your gaal configuration:
+
+  - Validates gaal.yaml structure
+  - Checks skill source reachability (GitHub repos, local paths)
+  - Verifies MCP target files are valid JSON
+  - Reports installed agent status
+  - Shows telemetry configuration state
+
+Use --offline to skip network checks (skill source reachability).
+Use --no-upsell to suppress the Community Edition message.
+
+Exit codes:
+  0  all checks passed
+  1  warnings found
+  2  errors found`,
+	SilenceUsage: true,
+	RunE:         runDoctor,
+}
+
+func init() {
+	doctorCmd.Flags().BoolVar(&doctorOffline, "offline", false, "skip network checks (skill source reachability)")
+	doctorCmd.Flags().BoolVar(&doctorNoUpsell, "no-upsell", false, "suppress the Community Edition message")
+	rootCmd.AddCommand(doctorCmd)
+}
+
+func runDoctor(_ *cobra.Command, _ []string) error {
+	telemetry.Track("doctor")
+
+	cfg, err := config.LoadChain(cfgFile)
+	if err != nil {
+		telemetry.TrackError("doctor", err)
+		cfg = &config.Config{}
+	}
+
+	eng := engine.NewWithOptions(cfg, engineOpts)
+	report := eng.Doctor(ops.DoctorOptions{Offline: doctorOffline})
+
+	if outputFormat == "json" {
+		return renderDoctorJSON(report, !doctorNoUpsell)
+	}
+	renderDoctorTable(report)
+	if !doctorNoUpsell {
+		renderCommunityBlock()
+	}
+
+	if report.ExitCode != 0 {
+		os.Exit(report.ExitCode)
+	}
+	return nil
+}
+
+func renderDoctorTable(report *ops.DoctorReport) {
+	sections := []string{"config", "telemetry", "skills", "mcps", "agents"}
+	for _, section := range sections {
+		var sectionFindings []ops.Finding
+		for _, f := range report.Findings {
+			if f.Section == section {
+				sectionFindings = append(sectionFindings, f)
+			}
+		}
+		if len(sectionFindings) == 0 {
+			continue
+		}
+
+		title := strings.ToUpper(section[:1]) + section[1:]
+		styled := pterm.NewStyle(pterm.Bold, pterm.FgCyan).Sprintf("── %s ──", title)
+		fmt.Printf("\n%s\n", styled)
+
+		for _, f := range sectionFindings {
+			var icon string
+			switch f.Severity {
+			case ops.SeverityInfo:
+				icon = pterm.FgGreen.Sprint("✓")
+			case ops.SeverityWarning:
+				icon = pterm.FgYellow.Sprint("⚠")
+			case ops.SeverityError:
+				icon = pterm.FgRed.Sprint("✗")
+			}
+			fmt.Printf("  %s  %s\n", icon, f.Message)
+		}
+	}
+
+	fmt.Println()
+	switch report.ExitCode {
+	case 0:
+		pterm.Success.Println("All checks passed")
+	case 1:
+		pterm.Warning.Println("Checks completed with warnings")
+	case 2:
+		pterm.Error.Println("Checks completed with errors")
+	}
+}
+
+func renderDoctorJSON(report *ops.DoctorReport, showUpsell bool) error {
+	output := struct {
+		Findings []ops.Finding `json:"findings"`
+		ExitCode int           `json:"exit_code"`
+		Upsell   *string       `json:"upsell,omitempty"`
+	}{
+		Findings: report.Findings,
+		ExitCode: report.ExitCode,
+	}
+	if showUpsell {
+		msg := "When your team needs governance, drift detection, or approvals, see gaal Community Edition: https://getgaal.com"
+		output.Upsell = &msg
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(output); err != nil {
+		return err
+	}
+	if report.ExitCode != 0 {
+		os.Exit(report.ExitCode)
+	}
+	return nil
+}
+
+func renderCommunityBlock() {
+	fmt.Println()
+	fmt.Println(pterm.FgCyan.Sprint("→ ") + "When your team needs governance, drift detection, or approvals, see")
+	fmt.Println("  gaal Community Edition: " + pterm.FgCyan.Sprint("https://getgaal.com"))
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -216,3 +216,8 @@ func (e *Engine) InitFromPlan(dest string, plan ops.Plan, force bool) error {
 func (e *Engine) Migrate(target, url string, dryRun bool) (*ops.MigrateResult, error) {
 	return ops.Migrate(e.cfg, target, url, dryRun)
 }
+
+// Doctor runs sanity checks and returns a diagnostic report.
+func (e *Engine) Doctor(opts ops.DoctorOptions) *ops.DoctorReport {
+	return ops.RunDoctor(e.cfg, opts)
+}

--- a/internal/engine/ops/doctor.go
+++ b/internal/engine/ops/doctor.go
@@ -1,0 +1,267 @@
+package ops
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gaal/internal/config"
+	"gaal/internal/core/agent"
+	"gaal/internal/skill"
+	"gaal/internal/telemetry"
+)
+
+// Severity indicates the importance level of a doctor finding.
+type Severity string
+
+const (
+	SeverityInfo    Severity = "info"
+	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
+)
+
+// Finding represents a single check result from the doctor command.
+type Finding struct {
+	Section  string   `json:"section"`
+	Severity Severity `json:"severity"`
+	Message  string   `json:"message"`
+}
+
+// DoctorReport is the structured output of the doctor check pipeline.
+type DoctorReport struct {
+	Findings []Finding `json:"findings"`
+	ExitCode int       `json:"exit_code"`
+}
+
+// DoctorOptions configures the doctor check behaviour.
+type DoctorOptions struct {
+	Offline bool
+}
+
+// RunDoctor executes all sanity checks against the given config and returns
+// a structured report. Exit code: 0 = clean, 1 = warnings only, 2 = any errors.
+func RunDoctor(cfg *config.Config, opts DoctorOptions) *DoctorReport {
+	slog.Debug("running doctor checks", "offline", opts.Offline)
+
+	var findings []Finding
+	findings = append(findings, checkTelemetry(cfg)...)
+	findings = append(findings, checkSkillSources(cfg, opts.Offline)...)
+	findings = append(findings, checkMCPTargets(cfg)...)
+	findings = append(findings, checkAgents()...)
+
+	exitCode := 0
+	for _, f := range findings {
+		switch f.Severity {
+		case SeverityError:
+			exitCode = 2
+		case SeverityWarning:
+			if exitCode < 1 {
+				exitCode = 1
+			}
+		}
+	}
+
+	return &DoctorReport{
+		Findings: findings,
+		ExitCode: exitCode,
+	}
+}
+
+// checkTelemetry reports the current telemetry state as an info finding.
+func checkTelemetry(cfg *config.Config) []Finding {
+	status, source := telemetry.Status(cfg.Telemetry)
+	msg := fmt.Sprintf("telemetry: %s", status)
+	if source != "" {
+		msg += fmt.Sprintf(" (%s)", source)
+	}
+	return []Finding{
+		{Section: "telemetry", Severity: SeverityInfo, Message: msg},
+	}
+}
+
+// checkSkillSources validates each configured skill source.
+func checkSkillSources(cfg *config.Config, offline bool) []Finding {
+	var findings []Finding
+
+	// Check for duplicate sources.
+	seen := make(map[string]int, len(cfg.Skills))
+	for _, sk := range cfg.Skills {
+		seen[sk.Source]++
+	}
+	for src, count := range seen {
+		if count > 1 {
+			findings = append(findings, Finding{
+				Section:  "skills",
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("duplicate skill source %q (appears %d times)", src, count),
+			})
+		}
+	}
+
+	for _, sk := range cfg.Skills {
+		// Warn on agents:["*"] with zero detected agents.
+		if len(sk.Agents) == 1 && sk.Agents[0] == "*" {
+			if countInstalledAgents() == 0 {
+				findings = append(findings, Finding{
+					Section:  "skills",
+					Severity: SeverityWarning,
+					Message:  fmt.Sprintf("skill %q targets agents:[\"*\"] but no agents are detected", sk.Source),
+				})
+			}
+		}
+
+		if isLocalSkillPath(sk.Source) {
+			if _, err := os.Stat(sk.Source); err != nil {
+				findings = append(findings, Finding{
+					Section:  "skills",
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("local skill path does not exist: %s", sk.Source),
+				})
+			}
+		} else {
+			// Remote source (URL or GitHub shorthand).
+			if offline {
+				findings = append(findings, Finding{
+					Section:  "skills",
+					Severity: SeverityInfo,
+					Message:  fmt.Sprintf("skipped reachability check for %q (offline mode)", sk.Source),
+				})
+			} else {
+				url := resolveSkillURL(sk.Source)
+				if err := checkRemoteReachable(url); err != nil {
+					findings = append(findings, Finding{
+						Section:  "skills",
+						Severity: SeverityError,
+						Message:  fmt.Sprintf("remote skill source unreachable: %s (%v)", url, err),
+					})
+				}
+			}
+		}
+	}
+
+	return findings
+}
+
+// checkMCPTargets validates each configured MCP target file.
+func checkMCPTargets(cfg *config.Config) []Finding {
+	var findings []Finding
+
+	home, _ := os.UserHomeDir()
+
+	for _, m := range cfg.MCPs {
+		// Warn if target is outside $HOME.
+		if home != "" && !strings.HasPrefix(m.Target, home+string(filepath.Separator)) && m.Target != home {
+			findings = append(findings, Finding{
+				Section:  "mcps",
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("MCP %q target %q is outside $HOME", m.Name, m.Target),
+			})
+		}
+
+		data, err := os.ReadFile(m.Target)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Target doesn't exist yet — this is normal for first sync.
+				findings = append(findings, Finding{
+					Section:  "mcps",
+					Severity: SeverityInfo,
+					Message:  fmt.Sprintf("MCP %q target does not exist yet: %s (will be created on sync)", m.Name, m.Target),
+				})
+			} else {
+				findings = append(findings, Finding{
+					Section:  "mcps",
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("MCP %q target unreadable: %v", m.Name, err),
+				})
+			}
+			continue
+		}
+
+		// Check if target is valid JSON.
+		if !json.Valid(data) {
+			findings = append(findings, Finding{
+				Section:  "mcps",
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("MCP %q target contains invalid JSON: %s", m.Name, m.Target),
+			})
+		}
+	}
+
+	return findings
+}
+
+// checkAgents counts installed agents and reports as info.
+func checkAgents() []Finding {
+	count := countInstalledAgents()
+	return []Finding{
+		{Section: "agents", Severity: SeverityInfo, Message: fmt.Sprintf("%d agent(s) detected", count)},
+	}
+}
+
+// isLocalSkillPath returns true for paths starting with /, ./, ../, ~/, or
+// absolute paths. Returns false for URLs and GitHub shorthands (owner/repo).
+func isLocalSkillPath(source string) bool {
+	if strings.HasPrefix(source, "/") ||
+		strings.HasPrefix(source, "./") ||
+		strings.HasPrefix(source, "../") ||
+		strings.HasPrefix(source, "~/") ||
+		strings.HasPrefix(source, `.\`) ||
+		strings.HasPrefix(source, `..\`) ||
+		strings.HasPrefix(source, `~\`) {
+		return true
+	}
+	if filepath.IsAbs(source) {
+		return true
+	}
+	return false
+}
+
+// resolveSkillURL returns the URL to use for a reachability check.
+// GitHub shorthands (owner/repo) are converted to https://github.com/owner/repo.
+func resolveSkillURL(source string) string {
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		return source
+	}
+	// Assume GitHub shorthand: exactly owner/repo.
+	parts := strings.Split(source, "/")
+	if len(parts) == 2 {
+		return "https://github.com/" + source
+	}
+	return source
+}
+
+// checkRemoteReachable performs an HTTP HEAD request with a 5-second timeout
+// and returns an error if the status code is >= 400.
+func checkRemoteReachable(url string) error {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Head(url)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// countInstalledAgents returns the number of agents currently installed on this
+// machine, using agent.Names() and skill.IsAgentInstalled().
+func countInstalledAgents() int {
+	home, _ := os.UserHomeDir()
+	wd, _ := os.Getwd()
+
+	count := 0
+	for _, name := range agent.Names() {
+		if skill.IsAgentInstalled(name, true, home, wd) ||
+			skill.IsAgentInstalled(name, false, home, wd) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/engine/ops/doctor.go
+++ b/internal/engine/ops/doctor.go
@@ -115,15 +115,7 @@ func checkSkillSources(cfg *config.Config, offline bool) []Finding {
 			}
 		}
 
-		if isLocalSkillPath(sk.Source) {
-			if _, err := os.Stat(sk.Source); err != nil {
-				findings = append(findings, Finding{
-					Section:  "skills",
-					Severity: SeverityError,
-					Message:  fmt.Sprintf("local skill path does not exist: %s", sk.Source),
-				})
-			}
-		} else {
+		if isRemoteSource(sk.Source) {
 			// Remote source (URL or GitHub shorthand).
 			if offline {
 				findings = append(findings, Finding{
@@ -140,6 +132,15 @@ func checkSkillSources(cfg *config.Config, offline bool) []Finding {
 						Message:  fmt.Sprintf("remote skill source unreachable: %s (%v)", url, err),
 					})
 				}
+			}
+		} else {
+			// Local path.
+			if _, err := os.Stat(sk.Source); err != nil {
+				findings = append(findings, Finding{
+					Section:  "skills",
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("local skill path does not exist: %s", sk.Source),
+				})
 			}
 		}
 	}
@@ -203,36 +204,46 @@ func checkAgents() []Finding {
 	}
 }
 
-// isLocalSkillPath returns true for paths starting with /, ./, ../, ~/, or
-// absolute paths. Returns false for URLs and GitHub shorthands (owner/repo).
-func isLocalSkillPath(source string) bool {
-	if strings.HasPrefix(source, "/") ||
-		strings.HasPrefix(source, "./") ||
-		strings.HasPrefix(source, "../") ||
-		strings.HasPrefix(source, "~/") ||
-		strings.HasPrefix(source, `.\`) ||
-		strings.HasPrefix(source, `..\`) ||
-		strings.HasPrefix(source, `~\`) {
+// isRemoteSource returns true for URLs and GitHub shorthands.
+func isRemoteSource(source string) bool {
+	if strings.HasPrefix(source, "http://") ||
+		strings.HasPrefix(source, "https://") ||
+		strings.HasPrefix(source, "git@") ||
+		strings.HasPrefix(source, "ssh://") {
 		return true
 	}
-	if filepath.IsAbs(source) {
+	// GitHub shorthand: exactly owner/repo — no scheme, no dots in owner.
+	parts := strings.Split(source, "/")
+	if len(parts) == 2 && !strings.Contains(parts[0], ".") &&
+		!strings.HasPrefix(source, ".") && !strings.HasPrefix(source, "~") {
 		return true
 	}
 	return false
 }
 
-// resolveSkillURL returns the URL to use for a reachability check.
-// GitHub shorthands (owner/repo) are converted to https://github.com/owner/repo.
+// resolveSkillURL returns an HTTPS URL for a reachability check.
+// Handles GitHub shorthands (owner/repo), git@ SSH URLs, and plain HTTPS URLs.
 func resolveSkillURL(source string) string {
 	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
 		return source
 	}
-	// Assume GitHub shorthand: exactly owner/repo.
-	parts := strings.Split(source, "/")
-	if len(parts) == 2 {
-		return "https://github.com/" + source
+	// git@github.com:owner/repo.git → https://github.com/owner/repo
+	if strings.HasPrefix(source, "git@") {
+		// git@host:owner/repo.git
+		s := strings.TrimPrefix(source, "git@")
+		s = strings.TrimSuffix(s, ".git")
+		s = strings.Replace(s, ":", "/", 1)
+		return "https://" + s
 	}
-	return source
+	// ssh://git@github.com/owner/repo.git
+	if strings.HasPrefix(source, "ssh://") {
+		s := strings.TrimPrefix(source, "ssh://")
+		s = strings.TrimPrefix(s, "git@")
+		s = strings.TrimSuffix(s, ".git")
+		return "https://" + s
+	}
+	// GitHub shorthand: owner/repo
+	return "https://github.com/" + source
 }
 
 // checkRemoteReachable performs an HTTP HEAD request with a 5-second timeout

--- a/internal/engine/ops/doctor_test.go
+++ b/internal/engine/ops/doctor_test.go
@@ -258,3 +258,44 @@ func TestDoctorReportJSON(t *testing.T) {
 		t.Errorf("expected exit_code=0, got %d", decoded.ExitCode)
 	}
 }
+
+func TestResolveSkillURL(t *testing.T) {
+	tests := []struct {
+		source   string
+		expected string
+	}{
+		{"owner/repo", "https://github.com/owner/repo"},
+		{"https://github.com/owner/repo", "https://github.com/owner/repo"},
+		{"git@github.com:owner/repo.git", "https://github.com/owner/repo"},
+		{"ssh://git@github.com/owner/repo.git", "https://github.com/owner/repo"},
+		{"git@gitlab.com:team/project.git", "https://gitlab.com/team/project"},
+	}
+	for _, tt := range tests {
+		got := resolveSkillURL(tt.source)
+		if got != tt.expected {
+			t.Errorf("resolveSkillURL(%q) = %q, want %q", tt.source, got, tt.expected)
+		}
+	}
+}
+
+func TestIsRemoteSource(t *testing.T) {
+	tests := []struct {
+		source   string
+		expected bool
+	}{
+		{"owner/repo", true},
+		{"https://github.com/owner/repo", true},
+		{"git@github.com:owner/repo.git", true},
+		{"ssh://git@github.com/owner/repo.git", true},
+		{"/absolute/path", false},
+		{"./relative/path", false},
+		{"../parent/path", false},
+		{"~/home/path", false},
+	}
+	for _, tt := range tests {
+		got := isRemoteSource(tt.source)
+		if got != tt.expected {
+			t.Errorf("isRemoteSource(%q) = %v, want %v", tt.source, got, tt.expected)
+		}
+	}
+}

--- a/internal/engine/ops/doctor_test.go
+++ b/internal/engine/ops/doctor_test.go
@@ -1,0 +1,260 @@
+package ops
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gaal/internal/config"
+)
+
+func TestDoctorCleanConfig(t *testing.T) {
+	cfg := &config.Config{}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	if report.ExitCode != 0 {
+		t.Errorf("expected exit code 0 for clean config, got %d", report.ExitCode)
+	}
+}
+
+func TestDoctorSkillSourceLocalMissing(t *testing.T) {
+	cfg := &config.Config{
+		Skills: []config.SkillConfig{
+			{Source: "/nonexistent/path/that/does/not/exist", Agents: []string{"claude-code"}},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	if report.ExitCode != 2 {
+		t.Errorf("expected exit code 2, got %d", report.ExitCode)
+	}
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Severity == SeverityError && strings.Contains(f.Message, "/nonexistent/path") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected error finding about missing local path")
+	}
+}
+
+func TestDoctorSkillSourceLocalExists(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Skills: []config.SkillConfig{
+			{Source: dir, Agents: []string{"claude-code"}},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	for _, f := range report.Findings {
+		if f.Severity == SeverityError && f.Section == "skills" {
+			t.Errorf("unexpected error finding in skills section: %s", f.Message)
+		}
+	}
+}
+
+func TestDoctorSkillSourceRemoteReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Skills: []config.SkillConfig{
+			{Source: srv.URL, Agents: []string{"claude-code"}},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: false})
+
+	for _, f := range report.Findings {
+		if f.Severity == SeverityError && f.Section == "skills" {
+			t.Errorf("unexpected error finding in skills section: %s", f.Message)
+		}
+	}
+}
+
+func TestDoctorSkillSourceRemoteUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Skills: []config.SkillConfig{
+			{Source: srv.URL, Agents: []string{"claude-code"}},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: false})
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Severity == SeverityError && f.Section == "skills" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected error finding for unreachable remote source")
+	}
+}
+
+func TestDoctorOfflineSkipsNetwork(t *testing.T) {
+	cfg := &config.Config{
+		Skills: []config.SkillConfig{
+			{Source: "owner/repo", Agents: []string{"claude-code"}},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	for _, f := range report.Findings {
+		if f.Severity == SeverityError && f.Section == "skills" {
+			t.Errorf("unexpected error finding in skills section (offline should skip network): %s", f.Message)
+		}
+	}
+}
+
+func TestDoctorMCPTargetValid(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "mcp.json")
+	os.WriteFile(target, []byte(`{"mcpServers": {}}`), 0o644)
+
+	cfg := &config.Config{
+		MCPs: []config.MCPConfig{
+			{Name: "test", Target: target},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	for _, f := range report.Findings {
+		if f.Severity == SeverityError && f.Section == "mcps" {
+			t.Errorf("unexpected error finding in mcps section: %s", f.Message)
+		}
+	}
+}
+
+func TestDoctorMCPTargetInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "mcp.json")
+	os.WriteFile(target, []byte(`not valid json`), 0o644)
+
+	cfg := &config.Config{
+		MCPs: []config.MCPConfig{
+			{Name: "test", Target: target},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Severity == SeverityWarning && f.Section == "mcps" && strings.Contains(f.Message, "invalid JSON") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected warning finding about invalid JSON")
+	}
+}
+
+func TestDoctorMCPTargetOutsideHome(t *testing.T) {
+	// Use a target path under /tmp which is outside any reasonable $HOME.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "mcp.json")
+	os.WriteFile(target, []byte(`{}`), 0o644)
+
+	// Set HOME to a different directory so the target is "outside $HOME".
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &config.Config{
+		MCPs: []config.MCPConfig{
+			{Name: "test", Target: target},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Severity == SeverityWarning && f.Section == "mcps" && strings.Contains(f.Message, "outside $HOME") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about target outside $HOME, findings: %+v", report.Findings)
+	}
+}
+
+func TestDoctorExitCodeWarnings(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "mcp.json")
+	os.WriteFile(target, []byte(`not json`), 0o644)
+
+	cfg := &config.Config{
+		MCPs: []config.MCPConfig{
+			{Name: "test", Target: target},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	// Should have at least one warning and no errors in the mcps section.
+	hasWarning := false
+	hasError := false
+	for _, f := range report.Findings {
+		if f.Severity == SeverityWarning {
+			hasWarning = true
+		}
+		if f.Severity == SeverityError {
+			hasError = true
+		}
+	}
+	if !hasWarning {
+		t.Error("expected at least one warning finding")
+	}
+	if hasError {
+		t.Error("unexpected error finding — wanted warnings only for exit code 1")
+	}
+	if report.ExitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", report.ExitCode)
+	}
+}
+
+func TestDoctorReportJSON(t *testing.T) {
+	report := &DoctorReport{
+		Findings: []Finding{
+			{Section: "telemetry", Severity: SeverityInfo, Message: "enabled via GAAL_TELEMETRY=1"},
+		},
+		ExitCode: 0,
+	}
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded DoctorReport
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(decoded.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(decoded.Findings))
+	}
+	if decoded.Findings[0].Section != "telemetry" {
+		t.Errorf("expected section=telemetry, got %q", decoded.Findings[0].Section)
+	}
+	if decoded.Findings[0].Severity != SeverityInfo {
+		t.Errorf("expected severity=info, got %q", decoded.Findings[0].Severity)
+	}
+	if decoded.ExitCode != 0 {
+		t.Errorf("expected exit_code=0, got %d", decoded.ExitCode)
+	}
+}

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -40,6 +40,20 @@ func resolveState(cfgValue *bool) consentState {
 	return consentState{Enabled: false, Source: "unconfigured", NeedsPrompt: true}
 }
 
+// Status returns the current telemetry state as a human-readable string
+// and the source that determined it. cfgValue is the Telemetry field from
+// the user config (may be nil). This does not initialise the client.
+func Status(cfgValue *bool) (status string, source string) {
+	s := resolveState(cfgValue)
+	if s.NeedsPrompt {
+		return "not configured", ""
+	}
+	if s.Enabled {
+		return "enabled", s.Source
+	}
+	return "disabled", s.Source
+}
+
 // persistConsent writes or updates the telemetry field in the user config file.
 func persistConsent(cfgPath string, enabled bool) error {
 	slog.Debug("persisting telemetry consent", "path", cfgPath, "enabled", enabled)

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -145,6 +145,38 @@ func TestPersistConsentPreservesExisting(t *testing.T) {
 	}
 }
 
+func TestStatusEnabled(t *testing.T) {
+	t.Setenv("GAAL_TELEMETRY", "1")
+	status, source := Status(nil)
+	if status != "enabled" {
+		t.Fatalf("expected enabled, got %q", status)
+	}
+	if source != "GAAL_TELEMETRY=1" {
+		t.Fatalf("expected source GAAL_TELEMETRY=1, got %q", source)
+	}
+}
+
+func TestStatusDisabledEnv(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+	status, source := Status(nil)
+	if status != "disabled" {
+		t.Fatalf("expected disabled, got %q", status)
+	}
+	if source != "DO_NOT_TRACK=1" {
+		t.Fatalf("expected source DO_NOT_TRACK=1, got %q", source)
+	}
+}
+
+func TestStatusUnconfigured(t *testing.T) {
+	status, source := Status(nil)
+	if status != "not configured" {
+		t.Fatalf("expected not configured, got %q", status)
+	}
+	if source != "" {
+		t.Fatalf("expected empty source, got %q", source)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }


### PR DESCRIPTION
## Summary

- Add `gaal doctor` command with config, skills, MCP, and agent sanity checks
- Table and JSON output formats
- `--offline` flag to skip network checks, `--no-upsell` to suppress Community Edition message
- Exit codes: 0 (clean), 1 (warnings), 2 (errors)

## Checks performed

- **Telemetry**: reports current telemetry state (enabled/disabled/unconfigured + source)
- **Skills**: local source exists (os.Stat), remote source reachable (HTTP HEAD), duplicate sources, agents:["*"] with zero agents
- **MCP**: target file exists and is valid JSON, target outside $HOME
- **Agents**: count of installed agents

## Files

- `internal/telemetry/state.go` — add exported `Status()` function
- `internal/engine/ops/doctor.go` — check pipeline, Finding/DoctorReport types
- `internal/engine/engine.go` — `Doctor()` method
- `cmd/doctor.go` — Cobra command with table/JSON rendering + Community block
- `README.md` — doctor section under Usage

Closes #25

## Test plan

- [ ] 519 tests pass with `-race` flag
- [ ] `gaal doctor --offline` shows all sections with check results
- [ ] `gaal doctor --offline -o json` outputs valid structured JSON
- [ ] `gaal doctor --offline --no-upsell` suppresses Community block
- [ ] Exit code 0 when all checks pass
- [ ] Exit code 1 when warnings (e.g., MCP target outside $HOME)
- [ ] Exit code 2 when errors (e.g., missing local skill source)