### PR TITLE
refactor: rename top-level version: to schema:

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,16 +287,16 @@ gaal merges up to three configuration files in order:
 
 ### Schema stability
 
-Every `gaal.yaml` file should declare `version: 1` as its first field:
+Every `gaal.yaml` file should declare `schema: 1` as its first field:
 
 ```yaml
-version: 1
+schema: 1
 repositories: {}
 skills: []
 mcps: []
 ```
 
-gaal Lite commits to reading `version: 1` configs forever. Future releases may add optional fields, but breaking changes will only ship under `version: 2` (or higher) with a documented migration path. You can adopt gaal Lite today knowing your config file will keep working.
+gaal Lite commits to reading `schema: 1` configs forever. Future releases may add optional fields, but breaking changes will only ship under `schema: 2` (or higher) with a documented migration path. You can adopt gaal Lite today knowing your config file will keep working.
 
 ### Agent registry customization
 

--- a/dist/schema.json
+++ b/dist/schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/Config",
+  "$defs": {
+    "Config": {
+      "properties": {
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ],
+          "description": "gaal Lite config schema version. Currently must be 1."
+        },
+        "repositories": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RepoConfig"
+          },
+          "type": "object",
+          "description": "Map of workspace-relative paths to repository entries"
+        },
+        "skills": {
+          "items": {
+            "$ref": "#/$defs/SkillConfig"
+          },
+          "type": "array",
+          "description": "Skill sources to install into agent skill directories"
+        },
+        "mcps": {
+          "items": {
+            "$ref": "#/$defs/MCPConfig"
+          },
+          "type": "array",
+          "description": "MCP server configuration entries to merge"
+        },
+        "telemetry": {
+          "type": "boolean",
+          "description": "Opt-in anonymous usage telemetry (true/false)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema"
+      ]
+    },
+    "MCPConfig": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name identifying this MCP server entry"
+        },
+        "source": {
+          "type": "string",
+          "description": "URL to download a remote JSON server config (mutually exclusive with inline)"
+        },
+        "target": {
+          "type": "string",
+          "description": "Absolute or ~-relative path to the JSON file to write or merge into"
+        },
+        "merge": {
+          "type": "boolean",
+          "description": "Merge server entry into existing file rather than overwriting it (default true)"
+        },
+        "inline": {
+          "$ref": "#/$defs/MCPInlineConfig",
+          "description": "Inline server definition (mutually exclusive with source)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "target"
+      ]
+    },
+    "MCPInlineConfig": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Executable to launch the MCP server process"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Command-line arguments passed to the command"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Additional environment variables injected into the server process"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command"
+      ]
+    },
+    "RepoConfig": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "git",
+            "hg",
+            "svn",
+            "bzr",
+            "tar",
+            "zip"
+          ],
+          "description": "VCS backend type"
+        },
+        "url": {
+          "type": "string",
+          "description": "Repository URL or local path to clone/checkout"
+        },
+        "version": {
+          "type": "string",
+          "description": "Branch"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "url"
+      ]
+    },
+    "SkillConfig": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Skill source: GitHub shorthand (owner/repo)"
+        },
+        "agents": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Target agent identifiers; use [\"*\"] to target all detected agents"
+        },
+        "global": {
+          "type": "boolean",
+          "description": "When true the skill is installed globally under ~/.\u003cagent\u003e/skills/ instead of the project directory"
+        },
+        "select": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Specific skill names to include; empty list installs all skills from the source"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "source"
+      ]
+    }
+  }
+}

--- a/example.gaal.yaml
+++ b/example.gaal.yaml
@@ -6,8 +6,8 @@
 
 # gaal Lite config schema version. Always 1 for gaal Lite.
 # This field is stable forever: future gaal Lite releases will always read
-# version: 1 files. Breaking changes will use version: 2 with a migration path.
-version: 1
+# schema: 1 files. Breaking changes will use schema: 2 with a migration path.
+schema: 1
 
 # ─────────────────────────────────────────────────────────────────────────────
 # repositories

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,27 +17,27 @@ import (
 
 // Config is the top-level gaal configuration.
 type Config struct {
-	Version      *int                  `yaml:"version,omitempty" json:"version,omitempty" jsonschema:"description=gaal Lite config schema version. Currently must be 1."`
+	Schema       *int                  `yaml:"schema,omitempty" json:"schema,omitempty" jsonschema:"description=gaal Lite config schema version. Currently must be 1."`
 	Repositories map[string]RepoConfig `yaml:"repositories" json:"repositories,omitempty" jsonschema:"description=Map of workspace-relative paths to repository entries" validate:"dive"`
 	Skills       []SkillConfig         `yaml:"skills"       json:"skills,omitempty"       jsonschema:"description=Skill sources to install into agent skill directories"   validate:"dive"`
 	MCPs         []MCPConfig           `yaml:"mcps"         json:"mcps,omitempty"         jsonschema:"description=MCP server configuration entries to merge"             validate:"dive"`
 	Telemetry    *bool                 `yaml:"telemetry,omitempty" json:"telemetry,omitempty" jsonschema:"description=Opt-in anonymous usage telemetry (true/false)"`
 }
 
-// validateVersion checks the schema version field. Missing is tolerated for
+// validateSchema checks the schema version field. Missing is tolerated for
 // backward compatibility (the caller is responsible for warning once after
 // merging); any value other than 1 is a hard error.
-func (c *Config) validateVersion(path string) error {
-	if c.Version == nil {
+func (c *Config) validateSchema(path string) error {
+	if c.Schema == nil {
 		return nil
 	}
-	v := *c.Version
+	v := *c.Schema
 	if v <= 0 {
-		return fmt.Errorf("version must be a positive integer (got %d in %s)", v, path)
+		return fmt.Errorf("schema must be a positive integer (got %d in %s)", v, path)
 	}
 	if v != 1 {
 		return fmt.Errorf(
-			"%s declares version %d, but this build of gaal lite only understands version 1.\nUpgrade gaal lite, or check https://getgaal.com/schema for migration notes.",
+			"%s declares schema %d, but this build of gaal lite only understands schema 1.\nUpgrade gaal lite, or check https://getgaal.com/schema for migration notes.",
 			path, v,
 		)
 	}
@@ -45,14 +45,14 @@ func (c *Config) validateVersion(path string) error {
 }
 
 // JSONSchemaExtend customises the generated JSON Schema for Config.
-// The schema is intentionally stricter than the runtime parser: version is
+// The schema is intentionally stricter than the runtime parser: schema is
 // required (not optional-with-default) and constrained to exactly 1 so IDE
 // users get instant feedback.
-func (Config) JSONSchemaExtend(schema *jsonschema.Schema) {
-	if prop, ok := schema.Properties.Get("version"); ok {
+func (Config) JSONSchemaExtend(s *jsonschema.Schema) {
+	if prop, ok := s.Properties.Get("schema"); ok {
 		prop.Enum = []any{1}
 	}
-	schema.Required = append(schema.Required, "version")
+	s.Required = append(s.Required, "schema")
 }
 
 // RepoConfig is a vcstool-compatible repository entry.
@@ -231,7 +231,7 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parsing YAML: %w", err)
 	}
 
-	if err := cfg.validateVersion(path); err != nil {
+	if err := cfg.validateSchema(path); err != nil {
 		return nil, err
 	}
 
@@ -270,8 +270,8 @@ func LoadChain(workspacePath string) (*Config, error) {
 		return nil, fmt.Errorf("no configuration file found (tried: %v)", candidates)
 	}
 
-	if merged.Version == nil {
-		slog.Warn("config is missing 'version: 1'; this will be required in a future release")
+	if merged.Schema == nil {
+		slog.Warn("config is missing 'schema: 1'; this will be required in a future release")
 	}
 
 	return merged, nil
@@ -283,9 +283,9 @@ func LoadChain(workspacePath string) (*Config, error) {
 func (c *Config) mergeFrom(src *Config) {
 	slog.Debug("merging config", "repos", len(src.Repositories), "skills", len(src.Skills), "mcps", len(src.MCPs))
 
-	// Version: higher-priority source wins when set.
-	if src.Version != nil {
-		c.Version = src.Version
+	// Schema: higher-priority source wins when set.
+	if src.Schema != nil {
+		c.Schema = src.Schema
 	}
 
 	// Repositories: map merge — src (higher priority) wins on key conflict.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -320,12 +320,12 @@ mcps:
 }
 
 // ---------------------------------------------------------------------------
-// Version field
+// Schema field
 // ---------------------------------------------------------------------------
 
-func TestLoad_VersionExplicitOne(t *testing.T) {
+func TestLoad_SchemaExplicitOne(t *testing.T) {
 	p := writeYAML(t, `
-version: 1
+schema: 1
 skills:
   - source: owner/repo
 `)
@@ -333,12 +333,12 @@ skills:
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.Version == nil || *cfg.Version != 1 {
-		t.Errorf("expected Version=1, got %v", cfg.Version)
+	if cfg.Schema == nil || *cfg.Schema != 1 {
+		t.Errorf("expected Schema=1, got %v", cfg.Schema)
 	}
 }
 
-func TestLoad_VersionMissing_DefaultsToNil(t *testing.T) {
+func TestLoad_SchemaMissing_DefaultsToNil(t *testing.T) {
 	p := writeYAML(t, `
 skills:
   - source: owner/repo
@@ -347,96 +347,96 @@ skills:
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	// Missing version is accepted (with a warning) and left as nil.
-	if cfg.Version != nil {
-		t.Errorf("expected Version=nil for missing field, got %d", *cfg.Version)
+	// Missing schema is accepted (with a warning) and left as nil.
+	if cfg.Schema != nil {
+		t.Errorf("expected Schema=nil for missing field, got %d", *cfg.Schema)
 	}
 }
 
-func TestLoad_VersionTwo_Rejected(t *testing.T) {
+func TestLoad_SchemaTwo_Rejected(t *testing.T) {
 	p := writeYAML(t, `
-version: 2
+schema: 2
 skills:
   - source: owner/repo
 `)
 	_, err := Load(p)
 	if err == nil {
-		t.Fatal("expected error for version: 2")
+		t.Fatal("expected error for schema: 2")
 	}
-	if !strings.Contains(err.Error(), "version 2") {
-		t.Errorf("error should mention version 2, got: %v", err)
+	if !strings.Contains(err.Error(), "schema 2") {
+		t.Errorf("error should mention schema 2, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "only understands version 1") {
-		t.Errorf("error should mention supported version, got: %v", err)
+	if !strings.Contains(err.Error(), "only understands schema 1") {
+		t.Errorf("error should mention supported schema, got: %v", err)
 	}
 }
 
-func TestLoad_VersionZero_Rejected(t *testing.T) {
+func TestLoad_SchemaZero_Rejected(t *testing.T) {
 	p := writeYAML(t, `
-version: 0
+schema: 0
 skills:
   - source: owner/repo
 `)
 	_, err := Load(p)
 	if err == nil {
-		t.Fatal("expected error for version: 0")
+		t.Fatal("expected error for schema: 0")
 	}
 	if !strings.Contains(err.Error(), "positive integer") {
 		t.Errorf("error should mention positive integer, got: %v", err)
 	}
 }
 
-func TestLoad_VersionNegative_Rejected(t *testing.T) {
+func TestLoad_SchemaNegative_Rejected(t *testing.T) {
 	p := writeYAML(t, `
-version: -1
+schema: -1
 skills:
   - source: owner/repo
 `)
 	_, err := Load(p)
 	if err == nil {
-		t.Fatal("expected error for version: -1")
+		t.Fatal("expected error for schema: -1")
 	}
 	if !strings.Contains(err.Error(), "positive integer") {
 		t.Errorf("error should mention positive integer, got: %v", err)
 	}
 }
 
-func TestLoad_VersionString_Rejected(t *testing.T) {
+func TestLoad_SchemaString_Rejected(t *testing.T) {
 	p := writeYAML(t, `
-version: "1"
+schema: "1"
 skills:
   - source: owner/repo
 `)
 	_, err := Load(p)
 	if err == nil {
-		t.Fatal("expected error for version: \"1\" (string)")
+		t.Fatal("expected error for schema: \"1\" (string)")
 	}
 }
 
-func TestLoad_VersionLatest_Rejected(t *testing.T) {
+func TestLoad_SchemaLatest_Rejected(t *testing.T) {
 	p := writeYAML(t, `
-version: latest
+schema: latest
 skills:
   - source: owner/repo
 `)
 	_, err := Load(p)
 	if err == nil {
-		t.Fatal("expected error for version: latest")
+		t.Fatal("expected error for schema: latest")
 	}
 }
 
-func TestLoad_VersionLargeNumber_Rejected(t *testing.T) {
+func TestLoad_SchemaLargeNumber_Rejected(t *testing.T) {
 	p := writeYAML(t, `
-version: 99
+schema: 99
 skills:
   - source: owner/repo
 `)
 	_, err := Load(p)
 	if err == nil {
-		t.Fatal("expected error for version: 99")
+		t.Fatal("expected error for schema: 99")
 	}
-	if !strings.Contains(err.Error(), "version 99") {
-		t.Errorf("error should mention the actual version number, got: %v", err)
+	if !strings.Contains(err.Error(), "schema 99") {
+		t.Errorf("error should mention the actual schema number, got: %v", err)
 	}
 }
 
@@ -564,23 +564,23 @@ func TestMergeFrom_NilRepositoriesInDst(t *testing.T) {
 	}
 }
 
-func TestMergeFrom_VersionSrcWins(t *testing.T) {
+func TestMergeFrom_SchemaSrcWins(t *testing.T) {
 	v1 := 1
 	dst := &Config{}
-	src := &Config{Version: &v1}
+	src := &Config{Schema: &v1}
 	dst.mergeFrom(src)
-	if dst.Version == nil || *dst.Version != 1 {
-		t.Errorf("expected Version=1 from src, got %v", dst.Version)
+	if dst.Schema == nil || *dst.Schema != 1 {
+		t.Errorf("expected Schema=1 from src, got %v", dst.Schema)
 	}
 }
 
-func TestMergeFrom_VersionDstPreservedWhenSrcNil(t *testing.T) {
+func TestMergeFrom_SchemaDstPreservedWhenSrcNil(t *testing.T) {
 	v1 := 1
-	dst := &Config{Version: &v1}
+	dst := &Config{Schema: &v1}
 	src := &Config{}
 	dst.mergeFrom(src)
-	if dst.Version == nil || *dst.Version != 1 {
-		t.Errorf("expected Version=1 preserved from dst, got %v", dst.Version)
+	if dst.Schema == nil || *dst.Schema != 1 {
+		t.Errorf("expected Schema=1 preserved from dst, got %v", dst.Schema)
 	}
 }
 
@@ -712,34 +712,34 @@ func TestTelemetryNotMerged(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// GenerateSchema — version constraints
+// GenerateSchema — schema constraints
 // ---------------------------------------------------------------------------
 
-func TestGenerateSchema_VersionRequired(t *testing.T) {
+func TestGenerateSchema_SchemaRequired(t *testing.T) {
 	data, err := GenerateSchema()
 	if err != nil {
 		t.Fatalf("GenerateSchema: %v", err)
 	}
-	schema := string(data)
+	s := string(data)
 
-	// version must appear in "required" at the top level.
-	if !strings.Contains(schema, `"version"`) {
-		t.Error("schema should contain version property")
+	// schema must appear in "required" at the top level.
+	if !strings.Contains(s, `"schema"`) {
+		t.Error("schema should contain schema property")
 	}
 
-	// Check that version is in the required list.
-	if !strings.Contains(schema, `"required"`) {
+	// Check that schema is in the required list.
+	if !strings.Contains(s, `"required"`) {
 		t.Error("schema should have a required list")
 	}
 }
 
-func TestGenerateSchema_VersionEnumOne(t *testing.T) {
+func TestGenerateSchema_SchemaEnumOne(t *testing.T) {
 	data, err := GenerateSchema()
 	if err != nil {
 		t.Fatalf("GenerateSchema: %v", err)
 	}
 
-	// Parse the schema JSON to check the version property's enum constraint.
+	// Parse the schema JSON to check the schema property's enum constraint.
 	var root map[string]any
 	if err := json.Unmarshal(data, &root); err != nil {
 		t.Fatalf("unmarshal schema: %v", err)
@@ -765,13 +765,13 @@ func TestGenerateSchema_VersionEnumOne(t *testing.T) {
 	if !ok {
 		t.Fatal("schema missing properties")
 	}
-	versionProp, ok := props["version"].(map[string]any)
+	schemaProp, ok := props["schema"].(map[string]any)
 	if !ok {
-		t.Fatal("schema missing version property")
+		t.Fatal("schema missing schema property")
 	}
-	enumVal, ok := versionProp["enum"]
+	enumVal, ok := schemaProp["enum"]
 	if !ok {
-		t.Fatal("version property missing enum constraint")
+		t.Fatal("schema property missing enum constraint")
 	}
 	enumSlice, ok := enumVal.([]any)
 	if !ok || len(enumSlice) != 1 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -722,14 +722,14 @@ func TestGenerateSchema_SchemaRequired(t *testing.T) {
 	}
 	s := string(data)
 
-	// schema must appear in "required" at the top level.
+	// "schema" must appear in "required" at the top level.
 	if !strings.Contains(s, `"schema"`) {
-		t.Error("schema should contain schema property")
+		t.Error("generated JSON Schema should contain a 'schema' property")
 	}
 
 	// Check that schema is in the required list.
 	if !strings.Contains(s, `"required"`) {
-		t.Error("schema should have a required list")
+		t.Error("generated JSON Schema should have a required list")
 	}
 }
 

--- a/internal/engine/ops/doctor.go
+++ b/internal/engine/ops/doctor.go
@@ -49,7 +49,7 @@ func RunDoctor(cfg *config.Config, opts DoctorOptions) *DoctorReport {
 	slog.Debug("running doctor checks", "offline", opts.Offline)
 
 	var findings []Finding
-	findings = append(findings, checkVersion(cfg)...)
+	findings = append(findings, checkSchema(cfg)...)
 	findings = append(findings, checkTelemetry(cfg)...)
 	findings = append(findings, checkSkillSources(cfg, opts.Offline)...)
 	findings = append(findings, checkMCPTargets(cfg)...)
@@ -73,15 +73,15 @@ func RunDoctor(cfg *config.Config, opts DoctorOptions) *DoctorReport {
 	}
 }
 
-// checkVersion reports the schema version status.
-func checkVersion(cfg *config.Config) []Finding {
-	if cfg.Version == nil {
+// checkSchema reports the schema version status.
+func checkSchema(cfg *config.Config) []Finding {
+	if cfg.Schema == nil {
 		return []Finding{
-			{Section: "config", Severity: SeverityWarning, Message: "config is missing 'version: 1'; this will be required in a future release"},
+			{Section: "config", Severity: SeverityWarning, Message: "config is missing 'schema: 1'; this will be required in a future release"},
 		}
 	}
 	return []Finding{
-		{Section: "config", Severity: SeverityInfo, Message: fmt.Sprintf("version: %d", *cfg.Version)},
+		{Section: "config", Severity: SeverityInfo, Message: fmt.Sprintf("schema: %d", *cfg.Schema)},
 	}
 }
 

--- a/internal/engine/ops/doctor_test.go
+++ b/internal/engine/ops/doctor_test.go
@@ -16,52 +16,52 @@ func TestDoctorCleanConfig(t *testing.T) {
 	cfg := &config.Config{}
 	report := RunDoctor(cfg, DoctorOptions{Offline: true})
 
-	// Empty config has no Version → warning, so exit code is 1.
+	// Empty config has no Schema → warning, so exit code is 1.
 	if report.ExitCode != 1 {
-		t.Errorf("expected exit code 1 for config without version, got %d", report.ExitCode)
+		t.Errorf("expected exit code 1 for config without schema, got %d", report.ExitCode)
 	}
 }
 
-func TestDoctorVersionMissing_Warning(t *testing.T) {
-	cfg := &config.Config{} // Version is nil
+func TestDoctorSchemaMissing_Warning(t *testing.T) {
+	cfg := &config.Config{} // Schema is nil
 	report := RunDoctor(cfg, DoctorOptions{Offline: true})
 
 	found := false
 	for _, f := range report.Findings {
-		if f.Section == "config" && f.Severity == SeverityWarning && strings.Contains(f.Message, "version") {
+		if f.Section == "config" && f.Severity == SeverityWarning && strings.Contains(f.Message, "schema") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected warning about missing version, findings: %+v", report.Findings)
+		t.Errorf("expected warning about missing schema, findings: %+v", report.Findings)
 	}
 }
 
-func TestDoctorVersionOne_Info(t *testing.T) {
+func TestDoctorSchemaOne_Info(t *testing.T) {
 	v := 1
-	cfg := &config.Config{Version: &v}
+	cfg := &config.Config{Schema: &v}
 	report := RunDoctor(cfg, DoctorOptions{Offline: true})
 
 	found := false
 	for _, f := range report.Findings {
-		if f.Section == "config" && f.Severity == SeverityInfo && strings.Contains(f.Message, "version: 1") {
+		if f.Section == "config" && f.Severity == SeverityInfo && strings.Contains(f.Message, "schema: 1") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected info about version 1, findings: %+v", report.Findings)
+		t.Errorf("expected info about schema 1, findings: %+v", report.Findings)
 	}
 }
 
-func TestDoctorCleanConfigWithVersion(t *testing.T) {
+func TestDoctorCleanConfigWithSchema(t *testing.T) {
 	v := 1
-	cfg := &config.Config{Version: &v}
+	cfg := &config.Config{Schema: &v}
 	report := RunDoctor(cfg, DoctorOptions{Offline: true})
 
 	if report.ExitCode != 0 {
-		t.Errorf("expected exit code 0 for clean config with version, got %d", report.ExitCode)
+		t.Errorf("expected exit code 0 for clean config with schema, got %d", report.ExitCode)
 	}
 }
 

--- a/internal/engine/ops/init_template.yaml
+++ b/internal/engine/ops/init_template.yaml
@@ -14,7 +14,7 @@
 # Full reference:     docs/quick_start.md
 
 # gaal Lite config schema version — stable forever.
-version: 1
+schema: 1
 
 # ─────────────────────────────────────────────────────────────────────────────
 # repositories

--- a/internal/engine/ops/init_test.go
+++ b/internal/engine/ops/init_test.go
@@ -138,13 +138,13 @@ func TestInitFromPlan_OverwritesWithForce(t *testing.T) {
 	}
 }
 
-func TestInit_TemplateHasVersionField(t *testing.T) {
-	if !strings.Contains(string(InitTemplate), "version: 1") {
-		t.Error("InitTemplate missing 'version: 1'")
+func TestInit_TemplateHasSchemaField(t *testing.T) {
+	if !strings.Contains(string(InitTemplate), "schema: 1") {
+		t.Error("InitTemplate missing 'schema: 1'")
 	}
 }
 
-func TestInitFromPlan_IncludesVersion(t *testing.T) {
+func TestInitFromPlan_IncludesSchema(t *testing.T) {
 	dest := filepath.Join(t.TempDir(), "gaal.yaml")
 	if err := InitFromPlan(dest, Plan{}, false); err != nil {
 		t.Fatalf("InitFromPlan: %v", err)
@@ -153,7 +153,7 @@ func TestInitFromPlan_IncludesVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), "version: 1") {
-		t.Errorf("plan output missing 'version: 1'\n---\n%s\n---", data)
+	if !strings.Contains(string(data), "schema: 1") {
+		t.Errorf("plan output missing 'schema: 1'\n---\n%s\n---", data)
 	}
 }


### PR DESCRIPTION
## Summary

- Renames the top-level config field from `version: 1` to `schema: 1`, eliminating the naming collision with `RepoConfig.Version` (git ref) and better communicating the field's purpose
- Updates all validation, error messages, doctor checks, YAML examples, init templates, JSON Schema, and documentation
- Zero behavioral change — pure rename with identical semantics

Closes #29

## Test plan

- [x] All 538 tests pass (`go test ./...`)
- [x] Clean build (`go build ./...`)
- [x] No stale `validateVersion`/`checkVersion`/`cfg.Version` references in config code
- [x] `RepoConfig.Version` (git ref field) untouched
- [x] `gaal schema` output shows `"schema"` property with `enum: [1]`
- [x] `dist/schema.json` regenerated with correct field name