### PR TITLE
Smoke-test release pipeline on PRs, publish only on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   lint:
     name: Lint
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
 
       - name: Lint (gofmt + go vet)
         run: make lint
@@ -39,14 +39,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ (github.event_name == 'push' || github.event_name == 'workflow_call') && fromJson('["self-hosted", "macos-latest", "windows-latest"]') || fromJson('["self-hosted", "macos-latest"]') }}
+        os: ${{ (github.event_name == 'push' || github.event_name == 'workflow_call') && fromJson('[["self-hosted","Linux","X64"], "macos-latest", "windows-latest"]') || fromJson('[["self-hosted","Linux","X64"], "macos-latest"]') }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
 
       - name: Build
         run: make build
@@ -70,14 +70,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ (github.event_name == 'push' || github.event_name == 'workflow_call') && fromJson('["self-hosted", "macos-latest", "windows-latest"]') || fromJson('["self-hosted", "macos-latest"]') }}
+        os: ${{ (github.event_name == 'push' || github.event_name == 'workflow_call') && fromJson('[["self-hosted","Linux","X64"], "macos-latest", "windows-latest"]') || fromJson('[["self-hosted","Linux","X64"], "macos-latest"]') }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
 
       - name: Run tests
         run: make test-race
@@ -87,7 +87,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   coverage:
     name: Coverage
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux, X64]
     needs: test
     steps:
       - uses: actions/checkout@v6
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
 
       - name: Generate coverage report
         run: make coverage-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ (github.event_name == 'push' || github.event_name == 'workflow_call') && fromJson('[["self-hosted","Linux","X64"], "macos-latest", "windows-latest"]') || fromJson('[["self-hosted","Linux","X64"], "macos-latest"]') }}
+        os: ${{ (github.event_name == 'push' || github.event_name == 'workflow_call') && fromJson('[["self-hosted","Linux","X64"], ["self-hosted","macOS","ARM64"], "windows-latest"]') || fromJson('[["self-hosted","Linux","X64"], ["self-hosted","macOS","ARM64"]]') }}
     steps:
       - uses: actions/checkout@v6
 
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ (github.event_name == 'push' || github.event_name == 'workflow_call') && fromJson('[["self-hosted","Linux","X64"], "macos-latest", "windows-latest"]') || fromJson('[["self-hosted","Linux","X64"], "macos-latest"]') }}
+        os: ${{ (github.event_name == 'push' || github.event_name == 'workflow_call') && fromJson('[["self-hosted","Linux","X64"], ["self-hosted","macOS","ARM64"], "windows-latest"]') || fromJson('[["self-hosted","Linux","X64"], ["self-hosted","macOS","ARM64"]]') }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,14 @@
 name: Release
 
-# Triggered only on semver release tags (e.g. v0.1.0, v1.2.3).
-# Can also be triggered manually for testing.
+# Triggered on:
+#   - semver release tags (v0.1.0, v1.2.3) → builds + publishes GitHub Release
+#   - pull requests → smoke-tests the release pipeline (no publishing)
+#   - workflow_dispatch → manual run from any branch (no publishing unless tagged)
 on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -13,10 +16,12 @@ permissions:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────────────
-  # Reuse the full CI workflow: lint + build (3 OS) + test (3 OS) + coverage
+  # Reuse the full CI workflow: lint + build (3 OS) + test (3 OS) + coverage.
+  # Skipped on pull_request because ci.yml already runs standalone on PRs.
   # ──────────────────────────────────────────────────────────────────────────
   ci:
     name: CI
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
@@ -24,21 +29,23 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   # Cross-compile release binaries for all supported platforms / architectures.
   # Darwin builds run on macOS for code signing and notarization.
+  # Runs even when `ci` is skipped (PR runs) so the release pipeline is exercised.
   # ──────────────────────────────────────────────────────────────────────────
   binaries:
     name: Binary / ${{ matrix.goos }}-${{ matrix.goarch }}
     runs-on: ${{ matrix.runner }}
     needs: ci
+    if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { goos: linux,   goarch: amd64, runner: self-hosted }
-          - { goos: linux,   goarch: arm64, runner: self-hosted }
-          - { goos: darwin,  goarch: amd64, runner: macos-latest }
-          - { goos: darwin,  goarch: arm64, runner: macos-latest }
-          - { goos: windows, goarch: amd64, runner: self-hosted, ext: .exe }
-          - { goos: windows, goarch: arm64, runner: self-hosted, ext: .exe }
+          - { goos: linux,   goarch: amd64, runner: [self-hosted, Linux, X64] }
+          - { goos: linux,   goarch: arm64, runner: [self-hosted, Linux, X64] }
+          - { goos: darwin,  goarch: amd64, runner: [self-hosted, macOS, ARM64] }
+          - { goos: darwin,  goarch: arm64, runner: [self-hosted, macOS, ARM64] }
+          - { goos: windows, goarch: amd64, runner: [self-hosted, Linux, X64], ext: .exe }
+          - { goos: windows, goarch: arm64, runner: [self-hosted, Linux, X64], ext: .exe }
     steps:
       - uses: actions/checkout@v6
 
@@ -148,11 +155,14 @@ jobs:
           if-no-files-found: error
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Create the GitHub Release and attach all compiled binaries + checksums
+  # Create the GitHub Release and attach all compiled binaries + checksums.
+  # Only runs on semver tag pushes — PRs and manual dispatches build artifacts
+  # but do not publish.
   # ──────────────────────────────────────────────────────────────────────────
   release:
     name: Create Release
-    runs-on: self-hosted
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: [self-hosted, Linux, X64]
     needs: binaries
     steps:
       - uses: actions/download-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,13 +121,16 @@ jobs:
             -o "$API_KEY_JSON" \
             "$API_ISSUER" "$API_KEY_ID" "$API_KEY_FILE"
 
-          # Notarize. --staple is omitted because Mach-O binaries cannot be
-          # stapled (only .app/.dmg/.pkg can). Apple's notary service still
-          # records the notarization, and Gatekeeper checks online.
+          # Apple's notary service requires a wrapped artifact (.zip/.dmg/.pkg/.app),
+          # not a raw Mach-O. Use ditto (not plain zip) to produce an archive
+          # that Apple's notarizer accepts. --staple is omitted because Mach-O
+          # binaries cannot be stapled — Gatekeeper checks notarization online.
+          ditto -c -k --keepParent "$BINARY" "$BINARY.zip"
           "$RUNNER_TEMP/rcodesign" notary-submit \
             --api-key-file "$API_KEY_JSON" \
             --wait \
-            "$BINARY"
+            "$BINARY.zip"
+          rm "$BINARY.zip"
 
       - name: Verify signature
         if: matrix.goos == 'darwin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,17 @@ jobs:
         run: |
           echo "=== Search list ==="
           security list-keychains -d user
-          echo "=== All codesigning identities ==="
-          security find-identity -v -p codesigning
-          echo "=== All identities (any policy) ==="
-          security find-identity -v
-          IDENTITY=$(security find-identity -v -p codesigning \
+          echo "=== Certs in signing_temp keychain (PEM) ==="
+          security find-certificate -a -p signing_temp.keychain || echo "(none)"
+          echo "=== Certs in signing_temp keychain (subject only) ==="
+          security find-certificate -a signing_temp.keychain 2>&1 | grep -E '"labl"|"subj"' || echo "(none)"
+          echo "=== All identities (find-identity, no -v) ==="
+          security find-identity signing_temp.keychain
+          echo "=== All identities (find-identity -v) ==="
+          security find-identity -v signing_temp.keychain
+          echo "=== All codesigning identities (-v -p codesigning) ==="
+          security find-identity -v -p codesigning signing_temp.keychain
+          IDENTITY=$(security find-identity -v -p codesigning signing_temp.keychain \
             | grep "Developer ID Application" | head -1 \
             | sed 's/.*"\(.*\)"/\1/')
           if [ -z "$IDENTITY" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,22 @@ jobs:
 
       # ── macOS code signing & notarization ──────────────────────────────────
 
+      - name: Debug — verify .p12 secret integrity
+        if: matrix.goos == 'darwin'
+        env:
+          CERTIFICATE_P12: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
+        run: |
+          echo "$CERTIFICATE_P12" | base64 --decode > "$RUNNER_TEMP/debug.p12"
+          echo "=== file info ==="
+          ls -la "$RUNNER_TEMP/debug.p12"
+          echo "=== sha256 ==="
+          shasum -a 256 "$RUNNER_TEMP/debug.p12"
+          echo "=== file type ==="
+          file "$RUNNER_TEMP/debug.p12"
+          echo "=== openssl info ==="
+          openssl pkcs12 -in "$RUNNER_TEMP/debug.p12" -nodes -info -passin "pass:${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}" -legacy 2>&1 | grep -E "BEGIN|subject=|Bag|Encrypted" || true
+          rm "$RUNNER_TEMP/debug.p12"
+
       - name: Import Apple certificate
         if: matrix.goos == 'darwin'
         uses: apple-actions/import-codesign-certs@a22d0cee6aef91737ec4f75a776ad460774970ea  # v6.0.0
@@ -75,6 +91,12 @@ jobs:
       - name: Resolve signing identity
         if: matrix.goos == 'darwin'
         run: |
+          echo "=== Search list ==="
+          security list-keychains -d user
+          echo "=== All codesigning identities ==="
+          security find-identity -v -p codesigning
+          echo "=== All identities (any policy) ==="
+          security find-identity -v
           IDENTITY=$(security find-identity -v -p codesigning \
             | grep "Developer ID Application" | head -1 \
             | sed 's/.*"\(.*\)"/\1/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,29 +88,40 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
 
-      - name: Install Apple Developer ID CA chain
+      - name: Install Apple Developer ID intermediate CA
         if: matrix.goos == 'darwin'
         run: |
-          # The Developer ID Application leaf cert needs both the G2
-          # intermediate AND the Apple Root CA to build a trusted chain.
-          # GitHub-hosted macOS runners ship them; a fresh self-hosted Mac
-          # may not have them in a keychain codesign consults.
+          # The Developer ID Application leaf cert is signed by the
+          # "Developer ID Certification Authority G2" intermediate, which
+          # in turn chains to Apple Root CA (already trusted in the system
+          # keychain). We install only the intermediate here; the root is
+          # picked up from the system keychain via the search list step below.
           # See https://www.apple.com/certificateauthority/
           curl -fsSL -o "$RUNNER_TEMP/DeveloperIDG2CA.cer" \
             https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
-          curl -fsSL -o "$RUNNER_TEMP/AppleIncRootCertificate.cer" \
-            https://www.apple.com/appleca/AppleIncRootCertificate.cer
+          SUBJECT=$(openssl x509 -in "$RUNNER_TEMP/DeveloperIDG2CA.cer" -inform DER -noout -subject)
+          echo "Installing: $SUBJECT"
+          if ! echo "$SUBJECT" | grep -q "Apple Inc"; then
+            echo "::error::Downloaded intermediate is not from Apple Inc"
+            exit 1
+          fi
+          security import "$RUNNER_TEMP/DeveloperIDG2CA.cer" -k signing_temp.keychain
+          rm "$RUNNER_TEMP/DeveloperIDG2CA.cer"
 
-          for CER in "$RUNNER_TEMP/DeveloperIDG2CA.cer" "$RUNNER_TEMP/AppleIncRootCertificate.cer"; do
-            SUBJECT=$(openssl x509 -in "$CER" -inform DER -noout -subject)
-            echo "Installing: $SUBJECT"
-            if ! echo "$SUBJECT" | grep -q "Apple Inc"; then
-              echo "::error::$CER is not from Apple Inc"
-              exit 1
-            fi
-            security import "$CER" -k signing_temp.keychain
-          done
-          rm "$RUNNER_TEMP/DeveloperIDG2CA.cer" "$RUNNER_TEMP/AppleIncRootCertificate.cer"
+      - name: Extend keychain search list with system roots
+        if: matrix.goos == 'darwin'
+        run: |
+          # apple-actions/import-codesign-certs sets the user search list to
+          # ONLY [signing_temp.keychain, login.keychain], dropping the system
+          # roots keychain. Without it, codesign cannot reach Apple Root CA
+          # to validate the chain. Re-add it explicitly.
+          security list-keychains -d user -s \
+            "$HOME/Library/Keychains/signing_temp.keychain-db" \
+            "$HOME/Library/Keychains/login.keychain-db" \
+            "/Library/Keychains/System.keychain" \
+            "/System/Library/Keychains/SystemRootCertificates.keychain"
+          echo "=== Updated user search list ==="
+          security list-keychains -d user
 
       - name: Resolve signing identity
         if: matrix.goos == 'darwin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,121 +63,71 @@ jobs:
           make build-cross
           BIN_CROSS=dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
 
-      # ── macOS code signing & notarization ──────────────────────────────────
+      # ── macOS code signing & notarization (rcodesign) ─────────────────────
+      #
+      # We use rcodesign (https://github.com/indygreg/apple-platform-rs)
+      # instead of Apple's `codesign` + `notarytool` because rcodesign reads
+      # the .p12 directly from a file and validates the cert chain itself —
+      # no macOS keychain manipulation, no `add-trusted-cert` UI prompts, no
+      # persistent state on the runner. Works on any Mac runner.
 
-      - name: Debug — verify .p12 secret integrity
+      - name: Install rcodesign
         if: matrix.goos == 'darwin'
         env:
-          CERTIFICATE_P12: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
+          RCODESIGN_VERSION: "0.29.0"
+          RCODESIGN_SHA256: "d1a532150adaf90048260d76359261aa716abafc45c53c5dc18845029184334a"
         run: |
-          echo "$CERTIFICATE_P12" | base64 --decode > "$RUNNER_TEMP/debug.p12"
-          echo "=== file info ==="
-          ls -la "$RUNNER_TEMP/debug.p12"
-          echo "=== sha256 ==="
-          shasum -a 256 "$RUNNER_TEMP/debug.p12"
-          echo "=== file type ==="
-          file "$RUNNER_TEMP/debug.p12"
-          echo "=== openssl info ==="
-          openssl pkcs12 -in "$RUNNER_TEMP/debug.p12" -nodes -info -passin "pass:${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}" -legacy 2>&1 | grep -E "BEGIN|subject=|Bag|Encrypted" || true
-          rm "$RUNNER_TEMP/debug.p12"
+          # Self-hosted runner is aarch64 regardless of $GOARCH (we cross-compile).
+          ARCHIVE="apple-codesign-${RCODESIGN_VERSION}-aarch64-apple-darwin.tar.gz"
+          curl -fsSL -o "$RUNNER_TEMP/$ARCHIVE" \
+            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${ARCHIVE}"
 
-      - name: Import Apple certificate
-        if: matrix.goos == 'darwin'
-        uses: apple-actions/import-codesign-certs@a22d0cee6aef91737ec4f75a776ad460774970ea  # v6.0.0
-        with:
-          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
-          p12-password: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
-
-      - name: Install Apple Developer ID CA chain + trust root
-        if: matrix.goos == 'darwin'
-        run: |
-          # The Developer ID Application leaf cert needs:
-          #   1. The G2 intermediate ("Developer ID Certification Authority")
-          #   2. Apple Root CA marked as a trusted root for code signing
-          # On a fresh self-hosted Mac, codesign's trust evaluation doesn't
-          # fully inherit the system trust store, so we explicitly install
-          # both certs into signing_temp.keychain and add Apple Root CA to
-          # the user trust domain (no sudo / UI required for user domain).
-          # See https://www.apple.com/certificateauthority/
-          curl -fsSL -o "$RUNNER_TEMP/DeveloperIDG2CA.cer" \
-            https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
-          curl -fsSL -o "$RUNNER_TEMP/AppleIncRootCertificate.cer" \
-            https://www.apple.com/appleca/AppleIncRootCertificate.cer
-
-          for CER in "$RUNNER_TEMP/DeveloperIDG2CA.cer" "$RUNNER_TEMP/AppleIncRootCertificate.cer"; do
-            SUBJECT=$(openssl x509 -in "$CER" -inform DER -noout -subject)
-            echo "Installing: $SUBJECT"
-            if ! echo "$SUBJECT" | grep -q "Apple Inc"; then
-              echo "::error::$CER is not from Apple Inc"
-              exit 1
-            fi
-            security import "$CER" -k signing_temp.keychain
-          done
-
-          # Mark Apple Root CA as a trusted root in the user trust domain.
-          # Without -d (admin), this targets the user trust domain and runs
-          # non-interactively without sudo.
-          security add-trusted-cert -r trustRoot \
-            -k "$HOME/Library/Keychains/signing_temp.keychain-db" \
-            "$RUNNER_TEMP/AppleIncRootCertificate.cer"
-
-          rm "$RUNNER_TEMP/DeveloperIDG2CA.cer" "$RUNNER_TEMP/AppleIncRootCertificate.cer"
-
-      - name: Resolve signing identity
-        if: matrix.goos == 'darwin'
-        run: |
-          echo "=== Search list ==="
-          security list-keychains -d user
-          echo "=== Certs in signing_temp keychain (PEM) ==="
-          security find-certificate -a -p signing_temp.keychain || echo "(none)"
-          echo "=== Certs in signing_temp keychain (subject only) ==="
-          security find-certificate -a signing_temp.keychain 2>&1 | grep -E '"labl"|"subj"' || echo "(none)"
-          echo "=== All identities (find-identity, no -v) ==="
-          security find-identity signing_temp.keychain
-          echo "=== All identities (find-identity -v) ==="
-          security find-identity -v signing_temp.keychain
-          echo "=== All codesigning identities (-v -p codesigning) ==="
-          security find-identity -v -p codesigning signing_temp.keychain
-          IDENTITY=$(security find-identity -v -p codesigning signing_temp.keychain \
-            | grep "Developer ID Application" | head -1 \
-            | sed 's/.*"\(.*\)"/\1/')
-          if [ -z "$IDENTITY" ]; then
-            echo "::error::No Developer ID Application identity found in keychain"
+          ACTUAL=$(shasum -a 256 "$RUNNER_TEMP/$ARCHIVE" | awk '{print $1}')
+          if [ "$RCODESIGN_SHA256" != "$ACTUAL" ]; then
+            echo "::error::rcodesign SHA256 mismatch (expected $RCODESIGN_SHA256, got $ACTUAL)"
             exit 1
           fi
-          echo "Found identity: $IDENTITY"
-          echo "CODESIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
 
-      - name: Codesign binary
-        if: matrix.goos == 'darwin'
-        run: |
-          codesign --force --options runtime \
-            --sign "$CODESIGN_IDENTITY" \
-            --timestamp \
-            dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}
+          tar -xzf "$RUNNER_TEMP/$ARCHIVE" -C "$RUNNER_TEMP" --strip-components=1
+          "$RUNNER_TEMP/rcodesign" --version
 
-      - name: Notarize binary
+      - name: Sign and notarize binary
         if: matrix.goos == 'darwin'
         env:
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
+          P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          API_KEY: ${{ secrets.APPLE_API_KEY }}
+          API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: |
           BINARY="dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}"
+          P12="$RUNNER_TEMP/cert.p12"
+          API_KEY_FILE="$RUNNER_TEMP/AuthKey.p8"
+          API_KEY_JSON="$RUNNER_TEMP/api-key.json"
+          trap 'rm -f "$P12" "$API_KEY_FILE" "$API_KEY_JSON"' EXIT
 
-          # notarytool requires a zip/dmg/pkg — not a raw Mach-O
-          # ditto is required; plain zip produces archives Apple rejects
-          ditto -c -k --keepParent "$BINARY" "${BINARY}.zip"
+          echo "$P12_BASE64" | base64 --decode > "$P12"
+          echo "$API_KEY"     > "$API_KEY_FILE"
 
-          echo "$APPLE_API_KEY" > /tmp/AuthKey.p8
+          # Codesign with hardened runtime (required for notarization)
+          "$RUNNER_TEMP/rcodesign" sign \
+            --p12-file "$P12" \
+            --p12-password "$P12_PASSWORD" \
+            --code-signature-flags runtime \
+            "$BINARY"
 
-          xcrun notarytool submit "${BINARY}.zip" \
-            --key /tmp/AuthKey.p8 \
-            --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER" \
-            --wait --timeout 10m
+          # Encode the App Store Connect API key as the JSON form rcodesign expects
+          "$RUNNER_TEMP/rcodesign" encode-app-store-connect-api-key \
+            -o "$API_KEY_JSON" \
+            "$API_ISSUER" "$API_KEY_ID" "$API_KEY_FILE"
 
-          rm -f /tmp/AuthKey.p8 "${BINARY}.zip"
+          # Notarize. --staple is omitted because Mach-O binaries cannot be
+          # stapled (only .app/.dmg/.pkg can). Apple's notary service still
+          # records the notarization, and Gatekeeper checks online.
+          "$RUNNER_TEMP/rcodesign" notary-submit \
+            --api-key-file "$API_KEY_JSON" \
+            --wait \
+            "$BINARY"
 
       - name: Verify signature
         if: matrix.goos == 'darwin'
@@ -186,8 +136,6 @@ jobs:
             dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}
           # Show signing details for CI logs
           codesign -dvv dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}
-
-      # Keychain cleanup is handled by the import-codesign-certs action's post step.
 
       # ── Upload artifact ────────────────────────────────────────────────────
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,23 +88,29 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
 
-      - name: Install Apple Developer ID intermediate CA
+      - name: Install Apple Developer ID CA chain
         if: matrix.goos == 'darwin'
         run: |
-          # The Developer ID Application leaf cert requires the
-          # "Developer ID Certification Authority G2" intermediate to build
-          # a trusted chain. GitHub-hosted runners ship it; fresh self-hosted
-          # Macs may not. See https://www.apple.com/certificateauthority/
+          # The Developer ID Application leaf cert needs both the G2
+          # intermediate AND the Apple Root CA to build a trusted chain.
+          # GitHub-hosted macOS runners ship them; a fresh self-hosted Mac
+          # may not have them in a keychain codesign consults.
+          # See https://www.apple.com/certificateauthority/
           curl -fsSL -o "$RUNNER_TEMP/DeveloperIDG2CA.cer" \
             https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
-          SUBJECT=$(openssl x509 -in "$RUNNER_TEMP/DeveloperIDG2CA.cer" -inform DER -noout -subject)
-          echo "Downloaded intermediate: $SUBJECT"
-          if ! echo "$SUBJECT" | grep -q "Apple Inc"; then
-            echo "::error::Downloaded intermediate is not from Apple Inc"
-            exit 1
-          fi
-          security import "$RUNNER_TEMP/DeveloperIDG2CA.cer" -k signing_temp.keychain
-          rm "$RUNNER_TEMP/DeveloperIDG2CA.cer"
+          curl -fsSL -o "$RUNNER_TEMP/AppleIncRootCertificate.cer" \
+            https://www.apple.com/appleca/AppleIncRootCertificate.cer
+
+          for CER in "$RUNNER_TEMP/DeveloperIDG2CA.cer" "$RUNNER_TEMP/AppleIncRootCertificate.cer"; do
+            SUBJECT=$(openssl x509 -in "$CER" -inform DER -noout -subject)
+            echo "Installing: $SUBJECT"
+            if ! echo "$SUBJECT" | grep -q "Apple Inc"; then
+              echo "::error::$CER is not from Apple Inc"
+              exit 1
+            fi
+            security import "$CER" -k signing_temp.keychain
+          done
+          rm "$RUNNER_TEMP/DeveloperIDG2CA.cer" "$RUNNER_TEMP/AppleIncRootCertificate.cer"
 
       - name: Resolve signing identity
         if: matrix.goos == 'darwin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,14 @@ jobs:
       # the .p12 directly from a file and validates the cert chain itself —
       # no macOS keychain manipulation, no `add-trusted-cert` UI prompts, no
       # persistent state on the runner. Works on any Mac runner.
+      #
+      # Sign + notarize only run on semver tag pushes (actual releases),
+      # because Apple notarization adds 30-90s of waiting per binary and
+      # isn't needed for PR smoke tests. PRs still cross-compile the darwin
+      # binary so we catch build regressions, just unsigned.
 
       - name: Install rcodesign
-        if: matrix.goos == 'darwin'
+        if: matrix.goos == 'darwin' && startsWith(github.ref, 'refs/tags/v')
         env:
           RCODESIGN_VERSION: "0.29.0"
           RCODESIGN_SHA256: "d1a532150adaf90048260d76359261aa716abafc45c53c5dc18845029184334a"
@@ -92,7 +97,7 @@ jobs:
           "$RUNNER_TEMP/rcodesign" --version
 
       - name: Sign and notarize binary
-        if: matrix.goos == 'darwin'
+        if: matrix.goos == 'darwin' && startsWith(github.ref, 'refs/tags/v')
         env:
           P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
           P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
@@ -133,7 +138,7 @@ jobs:
           rm "$BINARY.zip"
 
       - name: Verify signature
-        if: matrix.goos == 'darwin'
+        if: matrix.goos == 'darwin' && startsWith(github.ref, 'refs/tags/v')
         run: |
           codesign --verify --deep --strict --verbose=2 \
             dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,24 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
 
+      - name: Install Apple Developer ID intermediate CA
+        if: matrix.goos == 'darwin'
+        run: |
+          # The Developer ID Application leaf cert requires the
+          # "Developer ID Certification Authority G2" intermediate to build
+          # a trusted chain. GitHub-hosted runners ship it; fresh self-hosted
+          # Macs may not. See https://www.apple.com/certificateauthority/
+          curl -fsSL -o "$RUNNER_TEMP/DeveloperIDG2CA.cer" \
+            https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
+          SUBJECT=$(openssl x509 -in "$RUNNER_TEMP/DeveloperIDG2CA.cer" -inform DER -noout -subject)
+          echo "Downloaded intermediate: $SUBJECT"
+          if ! echo "$SUBJECT" | grep -q "Apple Inc"; then
+            echo "::error::Downloaded intermediate is not from Apple Inc"
+            exit 1
+          fi
+          security import "$RUNNER_TEMP/DeveloperIDG2CA.cer" -k signing_temp.keychain
+          rm "$RUNNER_TEMP/DeveloperIDG2CA.cer"
+
       - name: Resolve signing identity
         if: matrix.goos == 'darwin'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
 
       - name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,32 +67,15 @@ jobs:
 
       - name: Import Apple certificate
         if: matrix.goos == 'darwin'
-        env:
-          CERTIFICATE_P12: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
-          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+        uses: apple-actions/import-codesign-certs@a22d0cee6aef91737ec4f75a776ad460774970ea  # v6.0.0
+        with:
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+
+      - name: Resolve signing identity
+        if: matrix.goos == 'darwin'
         run: |
-          KEYCHAIN="build.keychain"
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security set-keychain-settings -t 3600 "$KEYCHAIN"
-
-          # Add build keychain to search list while keeping the login keychain
-          # (which contains Apple's intermediate certificates needed for a valid chain)
-          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
-
-          echo "$CERTIFICATE_P12" | base64 --decode > /tmp/cert.p12
-          security import /tmp/cert.p12 -k "$KEYCHAIN" \
-            -P "$CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign
-          rm /tmp/cert.p12
-
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-
-          # Resolve the full signing identity from the imported certificate
-          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" \
+          IDENTITY=$(security find-identity -v -p codesigning \
             | grep "Developer ID Application" | head -1 \
             | sed 's/.*"\(.*\)"/\1/')
           if [ -z "$IDENTITY" ]; then
@@ -101,7 +84,6 @@ jobs:
           fi
           echo "Found identity: $IDENTITY"
           echo "CODESIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
-          echo "BUILD_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
 
       - name: Codesign binary
         if: matrix.goos == 'darwin'
@@ -142,9 +124,7 @@ jobs:
           # Show signing details for CI logs
           codesign -dvv dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}
 
-      - name: Clean up keychain
-        if: matrix.goos == 'darwin' && always()
-        run: security delete-keychain "$BUILD_KEYCHAIN" 2>/dev/null || true
+      # Keychain cleanup is handled by the import-codesign-certs action's post step.
 
       # ── Upload artifact ────────────────────────────────────────────────────
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,40 +88,40 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
 
-      - name: Install Apple Developer ID intermediate CA
+      - name: Install Apple Developer ID CA chain + trust root
         if: matrix.goos == 'darwin'
         run: |
-          # The Developer ID Application leaf cert is signed by the
-          # "Developer ID Certification Authority G2" intermediate, which
-          # in turn chains to Apple Root CA (already trusted in the system
-          # keychain). We install only the intermediate here; the root is
-          # picked up from the system keychain via the search list step below.
+          # The Developer ID Application leaf cert needs:
+          #   1. The G2 intermediate ("Developer ID Certification Authority")
+          #   2. Apple Root CA marked as a trusted root for code signing
+          # On a fresh self-hosted Mac, codesign's trust evaluation doesn't
+          # fully inherit the system trust store, so we explicitly install
+          # both certs into signing_temp.keychain and add Apple Root CA to
+          # the user trust domain (no sudo / UI required for user domain).
           # See https://www.apple.com/certificateauthority/
           curl -fsSL -o "$RUNNER_TEMP/DeveloperIDG2CA.cer" \
             https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
-          SUBJECT=$(openssl x509 -in "$RUNNER_TEMP/DeveloperIDG2CA.cer" -inform DER -noout -subject)
-          echo "Installing: $SUBJECT"
-          if ! echo "$SUBJECT" | grep -q "Apple Inc"; then
-            echo "::error::Downloaded intermediate is not from Apple Inc"
-            exit 1
-          fi
-          security import "$RUNNER_TEMP/DeveloperIDG2CA.cer" -k signing_temp.keychain
-          rm "$RUNNER_TEMP/DeveloperIDG2CA.cer"
+          curl -fsSL -o "$RUNNER_TEMP/AppleIncRootCertificate.cer" \
+            https://www.apple.com/appleca/AppleIncRootCertificate.cer
 
-      - name: Extend keychain search list with system roots
-        if: matrix.goos == 'darwin'
-        run: |
-          # apple-actions/import-codesign-certs sets the user search list to
-          # ONLY [signing_temp.keychain, login.keychain], dropping the system
-          # roots keychain. Without it, codesign cannot reach Apple Root CA
-          # to validate the chain. Re-add it explicitly.
-          security list-keychains -d user -s \
-            "$HOME/Library/Keychains/signing_temp.keychain-db" \
-            "$HOME/Library/Keychains/login.keychain-db" \
-            "/Library/Keychains/System.keychain" \
-            "/System/Library/Keychains/SystemRootCertificates.keychain"
-          echo "=== Updated user search list ==="
-          security list-keychains -d user
+          for CER in "$RUNNER_TEMP/DeveloperIDG2CA.cer" "$RUNNER_TEMP/AppleIncRootCertificate.cer"; do
+            SUBJECT=$(openssl x509 -in "$CER" -inform DER -noout -subject)
+            echo "Installing: $SUBJECT"
+            if ! echo "$SUBJECT" | grep -q "Apple Inc"; then
+              echo "::error::$CER is not from Apple Inc"
+              exit 1
+            fi
+            security import "$CER" -k signing_temp.keychain
+          done
+
+          # Mark Apple Root CA as a trusted root in the user trust domain.
+          # Without -d (admin), this targets the user trust domain and runs
+          # non-interactively without sudo.
+          security add-trusted-cert -r trustRoot \
+            -k "$HOME/Library/Keychains/signing_temp.keychain-db" \
+            "$RUNNER_TEMP/AppleIncRootCertificate.cer"
+
+          rm "$RUNNER_TEMP/DeveloperIDG2CA.cer" "$RUNNER_TEMP/AppleIncRootCertificate.cer"
 
       - name: Resolve signing identity
         if: matrix.goos == 'darwin'

--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,11 @@ coverage-ci:
 ## build-cross: cross-compile for a target platform
 ##   Override GOOS, GOARCH and optionally BIN_CROSS, e.g.:
 ##   make build-cross GOOS=linux GOARCH=arm64
+##   Note: does not run the binary post-build (the schema target is dev-only
+##   and would fail when the host can't execute the cross-compiled output).
 build-cross:
 	@mkdir -p dist
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -trimpath $(LDFLAGS_R) -o $(BIN_CROSS) .
-	$(BIN_CROSS) schema -f $(DIST_DIR)/schema.json
 
 ## clean: remove build artefacts
 clean:


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to release workflow so cross-compile, codesign, and notarization run on every PR (smoke test)
- Skip the redundant CI job on PRs since `ci.yml` already runs standalone
- Gate the publish step on semver tag pushes only — PRs and manual dispatches build artifacts but don't publish
- Use explicit runner labels (`[self-hosted, Linux, X64]` and `[self-hosted, macOS, ARM64]`) to route jobs to the correct self-hosted runner

## Trigger matrix
| Trigger | ci job | binaries job | release job |
|---|---|---|---|
| push tag `v*` | runs | runs | **publishes** |
| pull_request | skipped | runs | skipped |
| workflow_dispatch | runs | runs | only on tag ref |

## Test plan
- [ ] This PR itself should trigger the release workflow and run binaries (no publish)
- [ ] Verify darwin builds land on the macOS ARM64 self-hosted runner
- [ ] Verify linux/windows cross-compiles land on the VPS Linux runner
- [ ] Confirm the `release` job is skipped for this PR
- [ ] Next semver tag push should publish a GitHub Release as before