### PR TITLE
test: add error-path and edge-case coverage across packages

### DIFF
--- a/internal/core/agent/registry_internal_test.go
+++ b/internal/core/agent/registry_internal_test.go
@@ -153,6 +153,90 @@ func TestValidateEntry_MCPConfigWithoutTilde_Rejected(t *testing.T) {
 	}
 }
 
+func TestValidateEntry_EmptyProjectDir_NoGenericFlag_Rejected(t *testing.T) {
+	e := agentEntry{
+		ProjectSkillsDir:       "",
+		GlobalSkillsDir:        "~/.foo/skills",
+		SupportsGenericProject: false,
+	}
+	if err := validateEntry("foo", e); err == nil {
+		t.Error("expected error when project_skills_dir is empty and supports_generic_project is false")
+	}
+}
+
+func TestValidateEntry_EmptyGlobalDir_NoGenericFlag_Rejected(t *testing.T) {
+	e := agentEntry{
+		ProjectSkillsDir:      ".foo/skills",
+		GlobalSkillsDir:       "",
+		SupportsGenericGlobal: false,
+	}
+	if err := validateEntry("foo", e); err == nil {
+		t.Error("expected error when global_skills_dir is empty and supports_generic_global is false")
+	}
+}
+
+func TestValidateEntry_ProjectSearchAbsolute_Rejected(t *testing.T) {
+	e := agentEntry{
+		ProjectSkillsDir:    ".foo/skills",
+		GlobalSkillsDir:     "~/.foo/skills",
+		ProjectSkillsSearch: []string{"/absolute/path"},
+	}
+	if err := validateEntry("foo", e); err == nil {
+		t.Error("expected error for absolute path in project_skills_search")
+	}
+}
+
+func TestValidateEntry_ProjectSearchDotDot_Rejected(t *testing.T) {
+	e := agentEntry{
+		ProjectSkillsDir:    ".foo/skills",
+		GlobalSkillsDir:     "~/.foo/skills",
+		ProjectSkillsSearch: []string{"../escape"},
+	}
+	if err := validateEntry("foo", e); err == nil {
+		t.Error("expected error for '..' in project_skills_search")
+	}
+}
+
+func TestValidateEntry_GlobalSearchWithoutTilde_Rejected(t *testing.T) {
+	e := agentEntry{
+		ProjectSkillsDir:   ".foo/skills",
+		GlobalSkillsDir:    "~/.foo/skills",
+		GlobalSkillsSearch: []string{"/abs/path"},
+	}
+	if err := validateEntry("foo", e); err == nil {
+		t.Error("expected error for global_skills_search entry without ~/")
+	}
+}
+
+func TestValidateEntry_PmSearchWithoutTilde_Rejected(t *testing.T) {
+	e := agentEntry{
+		ProjectSkillsDir: ".foo/skills",
+		GlobalSkillsDir:  "~/.foo/skills",
+		PmSkillsSearch:   []string{"relative/path"},
+	}
+	if err := validateEntry("foo", e); err == nil {
+		t.Error("expected error for pm_skills_search entry without ~/")
+	}
+}
+
+func TestIsAbsPath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"/absolute/path", true},
+		{`\windows\path`, true},
+		{"relative/path", false},
+		{"./relative", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		if got := isAbsPath(tc.input); got != tc.want {
+			t.Errorf("isAbsPath(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
 // ── containsDotDot ────────────────────────────────────────────────────────────
 
 func TestContainsDotDot(t *testing.T) {

--- a/internal/core/vcs/archive_test.go
+++ b/internal/core/vcs/archive_test.go
@@ -343,3 +343,91 @@ func TestVcsArchive_HasChanges_AlwaysFalse(t *testing.T) {
 		t.Error("expected HasChanges=false for archive backend")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// fetchURL — network and HTTP error paths
+// ---------------------------------------------------------------------------
+
+func TestFetchURL_NetworkError(t *testing.T) {
+	// Close the server before making the request to get a connection refused error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	_, err := fetchURL(context.Background(), url)
+	if err == nil {
+		t.Fatal("expected error for connection refused")
+	}
+}
+
+func TestFetchURL_HTTP500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	_, err := fetchURL(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractZip — corrupted data
+// ---------------------------------------------------------------------------
+
+func TestExtractZip_CorruptedData(t *testing.T) {
+	// Pass random bytes that are not a valid zip archive.
+	r := bytes.NewReader([]byte("this is not a zip file at all"))
+	err := extractZip(r, t.TempDir(), "")
+	if err == nil {
+		t.Fatal("expected error for corrupted zip data")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Clone — destination MkdirAll failure
+// ---------------------------------------------------------------------------
+
+func TestVcsArchive_Clone_MkdirAllFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permissions — skipping")
+	}
+	// Serve a valid tar so the HTTP part succeeds; the mkdir will fail first.
+	data := buildTarGz(t, map[string]string{"p/file.txt": "hi"})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer srv.Close()
+
+	// Make the parent of the destination unwritable.
+	parent := t.TempDir()
+	if err := os.Chmod(parent, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(parent, 0o755) })
+
+	a := &VcsArchive{Format: "tar"}
+	err := a.Clone(context.Background(), srv.URL, filepath.Join(parent, "dest"), "")
+	if err == nil {
+		t.Fatal("expected error when destination parent is not writable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// writeFile — MkdirAll failure
+// ---------------------------------------------------------------------------
+
+func TestWriteFile_MkdirAllFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permissions — skipping")
+	}
+	parent := t.TempDir()
+	if err := os.Chmod(parent, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(parent, 0o755) })
+
+	err := writeFile(bytes.NewReader([]byte("data")), filepath.Join(parent, "sub", "file.txt"), 0o644)
+	if err == nil {
+		t.Fatal("expected error when parent directory is not writable")
+	}
+}

--- a/internal/core/vcs/bzr_test.go
+++ b/internal/core/vcs/bzr_test.go
@@ -122,3 +122,65 @@ func TestVcsBazaar_CurrentVersion_FakeBin(t *testing.T) {
 		t.Error("expected non-empty version")
 	}
 }
+
+func TestVcsBazaar_CurrentVersion_ExecError(t *testing.T) {
+	binDir := makeFakeBin(t, "bzr", "exit 1")
+	t.Setenv("PATH", binDir)
+	b := &VcsBazaar{}
+	_, err := b.CurrentVersion(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when bzr exits with non-zero status")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VcsBazaar - HasChanges
+// ---------------------------------------------------------------------------
+
+func TestVcsBazaar_HasChanges_NoBinary(t *testing.T) {
+	t.Setenv("PATH", "")
+	b := &VcsBazaar{}
+	_, err := b.HasChanges(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when bzr binary missing")
+	}
+}
+
+func TestVcsBazaar_HasChanges_FakeBin_Clean(t *testing.T) {
+	// Empty output from bzr status → no changes.
+	binDir := makeFakeBin(t, "bzr", "exit 0")
+	t.Setenv("PATH", binDir)
+	b := &VcsBazaar{}
+	dirty, err := b.HasChanges(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("HasChanges clean: %v", err)
+	}
+	if dirty {
+		t.Error("expected HasChanges=false for empty bzr status output")
+	}
+}
+
+func TestVcsBazaar_HasChanges_FakeBin_Dirty(t *testing.T) {
+	// Non-empty output from bzr status → has changes.
+	binDir := makeFakeBin(t, "bzr", "printf 'M  file.go'")
+	t.Setenv("PATH", binDir)
+	b := &VcsBazaar{}
+	dirty, err := b.HasChanges(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("HasChanges dirty: %v", err)
+	}
+	if !dirty {
+		t.Error("expected HasChanges=true for non-empty bzr status output")
+	}
+}
+
+func TestVcsBazaar_HasChanges_ExecError(t *testing.T) {
+	// bzr exits with non-zero — must propagate as error.
+	binDir := makeFakeBin(t, "bzr", "exit 1")
+	t.Setenv("PATH", binDir)
+	b := &VcsBazaar{}
+	_, err := b.HasChanges(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when bzr status exits with non-zero status")
+	}
+}

--- a/internal/core/vcs/git_test.go
+++ b/internal/core/vcs/git_test.go
@@ -308,6 +308,20 @@ func TestVcsGit_HasChanges_NotARepo(t *testing.T) {
 	}
 }
 
+// TestVcsGit_HasChanges_BareRepo exercises the r.Worktree() error path:
+// a bare repository has no working tree, so Worktree() returns an error.
+func TestVcsGit_HasChanges_BareRepo(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := gogit.PlainInit(dir, true /* bare */); err != nil {
+		t.Fatalf("PlainInit bare: %v", err)
+	}
+	g := &VcsGit{}
+	_, err := g.HasChanges(context.Background(), dir)
+	if err == nil {
+		t.Fatal("expected error for bare repository (no working tree)")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // VcsGit - Shallow clone and hard-reset update
 // ---------------------------------------------------------------------------

--- a/internal/core/vcs/hg_test.go
+++ b/internal/core/vcs/hg_test.go
@@ -122,3 +122,62 @@ func TestVcsMercurial_CurrentVersion_FakeBin(t *testing.T) {
 		t.Error("expected non-empty version")
 	}
 }
+
+func TestVcsMercurial_CurrentVersion_ExecError(t *testing.T) {
+	binDir := makeFakeBin(t, "hg", "exit 1")
+	t.Setenv("PATH", binDir)
+	m := &VcsMercurial{}
+	_, err := m.CurrentVersion(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when hg exits with non-zero status")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VcsMercurial - HasChanges
+// ---------------------------------------------------------------------------
+
+func TestVcsMercurial_HasChanges_NoBinary(t *testing.T) {
+	t.Setenv("PATH", "")
+	m := &VcsMercurial{}
+	_, err := m.HasChanges(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when hg binary missing")
+	}
+}
+
+func TestVcsMercurial_HasChanges_FakeBin_Clean(t *testing.T) {
+	binDir := makeFakeBin(t, "hg", "exit 0")
+	t.Setenv("PATH", binDir)
+	m := &VcsMercurial{}
+	dirty, err := m.HasChanges(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("HasChanges clean: %v", err)
+	}
+	if dirty {
+		t.Error("expected HasChanges=false for empty hg status output")
+	}
+}
+
+func TestVcsMercurial_HasChanges_FakeBin_Dirty(t *testing.T) {
+	binDir := makeFakeBin(t, "hg", "printf 'M file.go'")
+	t.Setenv("PATH", binDir)
+	m := &VcsMercurial{}
+	dirty, err := m.HasChanges(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("HasChanges dirty: %v", err)
+	}
+	if !dirty {
+		t.Error("expected HasChanges=true for non-empty hg status output")
+	}
+}
+
+func TestVcsMercurial_HasChanges_ExecError(t *testing.T) {
+	binDir := makeFakeBin(t, "hg", "exit 1")
+	t.Setenv("PATH", binDir)
+	m := &VcsMercurial{}
+	_, err := m.HasChanges(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when hg status exits with non-zero status")
+	}
+}

--- a/internal/core/vcs/svn_test.go
+++ b/internal/core/vcs/svn_test.go
@@ -112,3 +112,62 @@ func TestVcsSVN_CurrentVersion_FakeBin(t *testing.T) {
 		t.Error("expected non-empty version")
 	}
 }
+
+func TestVcsSVN_CurrentVersion_ExecError(t *testing.T) {
+	binDir := makeFakeBin(t, "svnversion", "exit 1")
+	t.Setenv("PATH", binDir)
+	s := &VcsSVN{}
+	_, err := s.CurrentVersion(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when svnversion exits with non-zero status")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VcsSVN - HasChanges
+// ---------------------------------------------------------------------------
+
+func TestVcsSVN_HasChanges_NoBinary(t *testing.T) {
+	t.Setenv("PATH", "")
+	s := &VcsSVN{}
+	_, err := s.HasChanges(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when svn binary missing")
+	}
+}
+
+func TestVcsSVN_HasChanges_FakeBin_Clean(t *testing.T) {
+	binDir := makeFakeBin(t, "svn", "exit 0")
+	t.Setenv("PATH", binDir)
+	s := &VcsSVN{}
+	dirty, err := s.HasChanges(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("HasChanges clean: %v", err)
+	}
+	if dirty {
+		t.Error("expected HasChanges=false for empty svn status output")
+	}
+}
+
+func TestVcsSVN_HasChanges_FakeBin_Dirty(t *testing.T) {
+	binDir := makeFakeBin(t, "svn", "printf 'M       file.go'")
+	t.Setenv("PATH", binDir)
+	s := &VcsSVN{}
+	dirty, err := s.HasChanges(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("HasChanges dirty: %v", err)
+	}
+	if !dirty {
+		t.Error("expected HasChanges=true for non-empty svn status output")
+	}
+}
+
+func TestVcsSVN_HasChanges_ExecError(t *testing.T) {
+	binDir := makeFakeBin(t, "svn", "exit 1")
+	t.Setenv("PATH", binDir)
+	s := &VcsSVN{}
+	_, err := s.HasChanges(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when svn status exits with non-zero status")
+	}
+}

--- a/internal/core/vcs/util_test.go
+++ b/internal/core/vcs/util_test.go
@@ -57,3 +57,27 @@ func TestCmdOutput_MissingBinary(t *testing.T) {
 		t.Fatal("expected error for missing binary")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// cmdOutput — non-zero exit and context cancellation
+// ---------------------------------------------------------------------------
+
+func TestCmdOutput_NonZeroExit(t *testing.T) {
+	binDir := makeFakeBin(t, "fail-cmd", "exit 1")
+	t.Setenv("PATH", binDir)
+	_, err := cmdOutput(context.Background(), t.TempDir(), "fail-cmd")
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+}
+
+func TestCmdOutput_ContextCancelled(t *testing.T) {
+	binDir := makeFakeBin(t, "slow-cmd", "sleep 30")
+	t.Setenv("PATH", binDir)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before starting
+	_, err := cmdOutput(ctx, t.TempDir(), "slow-cmd")
+	if err == nil {
+		t.Fatal("expected error for pre-cancelled context")
+	}
+}

--- a/internal/engine/ops/doctor_test.go
+++ b/internal/engine/ops/doctor_test.go
@@ -376,3 +376,86 @@ func TestIsRemoteSource(t *testing.T) {
 		}
 	}
 }
+
+func TestDoctorMCPTargetNotExistYet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	cfg := &config.Config{
+		MCPs: []config.ConfigMcp{
+			{Name: "test-mcp", Target: filepath.Join(home, "nonexistent.json")},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Section == "mcps" && f.Severity == SeverityInfo && strings.Contains(f.Message, "will be created on sync") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected info finding about target not existing yet; findings: %+v", report.Findings)
+	}
+}
+
+func TestDoctorMCPTarget_Unreadable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permissions — skipping")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	tmp, err := os.CreateTemp(home, "mcp*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if err := os.Chmod(tmp.Name(), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(tmp.Name(), 0o644) })
+
+	cfg := &config.Config{
+		MCPs: []config.ConfigMcp{
+			{Name: "test-mcp", Target: tmp.Name()},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Section == "mcps" && f.Severity == SeverityError && strings.Contains(f.Message, "unreadable") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected error finding for unreadable MCP target; findings: %+v", report.Findings)
+	}
+}
+
+func TestDoctorSkillSources_DuplicateSource(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Skills: []config.ConfigSkill{
+			{Source: dir, Agents: []string{"claude-code"}},
+			{Source: dir, Agents: []string{"claude-code"}},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Section == "skills" && f.Severity == SeverityWarning && strings.Contains(f.Message, "duplicate") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for duplicate skill source; findings: %+v", report.Findings)
+	}
+}

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -607,3 +607,100 @@ func TestLoadServers_InvalidJSON(t *testing.T) {
 		t.Error("expected error for invalid JSON, got nil")
 	}
 }
+
+func TestLoadServers_InvalidMCPServersType(t *testing.T) {
+	// mcpServers exists but is a number, not an object.
+	f := filepath.Join(t.TempDir(), "mcp.json")
+	if err := os.WriteFile(f, []byte(`{"mcpServers": 123}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadServers(f)
+	if err == nil {
+		t.Fatal("expected error when mcpServers is not a JSON object")
+	}
+}
+
+func TestLoadServers_ReadError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permissions — skipping")
+	}
+	tmp, err := os.CreateTemp(t.TempDir(), "mcp*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if err := os.Chmod(tmp.Name(), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(tmp.Name(), 0o644) })
+
+	_, err = LoadServers(tmp.Name())
+	if err == nil {
+		t.Fatal("expected error for unreadable file")
+	}
+}
+
+func TestListServers_InvalidMCPServersType(t *testing.T) {
+	// mcpServers exists but is a number, not an object.
+	f := filepath.Join(t.TempDir(), "mcp.json")
+	if err := os.WriteFile(f, []byte(`{"mcpServers": 123}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ListServers(f)
+	if err == nil {
+		t.Fatal("expected error when mcpServers is not a JSON object")
+	}
+}
+
+func TestListServers_ReadError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permissions — skipping")
+	}
+	tmp, err := os.CreateTemp(t.TempDir(), "mcp*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if err := os.Chmod(tmp.Name(), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(tmp.Name(), 0o644) })
+
+	_, err = ListServers(tmp.Name())
+	if err == nil {
+		t.Fatal("expected error for unreadable file")
+	}
+}
+
+func TestManager_Status_ReadError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permissions — skipping")
+	}
+	tmp, err := os.CreateTemp(t.TempDir(), "mcp*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if err := os.Chmod(tmp.Name(), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(tmp.Name(), 0o644) })
+
+	mcps := []config.ConfigMcp{{Name: "srv", Target: tmp.Name()}}
+	m := NewManager(mcps)
+	statuses := m.Status(context.Background())
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	if statuses[0].Err == nil {
+		t.Error("expected error status for unreadable target file")
+	}
+}
+
+func TestFetchRemoteEntry_InvalidURL(t *testing.T) {
+	// URL with a null byte causes http.NewRequestWithContext to fail.
+	_, err := fetchRemoteEntry(context.Background(), "http://\x00invalid", "any")
+	if err == nil {
+		t.Fatal("expected error for URL with null byte")
+	}
+}

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -626,3 +626,57 @@ func TestManager_Status_CleanSkill(t *testing.T) {
 		t.Errorf("expected Modified empty for clean skill, got: %v", st.Modified)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// installSkill — error paths
+// ---------------------------------------------------------------------------
+
+func TestInstallSkill_MkdirAllFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permissions — skipping")
+	}
+	parent := t.TempDir()
+	if err := os.Chmod(parent, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(parent, 0o755) })
+
+	src := t.TempDir()
+	os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# skill"), 0o644)
+
+	err := installSkill(src, filepath.Join(parent, "new-subdir"))
+	if err == nil {
+		t.Fatal("expected error when destination parent is not writable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// copyFile — error paths
+// ---------------------------------------------------------------------------
+
+func TestCopyFile_SourceNotFound(t *testing.T) {
+	err := copyFile("/nonexistent/source/file.txt", filepath.Join(t.TempDir(), "dst.txt"))
+	if err == nil {
+		t.Fatal("expected error for missing source file")
+	}
+}
+
+func TestCopyFile_WriteError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permissions — skipping")
+	}
+	src := t.TempDir()
+	srcFile := filepath.Join(src, "file.txt")
+	os.WriteFile(srcFile, []byte("content"), 0o644)
+
+	parent := t.TempDir()
+	if err := os.Chmod(parent, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(parent, 0o755) })
+
+	err := copyFile(srcFile, filepath.Join(parent, "dst.txt"))
+	if err == nil {
+		t.Fatal("expected error when destination parent is not writable")
+	}
+}


### PR DESCRIPTION
## Summary

Adds missing error-path and edge-case tests to improve coverage across several packages.

## Changes

### `internal/core/vcs`
- **bzr / hg / svn**: `HasChanges` (NoBinary, Clean, Dirty, ExecError) + `CurrentVersion` ExecError
- **archive**: network error (closed server), HTTP 500, corrupted zip, `MkdirAll` failure, `writeFile` failure
- **util**: `cmdOutput` non-zero exit, context cancellation
- **git**: bare-repo test exercising `r.Worktree()` error path

### `internal/skill`
- `installSkill` MkdirAll failure
- `copyFile` source-not-found and write-error (chmod 000)

### `internal/mcp`
- `LoadServers` / `ListServers` / `Status`: read error and invalid type (`mcpServers: 123`)
- `fetchRemoteEntry`: invalid URL (null byte)

### `internal/engine/ops/doctor`
- MCP target not-exist-yet → SeverityInfo "will be created on sync"
- MCP target unreadable (chmod 000) → SeverityError
- Duplicate skill source → SeverityWarning

### `internal/core/agent`
- `validateEntry`: empty `project_skills_dir` without `supports_generic_project`, empty `global_skills_dir` without `supports_generic_global`, absolute/dotdot in `project_skills_search`, missing `~/` in `global_skills_search` and `pm_skills_search`
- `isAbsPath`: direct table-driven tests

## Test Results

All tests pass (`make test`). No new production code was changed.