### PR TITLE
feat(sync): add --dry-run flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ gaal sync
 
 Clones or updates all repositories, installs skills, and upserts MCP entries.
 
+### Dry-run (preview changes)
+
+```bash
+gaal sync --dry-run
+```
+
+Runs the full sync planning pipeline but performs no writes to disk.
+Prints what sync *would* do — which repos would be cloned or updated,
+which skills would be installed, and which MCP entries would be created.
+
+Supports `--output table|json` and `--sandbox`. Incompatible with `--service`.
+
+Exit codes: **0** = nothing to change, **1** = changes pending, **2** = error.
+
 ### Continuous service mode
 
 ```bash

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -19,6 +19,7 @@ import (
 var (
 	service  bool
 	interval time.Duration
+	dryRun   bool
 )
 
 var syncCmd = &cobra.Command{
@@ -28,7 +29,8 @@ var syncCmd = &cobra.Command{
 configuration file: clones or updates repositories, installs or refreshes
 agent skills, and upserts MCP server entries.
 
-Use --service to run continuously at a fixed interval.`,
+Use --service to run continuously at a fixed interval.
+Use --dry-run to preview what sync would do without writing anything.`,
 	SilenceUsage: true,
 	RunE:         runSync,
 }
@@ -36,10 +38,15 @@ Use --service to run continuously at a fixed interval.`,
 func init() {
 	syncCmd.Flags().BoolVarP(&service, "service", "s", false, "run as a continuous service (daemon mode)")
 	syncCmd.Flags().DurationVarP(&interval, "interval", "i", 5*time.Minute, "polling interval in service mode")
+	syncCmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview what sync would do without writing anything")
 	rootCmd.AddCommand(syncCmd)
 }
 
 func runSync(_ *cobra.Command, _ []string) error {
+	if dryRun && service {
+		return fmt.Errorf("--dry-run and --service are incompatible: a dry-run service loop is meaningless")
+	}
+
 	cfg, err := config.LoadChain(cfgFile)
 	if err != nil {
 		telemetry.TrackError("sync", err)
@@ -50,6 +57,24 @@ func runSync(_ *cobra.Command, _ []string) error {
 	defer cancel()
 
 	eng := engine.NewWithOptions(cfg, engineOpts)
+
+	if dryRun {
+		slog.Info("dry-run mode", "config", cfgFile)
+		format := engine.OutputFormat(outputFormat)
+		plan, err := eng.DryRun(ctx, format)
+		if err != nil {
+			telemetry.TrackError("sync", err)
+			os.Exit(2)
+		}
+		telemetry.Track("sync-dry-run")
+		if plan.HasErrors {
+			os.Exit(2)
+		}
+		if plan.HasChanges {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
 
 	if service {
 		slog.Info("service mode started", "interval", interval, "config", cfgFile)

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestRunSync_DryRunAndServiceConflict(t *testing.T) {
+	// Save and restore global flags.
+	origDryRun := dryRun
+	origService := service
+	origCfgFile := cfgFile
+	t.Cleanup(func() {
+		dryRun = origDryRun
+		service = origService
+		cfgFile = origCfgFile
+	})
+
+	dryRun = true
+	service = true
+	cfgFile = "testdata/nonexistent.yaml"
+
+	err := runSync(nil, nil)
+	if err == nil {
+		t.Fatal("expected error when --dry-run and --service are both set")
+	}
+	want := "--dry-run and --service are incompatible"
+	if got := err.Error(); got != want+": a dry-run service loop is meaningless" {
+		t.Fatalf("unexpected error message: %q", got)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -31,6 +31,7 @@ type (
 	AuditReport     = render.AuditReport
 	AuditSkillEntry = render.AuditSkillEntry
 	AuditMCPEntry   = render.AuditMCPEntry
+	PlanReport      = render.PlanReport
 )
 
 // Re-exported constants from the render sub-package.
@@ -166,6 +167,13 @@ func (e *Engine) RunService(ctx context.Context, interval time.Duration) error {
 // Collect gathers the current status of all resources without side effects.
 func (e *Engine) Collect(ctx context.Context) (*render.StatusReport, error) {
 	return ops.Collect(ctx, e.repos, e.skills, e.mcps)
+}
+
+// DryRun computes what sync would do and renders the plan to os.Stdout.
+// It returns the plan so the caller can inspect HasChanges / HasErrors for
+// exit code logic.
+func (e *Engine) DryRun(ctx context.Context, format OutputFormat) (*render.PlanReport, error) {
+	return ops.RenderPlan(ctx, e.repos, e.skills, e.mcps, format)
 }
 
 // Status collects the current resource state and renders it to os.Stdout.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -245,6 +245,134 @@ func TestCollect_IncludesAgents(t *testing.T) {
 	}
 }
 
+func TestDryRun_EmptyConfig(t *testing.T) {
+	cfg := &config.Config{}
+	e := New(cfg)
+	var plan *PlanReport
+	var dryRunErr error
+	captureStdout(t, func() {
+		plan, dryRunErr = e.DryRun(context.Background(), FormatTable)
+	})
+	if dryRunErr != nil {
+		t.Fatalf("DryRun on empty config should succeed, got: %v", dryRunErr)
+	}
+	if plan.HasChanges {
+		t.Error("empty config should have no changes")
+	}
+	if plan.HasErrors {
+		t.Error("empty config should have no errors")
+	}
+}
+
+func TestDryRun_EmptyConfig_JSON(t *testing.T) {
+	cfg := &config.Config{}
+	e := New(cfg)
+	var plan *PlanReport
+	var dryRunErr error
+	out := captureStdout(t, func() {
+		plan, dryRunErr = e.DryRun(context.Background(), FormatJSON)
+	})
+	if dryRunErr != nil {
+		t.Fatalf("DryRun JSON on empty config should succeed, got: %v", dryRunErr)
+	}
+	if plan.HasChanges {
+		t.Error("empty config should have no changes")
+	}
+	if len(out) == 0 {
+		t.Error("expected JSON output, got empty string")
+	}
+}
+
+func TestDryRun_WithRepo_NotCloned(t *testing.T) {
+	// Point at a directory that does NOT exist yet so IsCloned returns false.
+	missingDir := filepath.Join(t.TempDir(), "nonexistent")
+	cfg := &config.Config{
+		Repositories: map[string]config.RepoConfig{
+			missingDir: {Type: "tar", URL: "https://example.com/archive.tar.gz"},
+		},
+	}
+	e := New(cfg)
+	var plan *PlanReport
+	var dryRunErr error
+	captureStdout(t, func() {
+		plan, dryRunErr = e.DryRun(context.Background(), FormatTable)
+	})
+	if dryRunErr != nil {
+		t.Fatalf("DryRun: %v", dryRunErr)
+	}
+	if !plan.HasChanges {
+		t.Error("expected HasChanges=true for not-cloned repo")
+	}
+}
+
+func TestDryRun_WithRepo_AlreadyCloned(t *testing.T) {
+	// Existing dir means IsCloned returns true for archive type; Update is a no-op.
+	existing := t.TempDir()
+	cfg := &config.Config{
+		Repositories: map[string]config.RepoConfig{
+			existing: {Type: "tar", URL: "https://example.com/archive.tar.gz"},
+		},
+	}
+	e := New(cfg)
+	var plan *PlanReport
+	var dryRunErr error
+	captureStdout(t, func() {
+		plan, dryRunErr = e.DryRun(context.Background(), FormatTable)
+	})
+	if dryRunErr != nil {
+		t.Fatalf("DryRun: %v", dryRunErr)
+	}
+	if plan.HasChanges {
+		t.Error("expected HasChanges=false for already-cloned repo")
+	}
+}
+
+func TestDryRun_WithRepoError(t *testing.T) {
+	cfg := &config.Config{
+		Repositories: map[string]config.RepoConfig{
+			"/some/path": {Type: "unknown-vcs-type", URL: "https://example.com/x"},
+		},
+	}
+	e := New(cfg)
+	var plan *PlanReport
+	var dryRunErr error
+	captureStdout(t, func() {
+		plan, dryRunErr = e.DryRun(context.Background(), FormatTable)
+	})
+	if dryRunErr != nil {
+		t.Fatalf("DryRun should not error, the plan should contain errors: %v", dryRunErr)
+	}
+	if !plan.HasErrors {
+		t.Error("expected HasErrors=true for unknown VCS type")
+	}
+}
+
+func TestDryRun_WithMCP_Absent(t *testing.T) {
+	// Target file doesn't exist yet → MCP is absent → plan should show create.
+	target := filepath.Join(t.TempDir(), "mcp.json")
+	cfg := &config.Config{
+		MCPs: []config.MCPConfig{
+			{
+				Name:   "test-mcp",
+				Target: target,
+				Inline: &config.MCPInlineConfig{Command: "node"},
+			},
+		},
+	}
+	e := New(cfg)
+	var plan *PlanReport
+	var dryRunErr error
+	captureStdout(t, func() {
+		plan, dryRunErr = e.DryRun(context.Background(), FormatTable)
+	})
+	if dryRunErr != nil {
+		t.Fatalf("DryRun: %v", dryRunErr)
+	}
+	if !plan.HasChanges {
+		t.Error("expected HasChanges=true for absent MCP")
+	}
+}
+
 func TestCollect_AgentsSorted(t *testing.T) {
 	cfg := &config.Config{}
 	e := New(cfg)

--- a/internal/engine/ops/plan.go
+++ b/internal/engine/ops/plan.go
@@ -1,0 +1,154 @@
+package ops
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"gaal/internal/engine/render"
+	"gaal/internal/mcp"
+	"gaal/internal/repo"
+	"gaal/internal/skill"
+)
+
+// SyncPlan computes what a sync would do without performing any writes.
+// The returned PlanReport describes every action that RunOnce would take.
+// This is the shared planner used by both `sync --dry-run` and the future
+// `diff` command.
+func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager) (*render.PlanReport, error) {
+	slog.DebugContext(ctx, "computing sync plan")
+
+	report, err := Collect(ctx, repos, skills, mcps)
+	if err != nil {
+		return nil, err
+	}
+
+	plan := &render.PlanReport{}
+
+	plan.Repositories = planRepos(report.Repositories)
+	plan.Skills = planSkills(report.Skills)
+	plan.MCPs = planMCPs(report.MCPs)
+
+	for _, r := range plan.Repositories {
+		if r.Action == render.PlanError {
+			plan.HasErrors = true
+		}
+		if r.Action != render.PlanNoOp && r.Action != render.PlanError {
+			plan.HasChanges = true
+		}
+	}
+	for _, s := range plan.Skills {
+		if s.Action == render.PlanError {
+			plan.HasErrors = true
+		}
+		if s.Action != render.PlanNoOp && s.Action != render.PlanError {
+			plan.HasChanges = true
+		}
+	}
+	for _, m := range plan.MCPs {
+		if m.Action == render.PlanError {
+			plan.HasErrors = true
+		}
+		if m.Action != render.PlanNoOp && m.Action != render.PlanError {
+			plan.HasChanges = true
+		}
+	}
+
+	return plan, nil
+}
+
+// RenderPlan computes and renders the sync plan to stdout.
+func RenderPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, format render.OutputFormat) (*render.PlanReport, error) {
+	plan, err := SyncPlan(ctx, repos, skills, mcps)
+	if err != nil {
+		return nil, err
+	}
+
+	renderer, err := render.NewPlanRenderer(format)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := renderer.Render(os.Stdout, plan); err != nil {
+		return nil, err
+	}
+
+	return plan, nil
+}
+
+func planRepos(entries []render.RepoEntry) []render.PlanRepoEntry {
+	out := make([]render.PlanRepoEntry, 0, len(entries))
+	for _, e := range entries {
+		p := render.PlanRepoEntry{
+			Path:    e.Path,
+			Type:    e.Type,
+			URL:     e.URL,
+			Current: e.Current,
+			Want:    e.Want,
+		}
+		switch e.Status {
+		case render.StatusError:
+			p.Action = render.PlanError
+			p.Error = e.Error
+		case render.StatusNotCloned:
+			p.Action = render.PlanClone
+		case render.StatusDirty:
+			p.Action = render.PlanUpdate
+		default:
+			p.Action = render.PlanNoOp
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func planSkills(entries []render.SkillEntry) []render.PlanSkillEntry {
+	out := make([]render.PlanSkillEntry, 0, len(entries))
+	for _, e := range entries {
+		p := render.PlanSkillEntry{
+			Source: e.Source,
+			Agent:  e.Agent,
+		}
+		switch e.Status {
+		case render.StatusError:
+			p.Action = render.PlanError
+			p.Error = e.Error
+		case render.StatusPartial:
+			p.Action = render.PlanCreate
+			p.Install = e.Missing
+			if len(e.Modified) > 0 {
+				p.Update = e.Modified
+			}
+		case render.StatusDirty:
+			p.Action = render.PlanUpdate
+			p.Update = e.Modified
+		default:
+			p.Action = render.PlanNoOp
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func planMCPs(entries []render.MCPEntry) []render.PlanMCPEntry {
+	out := make([]render.PlanMCPEntry, 0, len(entries))
+	for _, e := range entries {
+		p := render.PlanMCPEntry{
+			Name:   e.Name,
+			Target: e.Target,
+		}
+		switch e.Status {
+		case render.StatusError:
+			p.Action = render.PlanError
+			p.Error = e.Error
+		case render.StatusAbsent:
+			p.Action = render.PlanCreate
+		case render.StatusDirty:
+			p.Action = render.PlanUpdate
+		default:
+			p.Action = render.PlanNoOp
+		}
+		out = append(out, p)
+	}
+	return out
+}

--- a/internal/engine/ops/plan_test.go
+++ b/internal/engine/ops/plan_test.go
@@ -1,0 +1,116 @@
+package ops
+
+import (
+	"testing"
+
+	"gaal/internal/engine/render"
+)
+
+func TestPlanRepos_NotCloned(t *testing.T) {
+	entries := []render.RepoEntry{
+		{Path: "/repos/foo", Type: "git", Status: render.StatusNotCloned, URL: "https://example.com/foo.git"},
+	}
+	result := planRepos(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	if result[0].Action != render.PlanClone {
+		t.Errorf("expected action %q, got %q", render.PlanClone, result[0].Action)
+	}
+}
+
+func TestPlanRepos_Dirty(t *testing.T) {
+	entries := []render.RepoEntry{
+		{Path: "/repos/foo", Type: "git", Status: render.StatusDirty, Current: "abc", Want: "main"},
+	}
+	result := planRepos(entries)
+	if result[0].Action != render.PlanUpdate {
+		t.Errorf("expected action %q, got %q", render.PlanUpdate, result[0].Action)
+	}
+}
+
+func TestPlanRepos_OK(t *testing.T) {
+	entries := []render.RepoEntry{
+		{Path: "/repos/foo", Type: "git", Status: render.StatusOK, Current: "main", Want: "main"},
+	}
+	result := planRepos(entries)
+	if result[0].Action != render.PlanNoOp {
+		t.Errorf("expected action %q, got %q", render.PlanNoOp, result[0].Action)
+	}
+}
+
+func TestPlanRepos_Error(t *testing.T) {
+	entries := []render.RepoEntry{
+		{Path: "/repos/foo", Type: "unknown", Status: render.StatusError, Error: "unsupported type"},
+	}
+	result := planRepos(entries)
+	if result[0].Action != render.PlanError {
+		t.Errorf("expected action %q, got %q", render.PlanError, result[0].Action)
+	}
+	if result[0].Error != "unsupported type" {
+		t.Errorf("expected error %q, got %q", "unsupported type", result[0].Error)
+	}
+}
+
+func TestPlanSkills_Partial(t *testing.T) {
+	entries := []render.SkillEntry{
+		{Source: "owner/repo", Agent: "claude-code", Status: render.StatusPartial, Missing: []string{"skill-a"}},
+	}
+	result := planSkills(entries)
+	if result[0].Action != render.PlanCreate {
+		t.Errorf("expected action %q, got %q", render.PlanCreate, result[0].Action)
+	}
+	if len(result[0].Install) != 1 || result[0].Install[0] != "skill-a" {
+		t.Errorf("expected install=[skill-a], got %v", result[0].Install)
+	}
+}
+
+func TestPlanSkills_Dirty(t *testing.T) {
+	entries := []render.SkillEntry{
+		{Source: "owner/repo", Agent: "claude-code", Status: render.StatusDirty, Modified: []string{"skill-b"}},
+	}
+	result := planSkills(entries)
+	if result[0].Action != render.PlanUpdate {
+		t.Errorf("expected action %q, got %q", render.PlanUpdate, result[0].Action)
+	}
+}
+
+func TestPlanSkills_OK(t *testing.T) {
+	entries := []render.SkillEntry{
+		{Source: "owner/repo", Agent: "claude-code", Status: render.StatusOK, Installed: []string{"skill-a"}},
+	}
+	result := planSkills(entries)
+	if result[0].Action != render.PlanNoOp {
+		t.Errorf("expected action %q, got %q", render.PlanNoOp, result[0].Action)
+	}
+}
+
+func TestPlanMCPs_Absent(t *testing.T) {
+	entries := []render.MCPEntry{
+		{Name: "test-mcp", Target: "/path/to/config.json", Status: render.StatusAbsent},
+	}
+	result := planMCPs(entries)
+	if result[0].Action != render.PlanCreate {
+		t.Errorf("expected action %q, got %q", render.PlanCreate, result[0].Action)
+	}
+}
+
+func TestPlanMCPs_Dirty(t *testing.T) {
+	entries := []render.MCPEntry{
+		{Name: "test-mcp", Target: "/path/to/config.json", Status: render.StatusDirty, Dirty: true},
+	}
+	result := planMCPs(entries)
+	if result[0].Action != render.PlanUpdate {
+		t.Errorf("expected action %q, got %q", render.PlanUpdate, result[0].Action)
+	}
+}
+
+func TestPlanMCPs_Present(t *testing.T) {
+	entries := []render.MCPEntry{
+		{Name: "test-mcp", Target: "/path/to/config.json", Status: render.StatusPresent},
+	}
+	result := planMCPs(entries)
+	if result[0].Action != render.PlanNoOp {
+		t.Errorf("expected action %q, got %q", render.PlanNoOp, result[0].Action)
+	}
+}

--- a/internal/engine/render/plan_json.go
+++ b/internal/engine/render/plan_json.go
@@ -1,0 +1,16 @@
+package render
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+)
+
+type planJSONRenderer struct{}
+
+func (j *planJSONRenderer) Render(w io.Writer, r *PlanReport) error {
+	slog.Debug("rendering plan json output")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}

--- a/internal/engine/render/plan_table.go
+++ b/internal/engine/render/plan_table.go
@@ -1,0 +1,156 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pterm/pterm"
+)
+
+// actionLabel maps a PlanAction to a human-readable display string.
+var actionLabel = map[PlanAction]string{
+	PlanNoOp:   "no change",
+	PlanClone:  "clone",
+	PlanUpdate: "update",
+	PlanCreate: "create",
+	PlanError:  "error",
+}
+
+// actionCell renders a PlanAction as a coloured pterm string.
+func actionCell(action PlanAction, errMsg string) string {
+	label, ok := actionLabel[action]
+	if !ok {
+		label = string(action)
+	}
+	switch action {
+	case PlanNoOp:
+		return pterm.FgGreen.Sprint("  " + label)
+	case PlanClone, PlanCreate:
+		return pterm.FgCyan.Sprint("+ " + label)
+	case PlanUpdate:
+		return pterm.FgYellow.Sprint("~ " + label)
+	case PlanError:
+		msg := label
+		if errMsg != "" {
+			msg = errMsg
+		}
+		return pterm.FgRed.Sprint("! " + msg)
+	default:
+		return label
+	}
+}
+
+type planTableRenderer struct{}
+
+func (pr *planTableRenderer) Render(w io.Writer, r *PlanReport) error {
+	tr := &tableRenderer{}
+	termW := pterm.GetTerminalWidth()
+	if termW < 60 {
+		termW = 120
+	}
+
+	if err := pr.repoTable(w, tr, r.Repositories, termW); err != nil {
+		return err
+	}
+	if err := pr.skillTable(w, tr, r.Skills, termW); err != nil {
+		return err
+	}
+	if err := pr.mcpTable(w, tr, r.MCPs, termW); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w)
+	if r.HasErrors {
+		fmt.Fprintln(w, pterm.FgRed.Sprint("Plan completed with errors."))
+	} else if r.HasChanges {
+		fmt.Fprintln(w, pterm.FgYellow.Sprint("Sync would make changes. Run 'gaal sync' to apply."))
+	} else {
+		fmt.Fprintln(w, pterm.FgGreen.Sprint("Everything is up to date. Nothing to sync."))
+	}
+
+	return nil
+}
+
+func (pr *planTableRenderer) repoTable(w io.Writer, tr *tableRenderer, entries []PlanRepoEntry, termW int) error {
+	tr.section(w, "Repositories", len(entries))
+	vw := varColWidth(termW, 4, 2, 22)
+	pathMax := vw * 55 / 100
+	infoMax := vw * 45 / 100
+	if pathMax < 15 {
+		pathMax = 15
+	}
+	if infoMax < 15 {
+		infoMax = 15
+	}
+
+	data := pterm.TableData{{"PATH", "TYPE", "ACTION", "DETAIL"}}
+	for _, e := range entries {
+		var detail string
+		switch e.Action {
+		case PlanClone:
+			detail = e.URL
+		case PlanUpdate:
+			detail = e.Current + " -> " + e.Want
+		case PlanError:
+			detail = e.Error
+		}
+		data = append(data, []string{
+			trunc(e.Path, pathMax),
+			e.Type,
+			actionCell(e.Action, e.Error),
+			trunc(detail, infoMax),
+		})
+	}
+	return tr.ptermTable(w, data)
+}
+
+func (pr *planTableRenderer) skillTable(w io.Writer, tr *tableRenderer, entries []PlanSkillEntry, termW int) error {
+	tr.section(w, "Skills", len(entries))
+	vw := varColWidth(termW, 4, 3, 14)
+	if vw < 12 {
+		vw = 12
+	}
+
+	data := pterm.TableData{{"SOURCE", "AGENT", "ACTION", "DETAIL"}}
+	for _, e := range entries {
+		var detail string
+		switch e.Action {
+		case PlanCreate:
+			parts := append([]string{}, e.Install...)
+			if len(e.Update) > 0 {
+				parts = append(parts, e.Update...)
+			}
+			detail = "install: " + strings.Join(parts, ", ")
+		case PlanUpdate:
+			detail = "update: " + strings.Join(e.Update, ", ")
+		case PlanError:
+			detail = e.Error
+		}
+		data = append(data, []string{
+			trunc(e.Source, vw),
+			trunc(e.Agent, vw),
+			actionCell(e.Action, e.Error),
+			trunc(detail, vw),
+		})
+	}
+	return tr.ptermTable(w, data)
+}
+
+func (pr *planTableRenderer) mcpTable(w io.Writer, tr *tableRenderer, entries []PlanMCPEntry, termW int) error {
+	tr.section(w, "MCP Configs", len(entries))
+	vw := varColWidth(termW, 3, 1, 34)
+	if vw < 20 {
+		vw = 20
+	}
+
+	data := pterm.TableData{{"NAME", "ACTION", "TARGET"}}
+	for _, e := range entries {
+		data = append(data, []string{
+			e.Name,
+			actionCell(e.Action, e.Error),
+			trunc(e.Target, vw),
+		})
+	}
+	return tr.ptermTable(w, data)
+}

--- a/internal/engine/render/renderer.go
+++ b/internal/engine/render/renderer.go
@@ -31,3 +31,21 @@ func NewRenderer(f OutputFormat) (Renderer, error) {
 		return nil, fmt.Errorf("unknown output format %q (want: table, json)", f)
 	}
 }
+
+// PlanRenderer formats a PlanReport and writes it to an io.Writer.
+type PlanRenderer interface {
+	Render(w io.Writer, r *PlanReport) error
+}
+
+// NewPlanRenderer returns a PlanRenderer for format f.
+func NewPlanRenderer(f OutputFormat) (PlanRenderer, error) {
+	slog.Debug("creating plan renderer", "format", f)
+	switch f {
+	case FormatTable:
+		return &planTableRenderer{}, nil
+	case FormatJSON:
+		return &planJSONRenderer{}, nil
+	default:
+		return nil, fmt.Errorf("unknown output format %q (want: table, json)", f)
+	}
+}

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -85,6 +85,55 @@ type StatusReport struct {
 	Agents       []AgentEntry `json:"agents"`
 }
 
+// PlanAction describes what sync would do for a given resource.
+type PlanAction string
+
+const (
+	PlanNoOp   PlanAction = "no_change"
+	PlanClone  PlanAction = "clone"
+	PlanUpdate PlanAction = "update"
+	PlanCreate PlanAction = "create"
+	PlanError  PlanAction = "error"
+)
+
+// PlanRepoEntry describes the planned action for a single repository.
+type PlanRepoEntry struct {
+	Path    string     `json:"path"`
+	Type    string     `json:"type"`
+	Action  PlanAction `json:"action"`
+	URL     string     `json:"url,omitempty"`
+	Current string     `json:"current,omitempty"`
+	Want    string     `json:"want,omitempty"`
+	Error   string     `json:"error,omitempty"`
+}
+
+// PlanSkillEntry describes the planned action for a single skill config.
+type PlanSkillEntry struct {
+	Source  string     `json:"source"`
+	Agent   string     `json:"agent"`
+	Action  PlanAction `json:"action"`
+	Install []string   `json:"install,omitempty"`
+	Update  []string   `json:"update,omitempty"`
+	Error   string     `json:"error,omitempty"`
+}
+
+// PlanMCPEntry describes the planned action for a single MCP entry.
+type PlanMCPEntry struct {
+	Name   string     `json:"name"`
+	Target string     `json:"target"`
+	Action PlanAction `json:"action"`
+	Error  string     `json:"error,omitempty"`
+}
+
+// PlanReport aggregates the planned actions for all managed resources.
+type PlanReport struct {
+	Repositories []PlanRepoEntry  `json:"repositories"`
+	Skills       []PlanSkillEntry `json:"skills"`
+	MCPs         []PlanMCPEntry   `json:"mcps"`
+	HasChanges   bool             `json:"has_changes"`
+	HasErrors    bool             `json:"has_errors"`
+}
+
 // AuditSkillEntry holds the metadata of a single skill discovered during audit.
 type AuditSkillEntry struct {
 	Name string `json:"name"`


### PR DESCRIPTION
## Summary

- Adds `--dry-run` flag to `gaal sync` that previews what sync would do without writing anything to disk
- Extracts a shared planner (`ops.SyncPlan`) that both `--dry-run` and the future `diff` command (#25) can reuse
- Exit codes match the `diff` spec: **0** = nothing to change, **1** = changes pending, **2** = error
- `--dry-run --service` is rejected with a clear error message
- Supports `--output table|json` and `--sandbox`

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] All 555 tests pass (17 new tests added)
- [x] Manual: `gaal sync --dry-run` with repos not yet cloned shows "clone" action
- [x] Manual: `gaal sync --dry-run` after a successful sync shows "no change"
- [x] Manual: `gaal sync --dry-run --service` exits with clear error
- [x] Manual: `gaal sync --dry-run -o json` produces valid JSON output

Closes #24