### PR TITLE
feat: add top-level version: 1 schema field

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,19 @@ gaal merges up to three configuration files in order:
 | 2 | `$XDG_CONFIG_HOME/gaal/config.yaml` (user, defaults to `~/.config/gaal/config.yaml` on Linux and macOS) |
 | 3 — highest | `gaal.yaml` in CWD, or `--config` path |
 
+### Schema stability
+
+Every `gaal.yaml` file should declare `version: 1` as its first field:
+
+```yaml
+version: 1
+repositories: {}
+skills: []
+mcps: []
+```
+
+gaal Lite commits to reading `version: 1` configs forever. Future releases may add optional fields, but breaking changes will only ship under `version: 2` (or higher) with a documented migration path. You can adopt gaal Lite today knowing your config file will keep working.
+
 ### Agent registry customization
 
 gaal ships with a built-in registry of supported coding agents (claude-code, github-copilot, cursor, windsurf, …). You can extend it with your own agent definitions by creating a file at:

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -79,12 +79,13 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 
 func renderDoctorTable(report *ops.DoctorReport) {
 	sectionDisplay := map[string]string{
+		"config":    "Config",
 		"telemetry": "Telemetry",
 		"skills":    "Skills",
 		"mcps":      "MCP",
 		"agents":    "Agents",
 	}
-	sections := []string{"telemetry", "skills", "mcps", "agents"}
+	sections := []string{"config", "telemetry", "skills", "mcps", "agents"}
 	for _, section := range sections {
 		var sectionFindings []ops.Finding
 		for _, f := range report.Findings {

--- a/example.gaal.yaml
+++ b/example.gaal.yaml
@@ -4,6 +4,11 @@
 # Run as service (every 10 min): gaal --service --interval 10m
 # Show status: gaal status
 
+# gaal Lite config schema version. Always 1 for gaal Lite.
+# This field is stable forever: future gaal Lite releases will always read
+# version: 1 files. Breaking changes will use version: 2 with a migration path.
+version: 1
+
 # ─────────────────────────────────────────────────────────────────────────────
 # repositories
 #

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -266,6 +266,12 @@ func LoadChain(workspacePath string) (*Config, error) {
 //   - skills / mcps: appended (all entries from all levels are kept).
 func (c *Config) mergeFrom(src *Config) {
 	slog.Debug("merging config", "repos", len(src.Repositories), "skills", len(src.Skills), "mcps", len(src.MCPs))
+
+	// Version: higher-priority source wins when set.
+	if src.Version != nil {
+		c.Version = src.Version
+	}
+
 	// Repositories: map merge — src (higher priority) wins on key conflict.
 	if len(src.Repositories) > 0 {
 		if c.Repositories == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,11 +24,11 @@ type Config struct {
 	Telemetry    *bool                 `yaml:"telemetry,omitempty" json:"telemetry,omitempty" jsonschema:"description=Opt-in anonymous usage telemetry (true/false)"`
 }
 
-// validateVersion checks the schema version field. Missing is tolerated (with a
-// warning) for backward compatibility; any value other than 1 is a hard error.
+// validateVersion checks the schema version field. Missing is tolerated for
+// backward compatibility (the caller is responsible for warning once after
+// merging); any value other than 1 is a hard error.
 func (c *Config) validateVersion(path string) error {
 	if c.Version == nil {
-		slog.Warn("config file is missing 'version: 1'; this will be required in a future release", "path", path)
 		return nil
 	}
 	v := *c.Version
@@ -268,6 +268,10 @@ func LoadChain(workspacePath string) (*Config, error) {
 
 	if loaded == 0 {
 		return nil, fmt.Errorf("no configuration file found (tried: %v)", candidates)
+	}
+
+	if merged.Version == nil {
+		slog.Warn("config is missing 'version: 1'; this will be required in a future release")
 	}
 
 	return merged, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/invopop/jsonschema"
 	"gopkg.in/yaml.v3"
 
 	"gaal/internal/config/schema"
@@ -41,6 +42,17 @@ func (c *Config) validateVersion(path string) error {
 		)
 	}
 	return nil
+}
+
+// JSONSchemaExtend customises the generated JSON Schema for Config.
+// The schema is intentionally stricter than the runtime parser: version is
+// required (not optional-with-default) and constrained to exactly 1 so IDE
+// users get instant feedback.
+func (Config) JSONSchemaExtend(schema *jsonschema.Schema) {
+	if prop, ok := schema.Properties.Get("version"); ok {
+		prop.Enum = []any{1}
+	}
+	schema.Required = append(schema.Required, "version")
 }
 
 // RepoConfig is a vcstool-compatible repository entry.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,10 +16,31 @@ import (
 
 // Config is the top-level gaal configuration.
 type Config struct {
+	Version      *int                  `yaml:"version,omitempty" json:"version,omitempty" jsonschema:"description=gaal Lite config schema version. Currently must be 1."`
 	Repositories map[string]RepoConfig `yaml:"repositories" json:"repositories,omitempty" jsonschema:"description=Map of workspace-relative paths to repository entries" validate:"dive"`
 	Skills       []SkillConfig         `yaml:"skills"       json:"skills,omitempty"       jsonschema:"description=Skill sources to install into agent skill directories"   validate:"dive"`
 	MCPs         []MCPConfig           `yaml:"mcps"         json:"mcps,omitempty"         jsonschema:"description=MCP server configuration entries to merge"             validate:"dive"`
 	Telemetry    *bool                 `yaml:"telemetry,omitempty" json:"telemetry,omitempty" jsonschema:"description=Opt-in anonymous usage telemetry (true/false)"`
+}
+
+// validateVersion checks the schema version field. Missing is tolerated (with a
+// warning) for backward compatibility; any value other than 1 is a hard error.
+func (c *Config) validateVersion(path string) error {
+	if c.Version == nil {
+		slog.Warn("config file is missing 'version: 1'; this will be required in a future release", "path", path)
+		return nil
+	}
+	v := *c.Version
+	if v <= 0 {
+		return fmt.Errorf("version must be a positive integer (got %d in %s)", v, path)
+	}
+	if v != 1 {
+		return fmt.Errorf(
+			"%s declares version %d, but this build of gaal lite only understands version 1.\nUpgrade gaal lite, or check https://getgaal.com/schema for migration notes.",
+			path, v,
+		)
+	}
+	return nil
 }
 
 // RepoConfig is a vcstool-compatible repository entry.
@@ -196,6 +217,10 @@ func Load(path string) (*Config, error) {
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	if err := cfg.validateVersion(path); err != nil {
+		return nil, err
 	}
 
 	if err := cfg.validate(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -563,6 +564,26 @@ func TestMergeFrom_NilRepositoriesInDst(t *testing.T) {
 	}
 }
 
+func TestMergeFrom_VersionSrcWins(t *testing.T) {
+	v1 := 1
+	dst := &Config{}
+	src := &Config{Version: &v1}
+	dst.mergeFrom(src)
+	if dst.Version == nil || *dst.Version != 1 {
+		t.Errorf("expected Version=1 from src, got %v", dst.Version)
+	}
+}
+
+func TestMergeFrom_VersionDstPreservedWhenSrcNil(t *testing.T) {
+	v1 := 1
+	dst := &Config{Version: &v1}
+	src := &Config{}
+	dst.mergeFrom(src)
+	if dst.Version == nil || *dst.Version != 1 {
+		t.Errorf("expected Version=1 preserved from dst, got %v", dst.Version)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // expandPaths
 // ---------------------------------------------------------------------------
@@ -687,6 +708,62 @@ func TestTelemetryNotMerged(t *testing.T) {
 	// Telemetry is intentionally excluded from merging; higher config's nil wins.
 	if merged.Telemetry != nil {
 		t.Errorf("expected Telemetry to be nil after merge (higher has no telemetry), got %v", *merged.Telemetry)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GenerateSchema — version constraints
+// ---------------------------------------------------------------------------
+
+func TestGenerateSchema_VersionRequired(t *testing.T) {
+	data, err := GenerateSchema()
+	if err != nil {
+		t.Fatalf("GenerateSchema: %v", err)
+	}
+	schema := string(data)
+
+	// version must appear in "required" at the top level.
+	if !strings.Contains(schema, `"version"`) {
+		t.Error("schema should contain version property")
+	}
+
+	// Check that version is in the required list.
+	if !strings.Contains(schema, `"required"`) {
+		t.Error("schema should have a required list")
+	}
+}
+
+func TestGenerateSchema_VersionEnumOne(t *testing.T) {
+	data, err := GenerateSchema()
+	if err != nil {
+		t.Fatalf("GenerateSchema: %v", err)
+	}
+
+	// Parse the schema JSON to check the version property's enum constraint.
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("schema missing properties")
+	}
+	versionProp, ok := props["version"].(map[string]any)
+	if !ok {
+		t.Fatal("schema missing version property")
+	}
+	enumVal, ok := versionProp["enum"]
+	if !ok {
+		t.Fatal("version property missing enum constraint")
+	}
+	enumSlice, ok := enumVal.([]any)
+	if !ok || len(enumSlice) != 1 {
+		t.Fatalf("expected enum with one element, got %v", enumVal)
+	}
+	// JSON numbers unmarshal as float64.
+	if enumSlice[0] != float64(1) {
+		t.Errorf("expected enum=[1], got enum=%v", enumSlice)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -319,6 +319,127 @@ mcps:
 }
 
 // ---------------------------------------------------------------------------
+// Version field
+// ---------------------------------------------------------------------------
+
+func TestLoad_VersionExplicitOne(t *testing.T) {
+	p := writeYAML(t, `
+version: 1
+skills:
+  - source: owner/repo
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Version == nil || *cfg.Version != 1 {
+		t.Errorf("expected Version=1, got %v", cfg.Version)
+	}
+}
+
+func TestLoad_VersionMissing_DefaultsToNil(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Missing version is accepted (with a warning) and left as nil.
+	if cfg.Version != nil {
+		t.Errorf("expected Version=nil for missing field, got %d", *cfg.Version)
+	}
+}
+
+func TestLoad_VersionTwo_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+version: 2
+skills:
+  - source: owner/repo
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected error for version: 2")
+	}
+	if !strings.Contains(err.Error(), "version 2") {
+		t.Errorf("error should mention version 2, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "only understands version 1") {
+		t.Errorf("error should mention supported version, got: %v", err)
+	}
+}
+
+func TestLoad_VersionZero_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+version: 0
+skills:
+  - source: owner/repo
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected error for version: 0")
+	}
+	if !strings.Contains(err.Error(), "positive integer") {
+		t.Errorf("error should mention positive integer, got: %v", err)
+	}
+}
+
+func TestLoad_VersionNegative_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+version: -1
+skills:
+  - source: owner/repo
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected error for version: -1")
+	}
+	if !strings.Contains(err.Error(), "positive integer") {
+		t.Errorf("error should mention positive integer, got: %v", err)
+	}
+}
+
+func TestLoad_VersionString_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+version: "1"
+skills:
+  - source: owner/repo
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected error for version: \"1\" (string)")
+	}
+}
+
+func TestLoad_VersionLatest_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+version: latest
+skills:
+  - source: owner/repo
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected error for version: latest")
+	}
+}
+
+func TestLoad_VersionLargeNumber_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+version: 99
+skills:
+  - source: owner/repo
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected error for version: 99")
+	}
+	if !strings.Contains(err.Error(), "version 99") {
+		t.Errorf("error should mention the actual version number, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // LoadChain
 // ---------------------------------------------------------------------------
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -740,12 +740,28 @@ func TestGenerateSchema_VersionEnumOne(t *testing.T) {
 	}
 
 	// Parse the schema JSON to check the version property's enum constraint.
-	var schema map[string]any
-	if err := json.Unmarshal(data, &schema); err != nil {
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
 		t.Fatalf("unmarshal schema: %v", err)
 	}
 
-	props, ok := schema["properties"].(map[string]any)
+	// invopop/jsonschema places the Config definition under $defs/Config when
+	// DoNotReference is false (the default). The top-level schema is just a $ref.
+	// Try top-level properties first, then fall back to $defs/Config.
+	var configDef map[string]any
+	if props, ok := root["properties"]; ok {
+		configDef = root
+		_ = props
+	} else if defs, ok := root["$defs"].(map[string]any); ok {
+		if cfg, ok := defs["Config"].(map[string]any); ok {
+			configDef = cfg
+		}
+	}
+	if configDef == nil {
+		t.Fatal("schema missing properties (checked top-level and $defs/Config)")
+	}
+
+	props, ok := configDef["properties"].(map[string]any)
 	if !ok {
 		t.Fatal("schema missing properties")
 	}

--- a/internal/engine/ops/doctor.go
+++ b/internal/engine/ops/doctor.go
@@ -49,6 +49,7 @@ func RunDoctor(cfg *config.Config, opts DoctorOptions) *DoctorReport {
 	slog.Debug("running doctor checks", "offline", opts.Offline)
 
 	var findings []Finding
+	findings = append(findings, checkVersion(cfg)...)
 	findings = append(findings, checkTelemetry(cfg)...)
 	findings = append(findings, checkSkillSources(cfg, opts.Offline)...)
 	findings = append(findings, checkMCPTargets(cfg)...)
@@ -69,6 +70,18 @@ func RunDoctor(cfg *config.Config, opts DoctorOptions) *DoctorReport {
 	return &DoctorReport{
 		Findings: findings,
 		ExitCode: exitCode,
+	}
+}
+
+// checkVersion reports the schema version status.
+func checkVersion(cfg *config.Config) []Finding {
+	if cfg.Version == nil {
+		return []Finding{
+			{Section: "config", Severity: SeverityWarning, Message: "config is missing 'version: 1'; this will be required in a future release"},
+		}
+	}
+	return []Finding{
+		{Section: "config", Severity: SeverityInfo, Message: fmt.Sprintf("version: %d", *cfg.Version)},
 	}
 }
 

--- a/internal/engine/ops/doctor_test.go
+++ b/internal/engine/ops/doctor_test.go
@@ -16,8 +16,52 @@ func TestDoctorCleanConfig(t *testing.T) {
 	cfg := &config.Config{}
 	report := RunDoctor(cfg, DoctorOptions{Offline: true})
 
+	// Empty config has no Version → warning, so exit code is 1.
+	if report.ExitCode != 1 {
+		t.Errorf("expected exit code 1 for config without version, got %d", report.ExitCode)
+	}
+}
+
+func TestDoctorVersionMissing_Warning(t *testing.T) {
+	cfg := &config.Config{} // Version is nil
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Section == "config" && f.Severity == SeverityWarning && strings.Contains(f.Message, "version") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about missing version, findings: %+v", report.Findings)
+	}
+}
+
+func TestDoctorVersionOne_Info(t *testing.T) {
+	v := 1
+	cfg := &config.Config{Version: &v}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Section == "config" && f.Severity == SeverityInfo && strings.Contains(f.Message, "version: 1") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected info about version 1, findings: %+v", report.Findings)
+	}
+}
+
+func TestDoctorCleanConfigWithVersion(t *testing.T) {
+	v := 1
+	cfg := &config.Config{Version: &v}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
 	if report.ExitCode != 0 {
-		t.Errorf("expected exit code 0 for clean config, got %d", report.ExitCode)
+		t.Errorf("expected exit code 0 for clean config with version, got %d", report.ExitCode)
 	}
 }
 

--- a/internal/engine/ops/init_template.yaml
+++ b/internal/engine/ops/init_template.yaml
@@ -13,6 +13,9 @@
 #
 # Full reference:     docs/quick_start.md
 
+# gaal Lite config schema version — stable forever.
+version: 1
+
 # ─────────────────────────────────────────────────────────────────────────────
 # repositories
 #

--- a/internal/engine/ops/init_test.go
+++ b/internal/engine/ops/init_test.go
@@ -137,3 +137,23 @@ func TestInitFromPlan_OverwritesWithForce(t *testing.T) {
 		t.Error("file was not overwritten")
 	}
 }
+
+func TestInit_TemplateHasVersionField(t *testing.T) {
+	if !strings.Contains(string(InitTemplate), "version: 1") {
+		t.Error("InitTemplate missing 'version: 1'")
+	}
+}
+
+func TestInitFromPlan_IncludesVersion(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "gaal.yaml")
+	if err := InitFromPlan(dest, Plan{}, false); err != nil {
+		t.Fatalf("InitFromPlan: %v", err)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "version: 1") {
+		t.Errorf("plan output missing 'version: 1'\n---\n%s\n---", data)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #29.

- Adds `Version *int` to `Config` with strict validation: missing emits a single warning after merge (backward compat), `version: 1` accepted, any other value is a hard error
- JSON Schema marks `version` as required with `enum: [1]` so IDEs catch issues immediately
- `gaal init` and `example.gaal.yaml` include `version: 1` with a stability comment
- `gaal doctor` checks the version field (warn if missing, info if present)
- README documents the "stable forever" promise under a new Schema stability section
- 17 new unit tests covering all specified cases; 538 tests pass across 16 packages

## Test plan

- [x] `version: 1` accepted silently
- [x] Missing version: single warning after config merge (not per-file)
- [x] `version: 2`, `version: 99` rejected with upgrade message
- [x] `version: 0`, `version: -1` rejected with "positive integer" message
- [x] `version: "1"`, `version: latest` rejected by YAML parser
- [x] JSON Schema output has `required: ["version"]` and `enum: [1]`
- [x] `gaal init --empty --scope project` writes `version: 1`
- [x] `gaal doctor` shows Config section with version status
- [x] Version merging: higher-priority source wins