### PR TITLE
feat(release): macOS code signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: Release
 
-# Triggered when a version tag is pushed (e.g. v1.2.3).
+# Triggered only on semver release tags (e.g. v0.1.0, v1.2.3).
 # Can also be triggered manually for testing.
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 permissions:
@@ -22,23 +22,23 @@ jobs:
       contents: read
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Cross-compile release binaries for all supported platforms / architectures
-  # Runs only after the full CI suite passes.
+  # Cross-compile release binaries for all supported platforms / architectures.
+  # Darwin builds run on macOS for code signing and notarization.
   # ──────────────────────────────────────────────────────────────────────────
   binaries:
     name: Binary / ${{ matrix.goos }}-${{ matrix.goarch }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: ci
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { goos: linux,   goarch: amd64 }
-          - { goos: linux,   goarch: arm64 }
-          - { goos: darwin,  goarch: amd64 }
-          - { goos: darwin,  goarch: arm64 }
-          - { goos: windows, goarch: amd64, ext: .exe }
-          - { goos: windows, goarch: arm64, ext: .exe }
+          - { goos: linux,   goarch: amd64, runner: ubuntu-latest }
+          - { goos: linux,   goarch: arm64, runner: ubuntu-latest }
+          - { goos: darwin,  goarch: amd64, runner: macos-latest }
+          - { goos: darwin,  goarch: arm64, runner: macos-latest }
+          - { goos: windows, goarch: amd64, runner: ubuntu-latest, ext: .exe }
+          - { goos: windows, goarch: arm64, runner: ubuntu-latest, ext: .exe }
     steps:
       - uses: actions/checkout@v6
 
@@ -56,6 +56,91 @@ jobs:
           make build-cross
           BIN_CROSS=dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
 
+      # ── macOS code signing & notarization ──────────────────────────────────
+
+      - name: Import Apple certificate
+        if: matrix.goos == 'darwin'
+        env:
+          CERTIFICATE_P12: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN="build.keychain"
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -t 3600 "$KEYCHAIN"
+
+          # Add build keychain to search list while keeping the login keychain
+          # (which contains Apple's intermediate certificates needed for a valid chain)
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+
+          echo "$CERTIFICATE_P12" | base64 --decode > /tmp/cert.p12
+          security import /tmp/cert.p12 -k "$KEYCHAIN" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign
+          rm /tmp/cert.p12
+
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+          # Resolve the full signing identity from the imported certificate
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" \
+            | grep "Developer ID Application" | head -1 \
+            | sed 's/.*"\(.*\)"/\1/')
+          if [ -z "$IDENTITY" ]; then
+            echo "::error::No Developer ID Application identity found in keychain"
+            exit 1
+          fi
+          echo "Found identity: $IDENTITY"
+          echo "CODESIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+          echo "BUILD_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
+      - name: Codesign binary
+        if: matrix.goos == 'darwin'
+        run: |
+          codesign --force --options runtime \
+            --sign "$CODESIGN_IDENTITY" \
+            --timestamp \
+            dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}
+
+      - name: Notarize binary
+        if: matrix.goos == 'darwin'
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          BINARY="dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}"
+
+          # notarytool requires a zip/dmg/pkg — not a raw Mach-O
+          # ditto is required; plain zip produces archives Apple rejects
+          ditto -c -k --keepParent "$BINARY" "${BINARY}.zip"
+
+          echo "$APPLE_API_KEY" > /tmp/AuthKey.p8
+
+          xcrun notarytool submit "${BINARY}.zip" \
+            --key /tmp/AuthKey.p8 \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait --timeout 10m
+
+          rm -f /tmp/AuthKey.p8 "${BINARY}.zip"
+
+      - name: Verify signature
+        if: matrix.goos == 'darwin'
+        run: |
+          codesign --verify --deep --strict --verbose=2 \
+            dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}
+          # Show signing details for CI logs
+          codesign -dvv dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}
+
+      - name: Clean up keychain
+        if: matrix.goos == 'darwin' && always()
+        run: security delete-keychain "$BUILD_KEYCHAIN" 2>/dev/null || true
+
+      # ── Upload artifact ────────────────────────────────────────────────────
+
       - uses: actions/upload-artifact@v7
         with:
           name: gaal-${{ matrix.goos }}-${{ matrix.goarch }}
@@ -63,7 +148,7 @@ jobs:
           if-no-files-found: error
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Create the GitHub Release and attach all compiled binaries
+  # Create the GitHub Release and attach all compiled binaries + checksums
   # ──────────────────────────────────────────────────────────────────────────
   release:
     name: Create Release
@@ -75,6 +160,9 @@ jobs:
           pattern: gaal-*
           merge-multiple: true
           path: dist/
+
+      - name: Generate checksums
+        run: cd dist && sha256sum * > SHA256SUMS
 
       - name: List release assets
         run: ls -lh dist/


### PR DESCRIPTION
## Summary

- Darwin release binaries are now codesigned with a Developer ID Application certificate and notarized via Apple's notarytool — no Gatekeeper prompt on download
- Release tag trigger tightened to semver only (`v1.2.3`), `workflow_dispatch` kept for manual runs
- SHA256SUMS file added to release assets

## Details

- darwin matrix entries run on `macos-latest` (others stay on `ubuntu-latest`)
- Certificate imported into a temporary keychain per build, cleaned up on completion
- Uses `ditto` for zipping (Apple rejects archives from standard `zip`)
- Notarization uses App Store Connect API key auth (no 2FA friction)
- Build fails hard if signing or notarization fails — no silent fallback

Closes #22

## Test plan

- [ ] Push `v0.1.1` tag to trigger the release workflow
- [ ] Verify darwin jobs complete signing + notarization successfully
- [ ] Download macOS binary on a clean machine — no Gatekeeper prompt
- [ ] `codesign --verify --deep --strict dist/gaal-darwin-arm64` exits 0
- [ ] SHA256SUMS present in release assets