### PR TITLE
feat: FS-aware resource discovery, unmanaged detection and sync --prune

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -19,6 +19,7 @@ var (
 	service  bool
 	interval time.Duration
 	dryRun   bool
+	prune    bool
 )
 
 var syncCmd = &cobra.Command{
@@ -38,12 +39,16 @@ func init() {
 	syncCmd.Flags().BoolVarP(&service, "service", "s", false, "run as a continuous service (daemon mode)")
 	syncCmd.Flags().DurationVarP(&interval, "interval", "i", 5*time.Minute, "polling interval in service mode")
 	syncCmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview what sync would do without writing anything")
+	syncCmd.Flags().BoolVar(&prune, "prune", false, "remove skills and MCP entries no longer declared in config")
 	rootCmd.AddCommand(syncCmd)
 }
 
 func runSync(_ *cobra.Command, _ []string) error {
 	if dryRun && service {
 		return fmt.Errorf("--dry-run and --service are incompatible: a dry-run service loop is meaningless")
+	}
+	if prune && service {
+		return fmt.Errorf("--prune and --service are incompatible: use one-shot mode for destructive operations")
 	}
 
 	cfg := resolvedCfg
@@ -81,6 +86,13 @@ func runSync(_ *cobra.Command, _ []string) error {
 	if err := eng.RunOnce(ctx); err != nil {
 		telemetry.TrackError("sync", err)
 		return err
+	}
+	if prune {
+		slog.Info("pruning orphan resources")
+		if err := eng.Prune(ctx); err != nil {
+			telemetry.TrackError("sync-prune", err)
+			return err
+		}
 	}
 	telemetry.Track("sync")
 	telemetry.TrackFirstSync(0)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ gaal/
     ├── core/                  # Shared foundational packages
     │   ├── agent/             # Agent registry (YAML-driven)
     │   └── vcs/               # VCS backends (one file per backend)
+    ├── discover/              # FS-first resource discovery + Git-inspired snapshot index
     ├── engine/                # Central orchestrator — sequences the three managers
     │   ├── ops/               # Command operations (audit, info, init, status)
     │   └── render/            # Output types and renderers (table, JSON)
@@ -157,6 +158,25 @@ The two pillars exposed to the rest of the codebase:
 
 ---
 
+## Package `internal/discover`
+
+> The complete reference for the discovery system — resource model, snapshot lifecycle, drift detection algorithm, scan options, and per-resource-type scan logic — lives in [**docs/discover.md**](discover.md).
+
+Key responsibilities:
+
+| File | Description |
+|------|-------------|
+| `resource.go` | `ResourceType`, `Scope`, `DriftState`, `Resource` |
+| `snapshot.go` | `FileRecord`, `Snapshot`, `Load/Save`, `Record`, `DiffPath`, `SnapshotPath`, `WorkdirKey` |
+| `scan.go` | `ScanOptions`, public entry point `Scan(ctx, home, workDir, opts)` |
+| `global.go` | Scan agent-registry skill directories (global + user scope) |
+| `workspace.go` | Depth-limited FS walk for repos and skills in `workDir` |
+| `mcp.go` | Scan agent MCP config files; hash-based drift via snapshot |
+
+The drift detection follows the Git index fast-path: `stat()` → size+mtime match → unchanged; mismatch → sha256 → if hash matches, update mtime only (racy-git repair). VCS-native detection (`vcs.HasChanges`) is tried first for directories tracked by a VCS.
+
+---
+
 ## Package `internal/engine`
 
 The **single coupling point** between the configuration and the three resource managers. The engine holds no business logic of its own — it delegates every command operation to `engine/ops` and every rendering concern to `engine/render`.
@@ -192,7 +212,8 @@ Stateless functions that implement each CLI command. Each function receives the 
 
 | File | Exported symbols | Description |
 |------|-----------------|-------------|
-| `status.go` | `Collect()`, `Status()` | Gather resource state and render to stdout |
+| `status.go` | `Collect()`, `Status()` | FS-first resource state via `discover.Scan` — reconciles config-declared (managed) and FS-discovered (unmanaged) resources |
+| `plan.go` | `SyncPlan()`, `RenderPlan()` | Compute sync plan without writing |
 | `audit.go` | `Audit()` | Discover all installed skills and MCP servers |
 | `info.go` | `Info()` | Detailed per-entry card rendering |
 | `init.go` | `Init()`, `InitTemplate` | Write the config file skeleton to disk |

--- a/docs/discover.md
+++ b/docs/discover.md
@@ -1,0 +1,202 @@
+# FS-aware Discovery — `internal/discover`
+
+## Overview
+
+`internal/discover` provides **configuration-independent** resource discovery: it scans the filesystem to find skills, repositories, and MCP configuration files that are actually installed on the machine, regardless of whether they appear in `gaal.yaml`. This powers the Git-inspired drift detection used by `gaal status` and `gaal info`.
+
+The design follows two principles:
+
+1. **FS-first**: discovered resources are the ground truth; config-declared resources are reconciled on top.
+2. **Git index fast path**: `stat()` → size+mtime match → no change; mismatch → sha256 comparison → if hash matches, update mtime only (racy-git repair). VCS-native detection (`vcs.HasChanges`) is used first for directories tracked by a VCS.
+
+---
+
+## Resource Model
+
+### `ResourceType`
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `ResourceSkill` | `"skill"` | A skill directory (contains `SKILL.md`) |
+| `ResourceRepo` | `"repo"` | A VCS-tracked repository |
+| `ResourceMCP` | `"mcp"` | An MCP JSON configuration file |
+
+### `Scope`
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `ScopeGlobal` | `"global"` | Installed in a global agent directory (e.g. `~/.claude/skills/`) |
+| `ScopeUser` | `"user"` | Installed in a user agent directory (e.g. `~/.config/claude/skills/`) |
+| `ScopeWorkspace` | `"workspace"` | Discovered inside the current working directory |
+
+### `DriftState`
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `DriftOK` | `"ok"` | Resource matches its last-synced snapshot |
+| `DriftModified` | `"modified"` | Resource has changed since last sync |
+| `DriftMissing` | `"missing"` | Resource was recorded in a snapshot but is no longer present |
+| `DriftUnmanaged` | `"unmanaged"` | Resource found on disk but not tracked by any snapshot |
+| `DriftUnknown` | `"unknown"` | State cannot be determined (e.g. snapshot error) |
+
+### `Resource`
+
+```go
+type Resource struct {
+    Type    ResourceType
+    Scope   Scope
+    Path    string          // absolute path to the resource
+    Name    string          // display name (skill name, repo URL, MCP name)
+    Drift   DriftState
+    VCSType string          // for repos: "git", "hg", "svn", "bzr"
+    Managed bool            // true if the resource is declared in gaal.yaml
+    Meta    map[string]string // extra attributes (e.g. "agent" for skills)
+}
+```
+
+---
+
+## Snapshot System
+
+Snapshots provide the reference state against which drift is measured. Each snapshot is a JSON file stored in the state directory (`~/.cache/gaal/state/` by default, sandbox-aware).
+
+### `FileRecord`
+
+```go
+type FileRecord struct {
+    Size    int64
+    ModTime time.Time
+    Hash    [32]byte // sha256
+}
+```
+
+### `Snapshot`
+
+A `Snapshot` is a `map[string]FileRecord` keyed by relative path (for directories) or the file's base name (for single-file resources like MCP configs).
+
+### Key functions
+
+| Function | Description |
+|----------|-------------|
+| `Load(path string) (Snapshot, error)` | Deserialize a snapshot from disk; returns empty snapshot if the file does not exist |
+| `Save(path string, s Snapshot) error` | Atomic write (temp file + `os.Rename`) |
+| `Record(path string) (FileRecord, error)` | Stat + hash a single file |
+| `SnapshotDir(root string) (Snapshot, error)` | Walk a directory tree and record every file |
+| `DiffPath(root string, s Snapshot) ([]Change, error)` | Compare current FS state against snapshot using the Git fast-path heuristic |
+| `SnapshotPath(stateDir, key string) string` | Canonical path for a snapshot file: `stateDir/<key>.json` |
+| `WorkdirKey(path string) string` | 8-character hex key derived from `sha256(path)[:4]` — used to namespace snapshots per installation path |
+
+### Snapshot lifecycle
+
+```
+gaal sync
+  └─► manager.Sync()
+        └─► installSkill() / mergeIntoTarget() / clone+update
+              └─► writeSkillSnapshot() / writeMCPSnapshot()
+                    └─► discover.SnapshotDir() or discover.Record()
+                          └─► discover.Save(SnapshotPath(stateDir, key), snap)
+
+gaal status / gaal info
+  └─► discover.Scan()
+        └─► computeSkillDrift() / computeRepoDrift() / computeMCPDrift()
+              ├─► hasVCSMarker(dir) → vcs.HasChanges()   ← fast-path for VCS dirs
+              └─► discover.DiffPath(root, snap)           ← snapshot fallback
+```
+
+Snapshots are keyed by `WorkdirKey(path)` so that two different installation paths for the same skill name do not collide.
+
+---
+
+## Scan
+
+### `ScanOptions`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `MaxDepth` | `4` | Maximum depth for workspace FS walk |
+| `IncludeWorkspace` | `false` | Whether to scan `workDir` for repos and skills |
+| `StateDir` | `""` | Override for the state directory (snapshot storage) |
+| `Timeout` | `2s` | Context deadline added around the workspace scan |
+
+### `Scan(ctx, home, workDir string, opts ScanOptions) ([]Resource, error)`
+
+Public entry point. Calls three sub-scanners in sequence:
+
+1. `scanGlobal(ctx, home, workDir, stateDir)` — agent-registry skill directories
+2. `scanMCPs(ctx, home, stateDir)` — agent MCP config files
+3. `scanWorkspace(ctx, workDir, maxDepth, stateDir)` — depth-limited FS walk (when `IncludeWorkspace` is true, wrapped in a 2-second timeout)
+
+Results are deduplicated by path before being returned.
+
+---
+
+## Per-resource-type scan logic
+
+### Skills — `global.go`
+
+Iterates every registered agent (`core/agent.List()`), resolves its skill directory (global and user scope), then calls `skillsFromDir()`. For each sub-directory a `Resource` is emitted with:
+
+- `Type = ResourceSkill`
+- `Scope` = global or user (derived from which path matched)
+- `Name` = last path segment of the skill directory
+- `Meta["agent"]` = the owning agent's name
+- `Drift` = result of `computeSkillDrift()`
+
+`computeSkillDrift()` tries VCS detection first (`hasVCSMarker` + `vcs.HasChanges`); if the directory is not a VCS working copy it falls back to `DiffPath` against the stored snapshot.
+
+### Repositories — `workspace.go`
+
+`scanWorkspace()` walks `workDir` up to `maxDepth` levels, skipping `node_modules`, `vendor`, `dist`, `.cache`, and `bin`. Whenever a VCS marker (`.git`, `.hg`, `.svn`, `.bzr`) is found **inside** a directory (not at the root), that directory is emitted as a `ResourceRepo`:
+
+- `VCSType` = detected VCS string
+- `Drift` = `computeRepoDrift()` which calls `vcs.HasChanges()`
+
+Directories containing `SKILL.md` at their root are emitted as `ResourceSkill` with `Scope = ScopeWorkspace`.
+
+### MCPs — `mcp.go`
+
+`scanMCPs()` iterates `core/agent.List()`, resolves each agent's MCP config file path via `agent.MCPConfigPath()`, and for each existing file emits a `ResourceMCP`:
+
+- `Path` = absolute path to the config JSON file
+- `Name` = agent name
+- `Drift` = `computeMCPDrift()` — stat fast-path against snapshot, sha256 fallback
+
+---
+
+## Integration with `engine/ops`
+
+`Collect()` in `engine/ops/status.go` is the main consumer:
+
+```go
+discovered, err := discover.Scan(ctx, home, workDir, discover.ScanOptions{
+    IncludeWorkspace: true,
+    StateDir:         stateDir,
+})
+```
+
+After the scan, three reconcile helpers (`reconcileRepos`, `reconcileSkills`, `reconcileMCPs`) merge config-declared entries (from the three managers) with FS-discovered resources. Config-declared resources take priority; FS-discovered resources that have no matching config entry are appended as unmanaged.
+
+The `driftToStatus()` mapper translates `DriftState` to the `render.StatusCode` displayed in the table and JSON output:
+
+| DriftState | StatusCode |
+|------------|------------|
+| `DriftOK` | `StatusOK` |
+| `DriftModified` | `StatusDirty` |
+| `DriftMissing` | `StatusNotCloned` |
+| others | `StatusOK` |
+
+---
+
+## State directory
+
+The state directory defaults to `filepath.Join(os.UserCacheDir(), "gaal", "state")`:
+
+| OS | Default path |
+|----|-------------|
+| Linux | `~/.cache/gaal/state/` |
+| macOS | `~/Library/Caches/gaal/state/` |
+| Windows | `%LocalAppData%\gaal\state\` |
+
+In `--sandbox` mode `os.UserCacheDir()` is redirected, so all snapshot files resolve inside the sandbox tree automatically.
+
+The path can be overridden for testing via `engine.Options.StateDir`.

--- a/internal/discover/global.go
+++ b/internal/discover/global.go
@@ -1,0 +1,233 @@
+package discover
+
+import (
+	"bufio"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gaal/internal/core/agent"
+	"gaal/internal/core/vcs"
+)
+
+// scanGlobal discovers skill resources at predictable agent-registry paths.
+//
+// It mirrors the two-pass attribution strategy from ops/audit.go:
+//   - Pass 1: canonical dirs only (ProjectSkillsDir / GlobalSkillsDir).
+//   - Pass 2: full search lists, skipping already-attributed directories.
+func scanGlobal(ctx context.Context, home, workDir, stateDir string) ([]Resource, error) {
+	slog.DebugContext(ctx, "scanning global skill paths", "home", home)
+
+	seen := make(map[string]struct{})
+	var resources []Resource
+
+	agents := agent.List()
+
+	// Pass 1: canonical install dirs.
+	for _, a := range agents {
+		if a.Info.ProjectSkillsDir != "" {
+			dir := filepath.Join(workDir, a.Info.ProjectSkillsDir)
+			resources = append(resources, skillsFromDir(ctx, dir, ScopeWorkspace, a.Name, stateDir, seen)...)
+		}
+		if a.Info.GlobalSkillsDir != "" {
+			dir := agent.ExpandHome(a.Info.GlobalSkillsDir, home)
+			resources = append(resources, skillsFromDir(ctx, dir, ScopeGlobal, a.Name, stateDir, seen)...)
+		}
+	}
+
+	// Pass 2: extended search lists.
+	for _, a := range agents {
+		for _, rel := range agent.ExpandedProjectSkillsSearch(a.Name) {
+			dir := filepath.Join(workDir, rel)
+			resources = append(resources, skillsFromDir(ctx, dir, ScopeWorkspace, a.Name, stateDir, seen)...)
+		}
+		for _, abs := range agent.ExpandedGlobalSkillsSearch(a.Name, home) {
+			resources = append(resources, skillsFromDir(ctx, abs, ScopeGlobal, a.Name, stateDir, seen)...)
+		}
+		for _, pmRoot := range agent.ExpandedPmSkillsSearch(a.Name, home) {
+			skillDirs, err := walkSkillDirs(pmRoot)
+			if err != nil {
+				slog.DebugContext(ctx, "pm walk error", "agent", a.Name, "root", pmRoot, "err", err)
+				continue
+			}
+			for _, sd := range skillDirs {
+				resources = append(resources, skillsFromDir(ctx, sd, ScopeGlobal, a.Name, stateDir, seen)...)
+			}
+		}
+	}
+
+	return resources, nil
+}
+
+// skillsFromDir scans dir at one level deep and returns a Resource for each
+// subdirectory that contains a SKILL.md file. dir itself is also checked.
+// Directories already present in seen are skipped.
+func skillsFromDir(ctx context.Context, dir string, scope Scope, agentName, stateDir string, seen map[string]struct{}) []Resource {
+	var out []Resource
+
+	add := func(skillDir string) {
+		if _, ok := seen[skillDir]; ok {
+			return
+		}
+		seen[skillDir] = struct{}{}
+		name := skillName(skillDir)
+		drift := computeSkillDrift(ctx, skillDir, stateDir)
+		out = append(out, Resource{
+			Type:  ResourceSkill,
+			Scope: scope,
+			Path:  skillDir,
+			Name:  name,
+			Drift: drift,
+			Meta:  map[string]string{"agent": agentName},
+		})
+	}
+
+	// dir itself may be a skill root.
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
+		add(dir)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		skillDir := filepath.Join(dir, e.Name())
+		if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err == nil {
+			add(skillDir)
+		}
+	}
+
+	return out
+}
+
+// computeSkillDrift determines DriftState for an installed skill directory.
+// VCS-native detection is preferred when the directory is a VCS working copy;
+// snapshot-based diff is used as fallback.
+func computeSkillDrift(ctx context.Context, dir, stateDir string) DriftState {
+	// VCS-native: equivalent of "git status" on the skill directory.
+	if hasVCSMarker(dir) {
+		vcsType := vcs.DetectType(dir)
+		backend, err := vcs.New(vcsType)
+		if err == nil && backend.IsCloned(dir) {
+			changed, err := backend.HasChanges(ctx, dir)
+			if err != nil {
+				slog.DebugContext(ctx, "vcs drift check failed", "dir", dir, "err", err)
+				return DriftUnknown
+			}
+			if changed {
+				return DriftModified
+			}
+			return DriftOK
+		}
+	}
+
+	// Snapshot-based fallback.
+	if stateDir == "" {
+		return DriftUnknown
+	}
+	key := "skill-" + WorkdirKey(dir)
+	snap, err := Load(SnapshotPath(stateDir, key))
+	if err != nil || len(snap) == 0 {
+		return DriftUnknown
+	}
+	changes, err := DiffPath(dir, snap)
+	if err != nil || len(changes) == 0 {
+		return DriftOK
+	}
+	for _, c := range changes {
+		if c.Drift == DriftMissing {
+			return DriftMissing
+		}
+	}
+	return DriftModified
+}
+
+// skillName extracts a human-readable skill name from a directory.
+// It parses the SKILL.md frontmatter when available, falling back to the
+// directory base name.
+func skillName(dir string) string {
+	name, _, _ := parseSkillFrontmatter(filepath.Join(dir, "SKILL.md"))
+	if name != "" {
+		return name
+	}
+	return filepath.Base(dir)
+}
+
+// parseSkillFrontmatter reads the "name" and "description" fields from the
+// YAML frontmatter block (--- … ---) of a SKILL.md file.
+// Returns empty strings on any error; the caller must use a sensible fallback.
+func parseSkillFrontmatter(path string) (name, desc string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", "", err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	inFrontmatter := false
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "---" {
+			if !inFrontmatter {
+				inFrontmatter = true
+				continue
+			}
+			break
+		}
+		if !inFrontmatter {
+			continue
+		}
+		k, v, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(k) {
+		case "name":
+			name = strings.TrimSpace(v)
+		case "description":
+			desc = strings.TrimSpace(v)
+		}
+	}
+	return name, desc, sc.Err()
+}
+
+// walkSkillDirs recursively finds directories named "skills" under root.
+// Each found "skills" directory is appended to the result; the walk does not
+// descend into them.
+func walkSkillDirs(root string) ([]string, error) {
+	slog.Debug("walking for skill directories", "root", root)
+	var dirs []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) == "skills" {
+			dirs = append(dirs, path)
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return dirs, nil
+}
+
+// hasVCSMarker reports whether dir contains at least one VCS metadata directory.
+func hasVCSMarker(dir string) bool {
+	for _, marker := range []string{".git", ".hg", ".svn", ".bzr"} {
+		if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/discover/global_test.go
+++ b/internal/discover/global_test.go
@@ -1,0 +1,232 @@
+package discover
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeSkillDir creates a minimal skill directory with a SKILL.md at dir.
+func makeSkillDir(t *testing.T, dir, name, desc string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: " + name + "\ndescription: " + desc + "\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestParseSkillFrontmatter_valid parses name and description.
+func TestParseSkillFrontmatter_valid(t *testing.T) {
+	dir := t.TempDir()
+	md := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(md, []byte("---\nname: my-skill\ndescription: A test skill\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	name, desc, err := parseSkillFrontmatter(md)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "my-skill" {
+		t.Errorf("name: got %q, want %q", name, "my-skill")
+	}
+	if desc != "A test skill" {
+		t.Errorf("desc: got %q, want %q", desc, "A test skill")
+	}
+}
+
+// TestParseSkillFrontmatter_noFrontmatter returns empty strings gracefully.
+func TestParseSkillFrontmatter_noFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	md := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(md, []byte("# Just a skill, no frontmatter\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	name, _, err := parseSkillFrontmatter(md)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "" {
+		t.Errorf("expected empty name, got %q", name)
+	}
+}
+
+// TestParseSkillFrontmatter_missing returns an error.
+func TestParseSkillFrontmatter_missing(t *testing.T) {
+	_, _, err := parseSkillFrontmatter(filepath.Join(t.TempDir(), "SKILL.md"))
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+// TestSkillName_frontmatter uses frontmatter name when available.
+func TestSkillName_frontmatter(t *testing.T) {
+	dir := t.TempDir()
+	makeSkillDir(t, dir, "from-frontmatter", "desc")
+	if got := skillName(dir); got != "from-frontmatter" {
+		t.Errorf("got %q, want %q", got, "from-frontmatter")
+	}
+}
+
+// TestSkillName_fallback falls back to directory base name.
+func TestSkillName_fallback(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "my-skill-dir")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := skillName(dir); got != "my-skill-dir" {
+		t.Errorf("got %q, want %q", got, "my-skill-dir")
+	}
+}
+
+// TestHasVCSMarker detects a .git directory.
+func TestHasVCSMarker(t *testing.T) {
+	dir := t.TempDir()
+	if hasVCSMarker(dir) {
+		t.Error("expected false for dir without VCS marker")
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !hasVCSMarker(dir) {
+		t.Error("expected true for dir with .git")
+	}
+}
+
+// TestSkillsFromDir_basic finds a skill inside a parent directory.
+func TestSkillsFromDir_basic(t *testing.T) {
+	parent := t.TempDir()
+	skillDir := filepath.Join(parent, "my-skill")
+	makeSkillDir(t, skillDir, "my-skill", "")
+
+	seen := make(map[string]struct{})
+	results := skillsFromDir(t.Context(), parent, ScopeGlobal, "test-agent", "", seen)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Path != skillDir {
+		t.Errorf("path: got %q, want %q", results[0].Path, skillDir)
+	}
+	if results[0].Meta["agent"] != "test-agent" {
+		t.Errorf("agent: got %q", results[0].Meta["agent"])
+	}
+}
+
+// TestSkillsFromDir_dedup does not return the same skill twice.
+func TestSkillsFromDir_dedup(t *testing.T) {
+	parent := t.TempDir()
+	skillDir := filepath.Join(parent, "my-skill")
+	makeSkillDir(t, skillDir, "my-skill", "")
+
+	seen := make(map[string]struct{})
+	r1 := skillsFromDir(t.Context(), parent, ScopeGlobal, "agent-a", "", seen)
+	r2 := skillsFromDir(t.Context(), parent, ScopeGlobal, "agent-b", "", seen)
+	if len(r1) != 1 || len(r2) != 0 {
+		t.Errorf("dedup failed: r1=%d r2=%d", len(r1), len(r2))
+	}
+}
+
+// TestSkillsFromDir_rootIsSkill detects when the dir itself is a skill root.
+func TestSkillsFromDir_rootIsSkill(t *testing.T) {
+	dir := t.TempDir()
+	makeSkillDir(t, dir, "root-skill", "")
+
+	seen := make(map[string]struct{})
+	results := skillsFromDir(t.Context(), dir, ScopeGlobal, "agent", "", seen)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Path != dir {
+		t.Errorf("expected root dir as skill path")
+	}
+}
+
+// TestSkillsFromDir_emptyDir returns nothing for a non-existent directory.
+func TestSkillsFromDir_emptyDir(t *testing.T) {
+	seen := make(map[string]struct{})
+	results := skillsFromDir(t.Context(), filepath.Join(t.TempDir(), "nope"), ScopeGlobal, "agent", "", seen)
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for missing dir, got %d", len(results))
+	}
+}
+
+// TestComputeSkillDrift_noSnapshot returns DriftUnknown without a stateDir.
+func TestComputeSkillDrift_noSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: x\n---\n")
+	got := computeSkillDrift(t.Context(), dir, "")
+	if got != DriftUnknown {
+		t.Errorf("got %q, want DriftUnknown", got)
+	}
+}
+
+// TestComputeSkillDrift_ok returns DriftOK when snapshot matches disk.
+func TestComputeSkillDrift_ok(t *testing.T) {
+	stateDir := t.TempDir()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: x\n---\n")
+
+	snap, _ := SnapshotDir(dir)
+	key := "skill-" + WorkdirKey(dir)
+	if err := Save(SnapshotPath(stateDir, key), snap); err != nil {
+		t.Fatal(err)
+	}
+	got := computeSkillDrift(t.Context(), dir, stateDir)
+	if got != DriftOK {
+		t.Errorf("got %q, want DriftOK", got)
+	}
+}
+
+// TestComputeSkillDrift_modified returns DriftModified when a file changed.
+func TestComputeSkillDrift_modified(t *testing.T) {
+	stateDir := t.TempDir()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "SKILL.md")
+	writeFile(t, p, "---\nname: x\n---\n")
+
+	snap, _ := SnapshotDir(dir)
+	key := "skill-" + WorkdirKey(dir)
+	_ = Save(SnapshotPath(stateDir, key), snap)
+
+	// Modify the file.
+	if err := os.WriteFile(p, []byte("changed content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := computeSkillDrift(t.Context(), dir, stateDir)
+	if got != DriftModified {
+		t.Errorf("got %q, want DriftModified", got)
+	}
+}
+
+// TestWalkSkillDirs finds nested "skills" directories.
+func TestWalkSkillDirs(t *testing.T) {
+	root := t.TempDir()
+	s1 := filepath.Join(root, "pkg", "skills")
+	s2 := filepath.Join(root, "other", "skills")
+	for _, d := range []string{s1, s2} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dirs, err := walkSkillDirs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirs) != 2 {
+		t.Errorf("expected 2, got %d: %v", len(dirs), dirs)
+	}
+}
+
+// TestWalkSkillDirs_missing returns no error for a non-existent root.
+func TestWalkSkillDirs_missing(t *testing.T) {
+	dirs, err := walkSkillDirs(filepath.Join(t.TempDir(), "nope"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs, got %d", len(dirs))
+	}
+}

--- a/internal/discover/mcp.go
+++ b/internal/discover/mcp.go
@@ -1,0 +1,88 @@
+package discover
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"gaal/internal/core/agent"
+)
+
+// scanMCPs discovers MCP config files by reading each registered agent's
+// project_mcp_config_file path directly from the filesystem, independent of
+// any gaal.yaml.
+func scanMCPs(ctx context.Context, home, stateDir string) ([]Resource, error) {
+	slog.DebugContext(ctx, "scanning MCP config files", "home", home)
+
+	seen := make(map[string]struct{})
+	var resources []Resource
+
+	for _, a := range agent.List() {
+		cfgFile, ok := agent.ProjectMCPConfigPath(a.Name, home)
+		if !ok {
+			continue
+		}
+		if _, ok := seen[cfgFile]; ok {
+			continue
+		}
+		seen[cfgFile] = struct{}{}
+
+		if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
+			continue
+		}
+
+		resources = append(resources, Resource{
+			Type:  ResourceMCP,
+			Scope: ScopeGlobal,
+			Path:  cfgFile,
+			Name:  a.Name,
+			Drift: computeMCPDrift(cfgFile, stateDir),
+			Meta:  map[string]string{"config_file": cfgFile},
+		})
+	}
+
+	return resources, nil
+}
+
+// computeMCPDrift compares the SHA-256 hash of an MCP config file against
+// the value stored in the snapshot (Git-inspired fast path: stat first).
+func computeMCPDrift(cfgFile, stateDir string) DriftState {
+	if stateDir == "" {
+		return DriftUnknown
+	}
+	key := "mcp-" + WorkdirKey(cfgFile)
+	snap, err := Load(SnapshotPath(stateDir, key))
+	if err != nil || len(snap) == 0 {
+		return DriftUnknown
+	}
+
+	base := filepath.Base(cfgFile)
+	rec, ok := snap[base]
+	if !ok {
+		return DriftUnknown
+	}
+
+	fi, err := os.Stat(cfgFile)
+	if err != nil {
+		return DriftMissing
+	}
+
+	// Fast path: stat matches → assume unchanged.
+	if fi.Size() == rec.Size && fi.ModTime().Equal(rec.ModTime) {
+		return DriftOK
+	}
+
+	// Hash comparison.
+	h, err := hashFile(cfgFile)
+	if err != nil {
+		return DriftUnknown
+	}
+	if h == rec.Hash {
+		// Racy-git: repair snapshot entry.
+		snap[base] = FileRecord{Size: fi.Size(), ModTime: fi.ModTime(), Hash: h}
+		return DriftOK
+	}
+
+	return DriftModified
+}

--- a/internal/discover/mcp_test.go
+++ b/internal/discover/mcp_test.go
@@ -1,0 +1,104 @@
+package discover
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeMCPConfig writes a fake MCP JSON config file and returns its path.
+func makeMCPConfig(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestComputeMCPDrift_noStateDir returns DriftUnknown with empty stateDir.
+func TestComputeMCPDrift_noStateDir(t *testing.T) {
+	cfgFile := makeMCPConfig(t, t.TempDir(), "mcp.json")
+	got := computeMCPDrift(cfgFile, "")
+	if got != DriftUnknown {
+		t.Errorf("got %q, want DriftUnknown", got)
+	}
+}
+
+// TestComputeMCPDrift_noSnapshot returns DriftUnknown when no snapshot exists.
+func TestComputeMCPDrift_noSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := makeMCPConfig(t, dir, "mcp.json")
+	got := computeMCPDrift(cfgFile, t.TempDir())
+	if got != DriftUnknown {
+		t.Errorf("got %q, want DriftUnknown", got)
+	}
+}
+
+// TestComputeMCPDrift_ok returns DriftOK when file matches snapshot.
+func TestComputeMCPDrift_ok(t *testing.T) {
+	stateDir := t.TempDir()
+	cfgFile := makeMCPConfig(t, t.TempDir(), "mcp.json")
+
+	// Build and save a snapshot for this file.
+	rec, err := Record(cfgFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap := Snapshot{filepath.Base(cfgFile): rec}
+	key := "mcp-" + WorkdirKey(cfgFile)
+	if err := Save(SnapshotPath(stateDir, key), snap); err != nil {
+		t.Fatal(err)
+	}
+
+	got := computeMCPDrift(cfgFile, stateDir)
+	if got != DriftOK {
+		t.Errorf("got %q, want DriftOK", got)
+	}
+}
+
+// TestComputeMCPDrift_modified returns DriftModified when file content changed.
+func TestComputeMCPDrift_modified(t *testing.T) {
+	stateDir := t.TempDir()
+	cfgFile := makeMCPConfig(t, t.TempDir(), "mcp.json")
+
+	rec, _ := Record(cfgFile)
+	snap := Snapshot{filepath.Base(cfgFile): rec}
+	key := "mcp-" + WorkdirKey(cfgFile)
+	_ = Save(SnapshotPath(stateDir, key), snap)
+
+	// Modify the file.
+	if err := os.WriteFile(cfgFile, []byte(`{"mcpServers":{"new":{}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := computeMCPDrift(cfgFile, stateDir)
+	if got != DriftModified {
+		t.Errorf("got %q, want DriftModified", got)
+	}
+}
+
+// TestComputeMCPDrift_missing returns DriftMissing when the file was deleted.
+func TestComputeMCPDrift_missing(t *testing.T) {
+	stateDir := t.TempDir()
+	fileDir := t.TempDir()
+	cfgFile := makeMCPConfig(t, fileDir, "mcp.json")
+
+	rec, _ := Record(cfgFile)
+	snap := Snapshot{filepath.Base(cfgFile): rec}
+	key := "mcp-" + WorkdirKey(cfgFile)
+	_ = Save(SnapshotPath(stateDir, key), snap)
+
+	// Delete the file.
+	if err := os.Remove(cfgFile); err != nil {
+		t.Fatal(err)
+	}
+
+	got := computeMCPDrift(cfgFile, stateDir)
+	if got != DriftMissing {
+		t.Errorf("got %q, want DriftMissing", got)
+	}
+}

--- a/internal/discover/resource.go
+++ b/internal/discover/resource.go
@@ -1,0 +1,44 @@
+package discover
+
+// ResourceType identifies the kind of managed resource.
+type ResourceType string
+
+const (
+	ResourceSkill ResourceType = "skill"
+	ResourceRepo  ResourceType = "repo"
+	ResourceMCP   ResourceType = "mcp"
+)
+
+// Scope describes where the resource lives relative to the user's environment.
+type Scope string
+
+const (
+	ScopeGlobal    Scope = "global"    // home-relative, shared across all projects
+	ScopeWorkspace Scope = "workspace" // project-relative
+)
+
+// DriftState describes the divergence between the installed resource and its
+// last-recorded snapshot.
+type DriftState string
+
+const (
+	DriftOK        DriftState = "ok"        // matches snapshot exactly
+	DriftModified  DriftState = "modified"  // content changed since last sync
+	DriftMissing   DriftState = "missing"   // expected by snapshot but absent on disk
+	DriftUnmanaged DriftState = "unmanaged" // present on disk, not in any snapshot
+	DriftUnknown   DriftState = "unknown"   // no snapshot available
+)
+
+// Resource is a generic, config-independent representation of a discovered
+// resource (skill directory, VCS repository, or MCP config file) found on
+// the local filesystem.
+type Resource struct {
+	Type    ResourceType
+	Scope   Scope
+	Path    string // absolute path on disk
+	Name    string // human-readable identifier
+	Drift   DriftState
+	VCSType string            // non-empty for VCS-backed resources ("git", "hg", …)
+	Managed bool              // true when reconciled with the current gaal config
+	Meta    map[string]string // free-form metadata: agent, url, desc, …
+}

--- a/internal/discover/resource_test.go
+++ b/internal/discover/resource_test.go
@@ -1,0 +1,62 @@
+package discover
+
+import "testing"
+
+func TestResourceTypeConstants(t *testing.T) {
+	cases := []struct {
+		got  ResourceType
+		want string
+	}{
+		{ResourceSkill, "skill"},
+		{ResourceRepo, "repo"},
+		{ResourceMCP, "mcp"},
+	}
+	for _, tc := range cases {
+		if string(tc.got) != tc.want {
+			t.Errorf("ResourceType %q: got %q", tc.want, tc.got)
+		}
+	}
+}
+
+func TestScopeConstants(t *testing.T) {
+	cases := []struct {
+		got  Scope
+		want string
+	}{
+		{ScopeGlobal, "global"},
+		{ScopeWorkspace, "workspace"},
+	}
+	for _, tc := range cases {
+		if string(tc.got) != tc.want {
+			t.Errorf("Scope %q: got %q", tc.want, tc.got)
+		}
+	}
+}
+
+func TestDriftStateConstants(t *testing.T) {
+	cases := []struct {
+		got  DriftState
+		want string
+	}{
+		{DriftOK, "ok"},
+		{DriftModified, "modified"},
+		{DriftMissing, "missing"},
+		{DriftUnmanaged, "unmanaged"},
+		{DriftUnknown, "unknown"},
+	}
+	for _, tc := range cases {
+		if string(tc.got) != tc.want {
+			t.Errorf("DriftState %q: got %q", tc.want, tc.got)
+		}
+	}
+}
+
+func TestResource_zeroValue(t *testing.T) {
+	var r Resource
+	if r.Type != "" || r.Scope != "" || r.Drift != "" {
+		t.Error("zero-value Resource should have empty Type, Scope, and Drift")
+	}
+	if r.Managed {
+		t.Error("zero-value Resource.Managed should be false")
+	}
+}

--- a/internal/discover/scan.go
+++ b/internal/discover/scan.go
@@ -1,0 +1,91 @@
+package discover
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+const (
+	defaultMaxDepth = 4
+	defaultTimeout  = 2 * time.Second
+)
+
+// ScanOptions controls the behaviour of Scan.
+type ScanOptions struct {
+	// MaxDepth limits how deep the workspace walk descends (default: 4).
+	MaxDepth int
+	// IncludeWorkspace enables the depth-limited workspace FS walk (default: true).
+	IncludeWorkspace bool
+	// StateDir is the root of the gaal state cache (e.g. ~/.cache/gaal/state).
+	// When empty, drift detection is skipped and resources get DriftUnknown.
+	StateDir string
+	// Timeout caps the total scan duration (default: 2s). A timed-out scan
+	// returns whatever results were gathered before the deadline.
+	Timeout time.Duration
+}
+
+// applyDefaults fills zero-value fields with their defaults.
+func applyDefaults(o ScanOptions) ScanOptions {
+	if o.MaxDepth <= 0 {
+		o.MaxDepth = defaultMaxDepth
+	}
+	if o.Timeout <= 0 {
+		o.Timeout = defaultTimeout
+	}
+	return o
+}
+
+// Scan discovers resources present on the filesystem and enriches each entry
+// with a DriftState derived from the persisted snapshot index.
+//
+// Two orthogonal domains are scanned:
+//   - Predictable (global/user) paths derived from the agent registry: skills and MCPs.
+//   - Workspace paths found by a depth-limited FS walk of workDir: skills and repos.
+//
+// Duplicate paths are silently deduplicated; the first attribution wins.
+func Scan(ctx context.Context, home, workDir string, opts ScanOptions) ([]Resource, error) {
+	slog.DebugContext(ctx, "scanning filesystem", "home", home, "workDir", workDir)
+	opts = applyDefaults(opts)
+
+	scanCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	seen := make(map[string]struct{})
+	var results []Resource
+
+	add := func(resources []Resource) {
+		for _, r := range resources {
+			if r.Path == "" {
+				continue
+			}
+			if _, ok := seen[r.Path]; ok {
+				continue
+			}
+			seen[r.Path] = struct{}{}
+			results = append(results, r)
+		}
+	}
+
+	global, err := scanGlobal(scanCtx, home, workDir, opts.StateDir)
+	if err != nil {
+		slog.DebugContext(scanCtx, "global scan error", "err", err)
+	}
+	add(global)
+
+	mcps, err := scanMCPs(scanCtx, home, opts.StateDir)
+	if err != nil {
+		slog.DebugContext(scanCtx, "mcp scan error", "err", err)
+	}
+	add(mcps)
+
+	if opts.IncludeWorkspace {
+		ws, err := scanWorkspace(scanCtx, workDir, opts.MaxDepth, opts.StateDir)
+		if err != nil {
+			slog.DebugContext(scanCtx, "workspace scan error", "err", err)
+		}
+		add(ws)
+	}
+
+	return results, nil
+}

--- a/internal/discover/scan_test.go
+++ b/internal/discover/scan_test.go
@@ -1,0 +1,76 @@
+package discover
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestApplyDefaults fills zero values correctly.
+func TestApplyDefaults(t *testing.T) {
+	o := applyDefaults(ScanOptions{})
+	if o.MaxDepth != defaultMaxDepth {
+		t.Errorf("MaxDepth: got %d, want %d", o.MaxDepth, defaultMaxDepth)
+	}
+	if o.Timeout != defaultTimeout {
+		t.Errorf("Timeout: got %v, want %v", o.Timeout, defaultTimeout)
+	}
+}
+
+// TestApplyDefaults_preservesExplicit does not overwrite explicit values.
+func TestApplyDefaults_preservesExplicit(t *testing.T) {
+	o := applyDefaults(ScanOptions{MaxDepth: 2, Timeout: 5 * time.Second})
+	if o.MaxDepth != 2 {
+		t.Errorf("MaxDepth should be 2, got %d", o.MaxDepth)
+	}
+	if o.Timeout != 5*time.Second {
+		t.Errorf("Timeout should be 5s, got %v", o.Timeout)
+	}
+}
+
+// TestScan_dedup does not return the same path twice even if multiple
+// scanners would find it (global + workspace).
+func TestScan_dedup(t *testing.T) {
+	root := t.TempDir()
+	// Place a skill that would be discoverable from the workspace walk.
+	skillDir := root
+	makeSkillDir(t, skillDir, "root-skill", "")
+
+	results, err := Scan(t.Context(), t.TempDir(), root, ScanOptions{
+		IncludeWorkspace: true,
+		MaxDepth:         1,
+		Timeout:          defaultTimeout,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := make(map[string]int)
+	for _, r := range results {
+		seen[r.Path]++
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("path %q appears %d times, expected 1", path, count)
+		}
+	}
+}
+
+// TestScan_noWorkspace skips workspace scan when IncludeWorkspace is false.
+func TestScan_noWorkspace(t *testing.T) {
+	root := t.TempDir()
+	// Create a skill that would only be found by workspace walk.
+	skillDir := filepath.Join(root, "hidden")
+	makeSkillDir(t, skillDir, "hidden-skill", "")
+
+	results, err := Scan(t.Context(), t.TempDir(), root, ScanOptions{
+		IncludeWorkspace: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if r.Path == skillDir {
+			t.Errorf("workspace skill should not appear when IncludeWorkspace=false")
+		}
+	}
+}

--- a/internal/discover/snapshot.go
+++ b/internal/discover/snapshot.go
@@ -1,0 +1,209 @@
+package discover
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// FileRecord stores per-file metadata for the fast-path drift check.
+// It mirrors Git's index format: size and mtime provide an O(1) "definitely
+// unchanged" decision; the SHA-256 hash is only computed when stat data differ.
+type FileRecord struct {
+	Size    int64     `json:"size"`
+	ModTime time.Time `json:"mtime"`
+	Hash    [32]byte  `json:"hash"`
+}
+
+// Snapshot maps root-relative file paths to their last-recorded FileRecord.
+// It is persisted as JSON in the gaal state directory after every successful sync.
+type Snapshot map[string]FileRecord
+
+// Change is a single file-level drift event returned by DiffPath.
+type Change struct {
+	Path  string
+	Drift DriftState
+}
+
+// SnapshotPath returns the conventional path for a snapshot file identified by
+// key under stateDir (e.g. stateDir/skill-abc123.json).
+func SnapshotPath(stateDir, key string) string {
+	return filepath.Join(stateDir, key+".json")
+}
+
+// WorkdirKey returns a short, stable, collision-resistant identifier derived
+// from an absolute path, suitable for use as part of a snapshot filename.
+func WorkdirKey(path string) string {
+	h := sha256.Sum256([]byte(path))
+	return fmt.Sprintf("%x", h[:4])
+}
+
+// Load reads a Snapshot from path. Returns an empty (non-nil) Snapshot when
+// the file does not exist — the normal first-run state.
+func Load(path string) (Snapshot, error) {
+	slog.Debug("loading snapshot", "path", path)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return make(Snapshot), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var s Snapshot
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Save writes s to path atomically via a temporary file and os.Rename.
+// Parent directories are created if they do not exist.
+func Save(path string, s Snapshot) error {
+	slog.Debug("saving snapshot", "path", path, "entries", len(s))
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// Record builds a FileRecord for the file at path by reading its stat and
+// computing its SHA-256 hash. Call this during sync to capture the
+// post-install state of each managed file.
+func Record(path string) (FileRecord, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return FileRecord{}, err
+	}
+	h, err := hashFile(path)
+	if err != nil {
+		return FileRecord{}, err
+	}
+	return FileRecord{Size: fi.Size(), ModTime: fi.ModTime(), Hash: h}, nil
+}
+
+// SnapshotDir walks root and builds a fresh Snapshot from every file it finds.
+// This is the canonical way to snapshot a directory after a successful sync.
+func SnapshotDir(root string) (Snapshot, error) {
+	slog.Debug("snapshotting directory", "root", root)
+	s := make(Snapshot)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		rec, err := Record(path)
+		if err != nil {
+			slog.Debug("snapshot record error", "path", path, "err", err)
+			return nil
+		}
+		s[rel] = rec
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// DiffPath compares every file under root against snapshot s and returns the
+// list of files that have drifted.
+//
+// Algorithm (Git index-inspired):
+//  1. stat(file): if size and mtime match the FileRecord → DriftOK (no read).
+//  2. If stat differs → compute SHA-256: if hash matches, update mtime
+//     in-place (racy-git repair) and return DriftOK.
+//  3. If hash differs → DriftModified.
+//  4. Files in snapshot but absent on disk → DriftMissing.
+//
+// Files found on disk but absent from the snapshot are silently skipped;
+// the caller classifies them (e.g. DriftUnmanaged) using higher-level logic.
+func DiffPath(root string, s Snapshot) ([]Change, error) {
+	slog.Debug("diffing path against snapshot", "root", root, "entries", len(s))
+	seen := make(map[string]struct{}, len(s))
+	var changes []Change
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			slog.Debug("walk error", "path", path, "err", err)
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		seen[rel] = struct{}{}
+
+		rec, known := s[rel]
+		if !known {
+			return nil // not tracked by this snapshot
+		}
+
+		fi, err := d.Info()
+		if err != nil {
+			changes = append(changes, Change{Path: rel, Drift: DriftUnknown})
+			return nil
+		}
+
+		// Fast path: stat matches → assume unchanged.
+		if fi.Size() == rec.Size && fi.ModTime().Equal(rec.ModTime) {
+			return nil
+		}
+
+		// Stat differs → verify via hash.
+		h, err := hashFile(path)
+		if err != nil {
+			changes = append(changes, Change{Path: rel, Drift: DriftUnknown})
+			return nil
+		}
+		if h == rec.Hash {
+			// Racy-git scenario: content unchanged but mtime updated. Repair.
+			s[rel] = FileRecord{Size: fi.Size(), ModTime: fi.ModTime(), Hash: h}
+			return nil
+		}
+
+		changes = append(changes, Change{Path: rel, Drift: DriftModified})
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	// Files expected by snapshot but missing from disk.
+	for rel := range s {
+		if _, ok := seen[rel]; !ok {
+			changes = append(changes, Change{Path: rel, Drift: DriftMissing})
+		}
+	}
+
+	return changes, nil
+}
+
+// hashFile computes the SHA-256 checksum of the file at path.
+func hashFile(path string) ([32]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return [32]byte{}, err
+	}
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}

--- a/internal/discover/snapshot_test.go
+++ b/internal/discover/snapshot_test.go
@@ -1,0 +1,287 @@
+package discover
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeFile creates path with content, returning its os.FileInfo.
+func writeFile(t *testing.T, path, content string) os.FileInfo {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fi
+}
+
+// TestSnapshotPath verifies the path construction helper.
+func TestSnapshotPath(t *testing.T) {
+	got := SnapshotPath("/state", "skill-abc")
+	want := "/state/skill-abc.json"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestWorkdirKey verifies stability and uniqueness.
+func TestWorkdirKey(t *testing.T) {
+	k1 := WorkdirKey("/home/user/project")
+	k2 := WorkdirKey("/home/user/project")
+	k3 := WorkdirKey("/home/user/other")
+	if k1 != k2 {
+		t.Errorf("same input produced different keys: %q vs %q", k1, k2)
+	}
+	if k1 == k3 {
+		t.Errorf("different inputs produced same key: %q", k1)
+	}
+	if len(k1) != 8 {
+		t.Errorf("expected 8-char hex key, got %q (len %d)", k1, len(k1))
+	}
+}
+
+// TestLoad_notExist returns an empty snapshot for a missing file.
+func TestLoad_notExist(t *testing.T) {
+	s, err := Load(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(s) != 0 {
+		t.Errorf("expected empty snapshot, got %d entries", len(s))
+	}
+}
+
+// TestLoad_valid round-trips a snapshot through Save then Load.
+func TestLoad_valid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "snap.json")
+	orig := Snapshot{
+		"a/b.txt": {Size: 42, ModTime: time.Unix(1000, 0).UTC()},
+	}
+	if err := Save(path, orig); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(loaded))
+	}
+	rec, ok := loaded["a/b.txt"]
+	if !ok {
+		t.Fatal("expected key 'a/b.txt'")
+	}
+	if rec.Size != 42 {
+		t.Errorf("size: got %d, want 42", rec.Size)
+	}
+}
+
+// TestLoad_invalid returns an error for corrupted JSON.
+func TestLoad_invalid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte("{not json}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+// TestSave_atomic verifies no leftover temp file after a successful Save.
+func TestSave_atomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "snap.json")
+	if err := Save(path, Snapshot{}); err != nil {
+		t.Fatal(err)
+	}
+	tmp := path + ".tmp"
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Error("temp file left behind after Save")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("snapshot file not created: %v", err)
+	}
+}
+
+// TestRecord builds a correct FileRecord for a known file.
+func TestRecord(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "file.txt")
+	writeFile(t, p, "hello")
+
+	rec, err := Record(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Size != 5 {
+		t.Errorf("size: got %d, want 5", rec.Size)
+	}
+	if rec.Hash == ([32]byte{}) {
+		t.Error("hash should not be zero")
+	}
+	// Re-record the same file: must be identical.
+	rec2, _ := Record(p)
+	if rec.Hash != rec2.Hash {
+		t.Error("same file produced different hashes")
+	}
+}
+
+// TestRecord_missing returns an error for a non-existent file.
+func TestRecord_missing(t *testing.T) {
+	_, err := Record(filepath.Join(t.TempDir(), "nope.txt"))
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+// TestHashFile is deterministic and differs for different content.
+func TestHashFile(t *testing.T) {
+	dir := t.TempDir()
+	p1 := filepath.Join(dir, "a.txt")
+	p2 := filepath.Join(dir, "b.txt")
+	writeFile(t, p1, "hello")
+	writeFile(t, p2, "world")
+
+	h1, err := hashFile(p1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := hashFile(p2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 == h2 {
+		t.Error("different contents should produce different hashes")
+	}
+	h1b, _ := hashFile(p1)
+	if h1 != h1b {
+		t.Error("same file should produce stable hash")
+	}
+}
+
+// TestSnapshotDir builds a snapshot from a directory tree.
+func TestSnapshotDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.txt"), "aaa")
+	writeFile(t, filepath.Join(dir, "sub", "b.txt"), "bbb")
+
+	s, err := SnapshotDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(s))
+	}
+	if _, ok := s["a.txt"]; !ok {
+		t.Error("missing a.txt")
+	}
+	if _, ok := s[filepath.Join("sub", "b.txt")]; !ok {
+		t.Error("missing sub/b.txt")
+	}
+}
+
+// TestDiffPath_ok: snapshot matches disk → no changes.
+func TestDiffPath_ok(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "f.txt"), "content")
+
+	s, _ := SnapshotDir(dir)
+	changes, err := DiffPath(dir, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected no changes, got %v", changes)
+	}
+}
+
+// TestDiffPath_modified: file content changed after snapshot.
+func TestDiffPath_modified(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	writeFile(t, p, "original")
+
+	s, _ := SnapshotDir(dir)
+
+	if err := os.WriteFile(p, []byte("changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := DiffPath(dir, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 1 || changes[0].Drift != DriftModified {
+		t.Errorf("expected DriftModified, got %v", changes)
+	}
+}
+
+// TestDiffPath_missing: file in snapshot but deleted from disk.
+func TestDiffPath_missing(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	writeFile(t, p, "hello")
+
+	s, _ := SnapshotDir(dir)
+
+	if err := os.Remove(p); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := DiffPath(dir, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 1 || changes[0].Drift != DriftMissing {
+		t.Errorf("expected DriftMissing, got %v", changes)
+	}
+}
+
+// TestDiffPath_racyGit: same content but mtime differs — snapshot is repaired.
+func TestDiffPath_racyGit(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	writeFile(t, p, "stable")
+
+	s, _ := SnapshotDir(dir)
+
+	// Alter the recorded mtime to simulate a racy situation.
+	old := s["f.txt"]
+	old.ModTime = old.ModTime.Add(-5 * time.Second)
+	s["f.txt"] = old
+
+	changes, err := DiffPath(dir, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected no changes (racy-git fix), got %v", changes)
+	}
+	// Snapshot must have been repaired.
+	fi, _ := os.Stat(p)
+	if !s["f.txt"].ModTime.Equal(fi.ModTime()) {
+		t.Error("snapshot mtime was not repaired after racy-git detection")
+	}
+}
+
+// TestDiffPath_emptyRoot: non-existent root → no error, no changes.
+func TestDiffPath_emptyRoot(t *testing.T) {
+	changes, err := DiffPath(filepath.Join(t.TempDir(), "nope"), make(Snapshot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected no changes for empty root, got %v", changes)
+	}
+}

--- a/internal/discover/workspace.go
+++ b/internal/discover/workspace.go
@@ -1,0 +1,131 @@
+package discover
+
+import (
+	"context"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gaal/internal/core/vcs"
+)
+
+// skipDirs is the set of directory names that the workspace walk never descends into.
+var skipDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	"dist":         true,
+	".cache":       true,
+	"bin":          true,
+}
+
+// scanWorkspace discovers repos and skills inside workDir using a depth-limited
+// FS walk. It respects context cancellation (e.g. from the scan timeout).
+//
+// Rules:
+//   - Directories containing a VCS marker (.git, .hg, .svn, .bzr) are
+//     reported as repos; the walk does not descend into them.
+//   - The workDir root itself is never reported as a repo (it is the project
+//     workspace, not a gaal-managed clone).
+//   - Directories containing SKILL.md are reported as skills.
+//   - Walks stops when reaching maxDepth levels below workDir.
+func scanWorkspace(ctx context.Context, workDir string, maxDepth int, stateDir string) ([]Resource, error) {
+	slog.DebugContext(ctx, "scanning workspace", "dir", workDir, "maxDepth", maxDepth)
+
+	root := filepath.Clean(workDir)
+	seen := make(map[string]struct{})
+	var resources []Resource
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+
+		rel, _ := filepath.Rel(root, path)
+		depth := depthOf(rel)
+		if depth > maxDepth {
+			return filepath.SkipDir
+		}
+
+		base := filepath.Base(path)
+		if skipDirs[base] && path != root {
+			return filepath.SkipDir
+		}
+
+		// Never report the workspace root itself as a repo.
+		if path != root && hasVCSMarker(path) {
+			if _, ok := seen[path]; !ok {
+				seen[path] = struct{}{}
+				vcsType := vcs.DetectType(path)
+				resources = append(resources, Resource{
+					Type:    ResourceRepo,
+					Scope:   ScopeWorkspace,
+					Path:    path,
+					Name:    base,
+					Drift:   computeRepoDrift(ctx, path, vcsType),
+					VCSType: vcsType,
+				})
+			}
+			return filepath.SkipDir
+		}
+
+		// Skill detection: directory contains SKILL.md.
+		if _, err := os.Stat(filepath.Join(path, "SKILL.md")); err == nil {
+			if _, ok := seen[path]; !ok {
+				seen[path] = struct{}{}
+				name := skillName(path)
+				resources = append(resources, Resource{
+					Type:  ResourceSkill,
+					Scope: ScopeWorkspace,
+					Path:  path,
+					Name:  name,
+					Drift: computeSkillDrift(ctx, path, stateDir),
+				})
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil && err != context.DeadlineExceeded && err != context.Canceled {
+		return nil, err
+	}
+	return resources, nil
+}
+
+// computeRepoDrift checks drift for a VCS repository using the native backend.
+func computeRepoDrift(ctx context.Context, dir, vcsType string) DriftState {
+	if vcsType == "" {
+		return DriftUnknown
+	}
+	backend, err := vcs.New(vcsType)
+	if err != nil {
+		return DriftUnknown
+	}
+	if !backend.IsCloned(dir) {
+		return DriftMissing
+	}
+	changed, err := backend.HasChanges(ctx, dir)
+	if err != nil {
+		return DriftUnknown
+	}
+	if changed {
+		return DriftModified
+	}
+	return DriftOK
+}
+
+// depthOf returns the number of path separators in a relative path string.
+func depthOf(rel string) int {
+	if rel == "." {
+		return 0
+	}
+	return strings.Count(rel, string(filepath.Separator)) + 1
+}

--- a/internal/discover/workspace_test.go
+++ b/internal/discover/workspace_test.go
@@ -1,0 +1,171 @@
+package discover
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDepthOf validates the path depth helper.
+func TestDepthOf(t *testing.T) {
+	cases := []struct {
+		rel  string
+		want int
+	}{
+		{".", 0},
+		{"a", 1},
+		{filepath.Join("a", "b"), 2},
+		{filepath.Join("a", "b", "c"), 3},
+	}
+	for _, tc := range cases {
+		if got := depthOf(tc.rel); got != tc.want {
+			t.Errorf("depthOf(%q) = %d, want %d", tc.rel, got, tc.want)
+		}
+	}
+}
+
+// TestScanWorkspace_empty returns nothing for an empty directory.
+func TestScanWorkspace_empty(t *testing.T) {
+	dir := t.TempDir()
+	resources, err := scanWorkspace(t.Context(), dir, 4, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resources) != 0 {
+		t.Errorf("expected 0 resources, got %d", len(resources))
+	}
+}
+
+// TestScanWorkspace_withSkill finds a skill directory.
+func TestScanWorkspace_withSkill(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "tools", "my-skill")
+	makeSkillDir(t, skillDir, "my-skill", "")
+
+	resources, err := scanWorkspace(t.Context(), root, 4, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range resources {
+		if r.Path == skillDir && r.Type == ResourceSkill {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("skill dir %q not found in results: %v", skillDir, resources)
+	}
+}
+
+// TestScanWorkspace_withRepo detects a subdirectory with a .git marker as a repo.
+func TestScanWorkspace_withRepo(t *testing.T) {
+	root := t.TempDir()
+	repoDir := filepath.Join(root, "clones", "my-repo")
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resources, err := scanWorkspace(t.Context(), root, 4, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range resources {
+		if r.Path == repoDir && r.Type == ResourceRepo {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("repo dir %q not found in results: %v", repoDir, resources)
+	}
+}
+
+// TestScanWorkspace_rootNotRepo ensures the workDir root is not reported as a repo.
+func TestScanWorkspace_rootNotRepo(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resources, err := scanWorkspace(t.Context(), root, 4, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range resources {
+		if r.Path == root && r.Type == ResourceRepo {
+			t.Errorf("workspace root should not be reported as a repo")
+		}
+	}
+}
+
+// TestScanWorkspace_maxDepth skips dirs beyond the depth limit.
+func TestScanWorkspace_maxDepth(t *testing.T) {
+	root := t.TempDir()
+	// Place a skill at depth 5 (beyond default 4).
+	deep := filepath.Join(root, "a", "b", "c", "d", "e", "deep-skill")
+	makeSkillDir(t, deep, "deep-skill", "")
+
+	resources, err := scanWorkspace(t.Context(), root, 4, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range resources {
+		if r.Path == deep {
+			t.Errorf("depth-5 skill should not appear with maxDepth=4")
+		}
+	}
+}
+
+// TestScanWorkspace_skipDirs does not descend into node_modules.
+func TestScanWorkspace_skipDirs(t *testing.T) {
+	root := t.TempDir()
+	nm := filepath.Join(root, "node_modules", "some-skill")
+	makeSkillDir(t, nm, "some-skill", "")
+
+	resources, err := scanWorkspace(t.Context(), root, 4, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range resources {
+		if r.Path == nm {
+			t.Errorf("skill inside node_modules should be skipped")
+		}
+	}
+}
+
+// TestScanWorkspace_dedup does not report the same directory twice.
+func TestScanWorkspace_dedup(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "skills", "tool")
+	makeSkillDir(t, skillDir, "tool", "")
+
+	resources, err := scanWorkspace(t.Context(), root, 4, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, r := range resources {
+		if r.Path == skillDir {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 occurrence, got %d", count)
+	}
+}
+
+// TestComputeRepoDrift_unknown returns DriftUnknown for empty vcsType.
+func TestComputeRepoDrift_unknown(t *testing.T) {
+	got := computeRepoDrift(t.Context(), t.TempDir(), "")
+	if got != DriftUnknown {
+		t.Errorf("got %q, want DriftUnknown", got)
+	}
+}
+
+// TestComputeRepoDrift_unknownVCSType returns DriftUnknown for unrecognised type.
+func TestComputeRepoDrift_unknownVCSType(t *testing.T) {
+	got := computeRepoDrift(t.Context(), t.TempDir(), "invalid-vcs-type")
+	if got != DriftUnknown {
+		t.Errorf("got %q, want DriftUnknown", got)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -45,6 +45,7 @@ const (
 	StatusPartial   StatusCode = render.StatusPartial
 	StatusPresent   StatusCode = render.StatusPresent
 	StatusAbsent    StatusCode = render.StatusAbsent
+	StatusUnmanaged StatusCode = render.StatusUnmanaged
 	StatusError     StatusCode = render.StatusError
 )
 
@@ -53,6 +54,9 @@ type Options struct {
 	// WorkDir overrides the current working directory used for project-relative
 	// skill install paths. Defaults to os.Getwd().
 	WorkDir string
+	// StateDir overrides the directory used to persist snapshot indexes.
+	// Defaults to <cacheRoot>/gaal/state.
+	StateDir string
 }
 
 // Engine orchestrates repository, skill and MCP synchronisation.
@@ -64,6 +68,7 @@ type Engine struct {
 	home      string
 	workDir   string
 	cacheRoot string
+	stateDir  string
 }
 
 // New creates an Engine from the given configuration using default directories.
@@ -89,16 +94,22 @@ func NewWithOptions(cfg *config.Config, opts Options) *Engine {
 	}
 	cacheDir := filepath.Join(cacheRoot, "gaal", "skills")
 
-	slog.Debug("engine initialised", "home", home, "workDir", workDir, "cacheDir", cacheDir)
+	stateDir := filepath.Join(cacheRoot, "gaal", "state")
+	if opts.StateDir != "" {
+		stateDir = opts.StateDir
+	}
+
+	slog.Debug("engine initialised", "home", home, "workDir", workDir, "cacheDir", cacheDir, "stateDir", stateDir)
 
 	return &Engine{
 		cfg:       cfg,
-		repos:     repo.NewManager(cfg.Repositories),
-		skills:    skill.NewManager(cfg.Skills, cacheDir, home, workDir),
-		mcps:      mcp.NewManager(cfg.MCPs),
+		repos:     repo.NewManager(cfg.Repositories, stateDir),
+		skills:    skill.NewManager(cfg.Skills, cacheDir, home, workDir, stateDir),
+		mcps:      mcp.NewManager(cfg.MCPs, stateDir),
 		home:      home,
 		workDir:   workDir,
 		cacheRoot: cacheRoot,
+		stateDir:  stateDir,
 	}
 }
 
@@ -164,21 +175,40 @@ func (e *Engine) RunService(ctx context.Context, interval time.Duration) error {
 	}
 }
 
+// Prune removes skills and MCP entries that are on disk but no longer declared
+// in the configuration. It is intended to be called after RunOnce (sources are
+// already cached so no network access occurs). Repositories are never pruned
+// automatically — deletion of source trees requires explicit user action.
+func (e *Engine) Prune(ctx context.Context) error {
+	slog.DebugContext(ctx, "pruning orphan resources")
+	var errs []error
+	if err := e.skills.Prune(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("skills prune: %w", err))
+	}
+	if err := e.mcps.Prune(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("mcps prune: %w", err))
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("prune errors: %v", errs)
+	}
+	return nil
+}
+
 // Collect gathers the current status of all resources without side effects.
 func (e *Engine) Collect(ctx context.Context) (*render.StatusReport, error) {
-	return ops.Collect(ctx, e.repos, e.skills, e.mcps)
+	return ops.Collect(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir)
 }
 
 // DryRun computes what sync would do and renders the plan to os.Stdout.
 // It returns the plan so the caller can inspect HasChanges / HasErrors for
 // exit code logic.
 func (e *Engine) DryRun(ctx context.Context, format OutputFormat) (*render.PlanReport, error) {
-	return ops.RenderPlan(ctx, e.repos, e.skills, e.mcps, format)
+	return ops.RenderPlan(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir, format)
 }
 
 // Status collects the current resource state and renders it to os.Stdout.
 func (e *Engine) Status(ctx context.Context, format OutputFormat) error {
-	return ops.Status(ctx, e.repos, e.skills, e.mcps, format)
+	return ops.Status(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir, format)
 }
 
 // Audit discovers all skills and MCP servers installed on the machine and
@@ -189,7 +219,7 @@ func (e *Engine) Audit(ctx context.Context, format OutputFormat) error {
 
 // Info renders a detailed view for the given package type to stdout.
 func (e *Engine) Info(ctx context.Context, pkg, filter string, format OutputFormat) error {
-	return ops.Info(ctx, e.repos, e.skills, e.mcps, e.cfg, pkg, filter, format)
+	return ops.Info(ctx, e.repos, e.skills, e.mcps, e.cfg, e.home, e.workDir, e.stateDir, pkg, filter, format)
 }
 
 // ListAgents returns all registered agents with installed-detection.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -96,7 +96,7 @@ func TestRunOnce_WithSkills_LocalSource(t *testing.T) {
 			{Source: sourceDir, Agents: []string{"claude-code"}},
 		},
 	}
-	e := NewWithOptions(cfg, Options{WorkDir: workDir})
+	e := NewWithOptions(cfg, Options{WorkDir: workDir, StateDir: t.TempDir()})
 	if err := e.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce with skill: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestRunOnce_WithMCP_Inline(t *testing.T) {
 			},
 		},
 	}
-	e := New(cfg)
+	e := NewWithOptions(cfg, Options{StateDir: t.TempDir()})
 	if err := e.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce with MCP: %v", err)
 	}

--- a/internal/engine/ops/info.go
+++ b/internal/engine/ops/info.go
@@ -25,10 +25,10 @@ import (
 // filter is an optional name/source substring; if non-empty only matching
 // entries are shown. Matching is case-insensitive.
 // format controls the output: FormatTable (pterm) or FormatJSON.
-func Info(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, cfg *config.Config, pkg, filter string, format render.OutputFormat) error {
+func Info(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, cfg *config.Config, home, workDir, stateDir, pkg, filter string, format render.OutputFormat) error {
 	slog.DebugContext(ctx, "info requested", "package", pkg, "filter", filter, "format", format)
 
-	report, err := Collect(ctx, repos, skills, mcps)
+	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/ops/plan.go
+++ b/internal/engine/ops/plan.go
@@ -15,10 +15,10 @@ import (
 // The returned PlanReport describes every action that RunOnce would take.
 // This is the shared planner used by both `sync --dry-run` and the future
 // `diff` command.
-func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager) (*render.PlanReport, error) {
+func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string) (*render.PlanReport, error) {
 	slog.DebugContext(ctx, "computing sync plan")
 
-	report, err := Collect(ctx, repos, skills, mcps)
+	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +58,8 @@ func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, m
 }
 
 // RenderPlan computes and renders the sync plan to stdout.
-func RenderPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, format render.OutputFormat) (*render.PlanReport, error) {
-	plan, err := SyncPlan(ctx, repos, skills, mcps)
+func RenderPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string, format render.OutputFormat) (*render.PlanReport, error) {
+	plan, err := SyncPlan(ctx, repos, skills, mcps, home, workDir, stateDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/ops/status.go
+++ b/internal/engine/ops/status.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 
+	"gaal/internal/discover"
 	"gaal/internal/engine/render"
 	"gaal/internal/mcp"
 	"gaal/internal/repo"
@@ -13,27 +14,49 @@ import (
 )
 
 // Collect gathers the current status of all resources without side effects.
-func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager) (*render.StatusReport, error) {
-	slog.DebugContext(ctx, "collecting status")
+// It performs a FS-first scan via discover.Scan and then reconciles with any
+// config-declared resources from the managers, marking them as managed.
+func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string) (*render.StatusReport, error) {
+	slog.DebugContext(ctx, "collecting status", "home", home, "workDir", workDir)
+
+	// FS-first: discover what is actually installed.
+	discovered, err := discover.Scan(ctx, home, workDir, discover.ScanOptions{
+		IncludeWorkspace: true,
+		StateDir:         stateDir,
+	})
+	if err != nil {
+		slog.DebugContext(ctx, "discover scan error", "err", err)
+	}
+
 	agents, err := collectAgents()
 	if err != nil {
 		return nil, err
 	}
 
+	// Config-driven status (may add managed resources absent from FS scan).
+	configRepos := collectRepos(repos.Status(ctx))
+	configSkills := collectSkills(skills.Status(ctx))
+	configMCPs := collectMCPs(mcps.Status(ctx))
+
+	// Reconcile: mark config-declared resources as managed and merge
+	// FS-discovered unmanaged resources into the report.
+	repoEntries := reconcileRepos(configRepos, discovered)
+	skillEntries := reconcileSkills(configSkills, discovered)
+	mcpEntries := reconcileMCPs(configMCPs, discovered)
+
 	return &render.StatusReport{
-		Repositories: collectRepos(repos.Status(ctx)),
-		Skills:       collectSkills(skills.Status(ctx)),
-		MCPs:         collectMCPs(mcps.Status(ctx)),
+		Repositories: repoEntries,
+		Skills:       skillEntries,
+		MCPs:         mcpEntries,
 		Agents:       agents,
 	}, nil
 }
 
-// Status collects the current resource state and renders it to os.Stdout
-// using the specified format (FormatTable or FormatJSON).
-func Status(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, format render.OutputFormat) error {
+// Status collects the current resource state and renders it to os.Stdout.
+func Status(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string, format render.OutputFormat) error {
 	slog.DebugContext(ctx, "status requested", "format", format)
 
-	report, err := Collect(ctx, repos, skills, mcps)
+	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir)
 	if err != nil {
 		return err
 	}
@@ -44,6 +67,98 @@ func Status(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcp
 	}
 
 	return renderer.Render(os.Stdout, report)
+}
+
+// reconcileRepos merges config-driven repo entries with FS-discovered repos.
+// Config entries are kept as-is (already enriched with URL, version, etc.).
+// FS-discovered repos not in config are appended as unmanaged.
+func reconcileRepos(config []render.RepoEntry, resources []discover.Resource) []render.RepoEntry {
+	known := make(map[string]struct{}, len(config))
+	for _, e := range config {
+		known[e.Path] = struct{}{}
+	}
+	out := append([]render.RepoEntry(nil), config...)
+	for _, r := range resources {
+		if r.Type != discover.ResourceRepo {
+			continue
+		}
+		if _, ok := known[r.Path]; ok {
+			continue
+		}
+		out = append(out, render.RepoEntry{
+			Path:   r.Path,
+			Type:   r.VCSType,
+			Status: render.StatusUnmanaged,
+		})
+	}
+	return out
+}
+
+// reconcileSkills merges config-driven skill entries with FS-discovered skills.
+// FS-discovered skills not covered by config are appended as unmanaged entries.
+func reconcileSkills(config []render.SkillEntry, resources []discover.Resource) []render.SkillEntry {
+	known := make(map[string]struct{}, len(config))
+	for _, e := range config {
+		known[e.Source+"/"+e.Agent] = struct{}{}
+	}
+	out := append([]render.SkillEntry(nil), config...)
+	for _, r := range resources {
+		if r.Type != discover.ResourceSkill {
+			continue
+		}
+		agent := r.Meta["agent"]
+		key := r.Path + "/" + agent
+		if _, ok := known[key]; ok {
+			continue
+		}
+		out = append(out, render.SkillEntry{
+			Source:    r.Path,
+			Agent:     agent,
+			Status:    render.StatusUnmanaged,
+			Installed: []string{r.Name},
+			Missing:   []string{},
+			Modified:  []string{},
+		})
+	}
+	return out
+}
+
+// reconcileMCPs merges config-driven MCP entries with FS-discovered MCP configs.
+// FS-discovered MCP config files not covered by config are appended as unmanaged.
+func reconcileMCPs(config []render.MCPEntry, resources []discover.Resource) []render.MCPEntry {
+	knownTargets := make(map[string]struct{}, len(config))
+	for _, e := range config {
+		knownTargets[e.Target] = struct{}{}
+	}
+	out := append([]render.MCPEntry(nil), config...)
+	for _, r := range resources {
+		if r.Type != discover.ResourceMCP {
+			continue
+		}
+		if _, ok := knownTargets[r.Path]; ok {
+			continue
+		}
+		out = append(out, render.MCPEntry{
+			Name:   r.Name,
+			Target: r.Path,
+			Status: render.StatusUnmanaged,
+		})
+	}
+	return out
+}
+
+// driftToStatus maps a discover.DriftState to the closest render.StatusCode.
+func driftToStatus(d discover.DriftState) render.StatusCode {
+	switch d {
+	case discover.DriftOK:
+		return render.StatusOK
+	case discover.DriftModified:
+		return render.StatusDirty
+	case discover.DriftMissing:
+		return render.StatusNotCloned
+	default:
+		return render.StatusOK
+	}
 }
 
 func collectRepos(stats []repo.Status) []render.RepoEntry {

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -10,6 +10,7 @@ const (
 	StatusPartial   StatusCode = "partial"
 	StatusPresent   StatusCode = "present"
 	StatusAbsent    StatusCode = "absent"
+	StatusUnmanaged StatusCode = "unmanaged"
 	StatusError     StatusCode = "error"
 )
 

--- a/internal/engine/render/table.go
+++ b/internal/engine/render/table.go
@@ -18,6 +18,7 @@ var statusLabel = map[StatusCode]string{
 	StatusPartial:   "partial",
 	StatusPresent:   "present",
 	StatusAbsent:    "absent",
+	StatusUnmanaged: "unmanaged",
 	StatusError:     "error",
 }
 
@@ -35,6 +36,8 @@ func statusCell(code StatusCode, errMsg string) string {
 		return pterm.FgYellow.Sprint("⚠ " + label)
 	case StatusNotCloned, StatusAbsent, StatusPartial:
 		return pterm.FgYellow.Sprint("~ " + label)
+	case StatusUnmanaged:
+		return pterm.FgCyan.Sprint("? " + label)
 	case StatusError:
 		msg := label
 		if errMsg != "" {

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 
 	"gaal/internal/config"
+	"gaal/internal/discover"
 )
 
 // serverEntry mirrors the MCP server JSON structure used by Claude Desktop,
@@ -39,12 +40,13 @@ type Status struct {
 
 // Manager handles MCP server configuration files.
 type Manager struct {
-	mcps []config.ConfigMcp
+	mcps     []config.ConfigMcp
+	stateDir string // gaal state root for snapshot writing
 }
 
 // NewManager creates a new MCP Manager.
-func NewManager(mcps []config.ConfigMcp) *Manager {
-	return &Manager{mcps: mcps}
+func NewManager(mcps []config.ConfigMcp, stateDir string) *Manager {
+	return &Manager{mcps: mcps, stateDir: stateDir}
 }
 
 // Sync applies every MCP configuration entry.
@@ -82,7 +84,30 @@ func (m *Manager) syncOne(ctx context.Context, mc config.ConfigMcp) error {
 		return fmt.Errorf("no source or inline config provided")
 	}
 
-	return mergeIntoTarget(mc.Target, mc.Name, entry)
+	if err := mergeIntoTarget(mc.Target, mc.Name, entry); err != nil {
+		return err
+	}
+	m.writeMCPSnapshot(mc.Target)
+	return nil
+}
+
+// writeMCPSnapshot records the current state of the target config file so that
+// discover.computeMCPDrift can apply the fast path on subsequent status checks.
+func (m *Manager) writeMCPSnapshot(target string) {
+	if m.stateDir == "" {
+		return
+	}
+	slog.Debug("writing mcp snapshot", "target", target)
+	rec, err := discover.Record(target)
+	if err != nil {
+		slog.Warn("mcp snapshot failed", "target", target, "err", err)
+		return
+	}
+	snap := discover.Snapshot{filepath.Base(target): rec}
+	key := "mcp-" + discover.WorkdirKey(target)
+	if err := discover.Save(discover.SnapshotPath(m.stateDir, key), snap); err != nil {
+		slog.Warn("mcp snapshot save failed", "target", target, "err", err)
+	}
 }
 
 // fetchRemoteEntry downloads a JSON config file and extracts the entry for name.
@@ -183,6 +208,86 @@ func mergeIntoTarget(target, name string, entry serverEntry) error {
 	}
 
 	slog.Info("mcp config updated", "name", name, "target", target)
+	return nil
+}
+
+// Prune removes mcpServers entries from each managed target file whose names
+// are no longer declared in the config for that target. Entries added manually
+// outside of gaal are also removed — callers should only use --prune on files
+// they intend to manage exclusively with gaal.
+func (m *Manager) Prune(ctx context.Context) error {
+	slog.DebugContext(ctx, "pruning orphan mcp entries")
+
+	// Build expected name set per target path.
+	keepPerTarget := make(map[string]map[string]struct{})
+	for _, mc := range m.mcps {
+		if keepPerTarget[mc.Target] == nil {
+			keepPerTarget[mc.Target] = make(map[string]struct{})
+		}
+		keepPerTarget[mc.Target][mc.Name] = struct{}{}
+	}
+
+	for target, keep := range keepPerTarget {
+		data, err := os.ReadFile(target)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			slog.Warn("mcp prune: cannot read target", "target", target, "err", err)
+			continue
+		}
+
+		raw := map[string]json.RawMessage{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			slog.Warn("mcp prune: cannot parse target", "target", target, "err", err)
+			continue
+		}
+
+		serversRaw, ok := raw["mcpServers"]
+		if !ok {
+			continue
+		}
+		servers := map[string]json.RawMessage{}
+		if err := json.Unmarshal(serversRaw, &servers); err != nil {
+			slog.Warn("mcp prune: cannot parse mcpServers", "target", target, "err", err)
+			continue
+		}
+
+		pruned := false
+		for name := range servers {
+			if _, ok := keep[name]; !ok {
+				slog.Info("pruning orphan mcp entry", "name", name, "target", target)
+				delete(servers, name)
+				pruned = true
+			}
+		}
+		if !pruned {
+			continue
+		}
+
+		updated, err := json.Marshal(servers)
+		if err != nil {
+			slog.Warn("mcp prune: marshal error", "target", target, "err", err)
+			continue
+		}
+		raw["mcpServers"] = updated
+
+		out, err := json.MarshalIndent(raw, "", "  ")
+		if err != nil {
+			slog.Warn("mcp prune: indent error", "target", target, "err", err)
+			continue
+		}
+
+		tmp := target + ".tmp"
+		if err := os.WriteFile(tmp, out, 0o600); err != nil {
+			slog.Warn("mcp prune: write error", "target", target, "err", err)
+			continue
+		}
+		if err := os.Rename(tmp, target); err != nil {
+			slog.Warn("mcp prune: rename error", "target", target, "err", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -285,7 +285,10 @@ func (m *Manager) Prune(ctx context.Context) error {
 		}
 		if err := os.Rename(tmp, target); err != nil {
 			slog.Warn("mcp prune: rename error", "target", target, "err", err)
+			continue
 		}
+		// Refresh snapshot so next status check reflects the pruned state.
+		m.writeMCPSnapshot(target)
 	}
 
 	return nil

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -164,7 +164,7 @@ func TestManager_Sync_Inline(t *testing.T) {
 			},
 		},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestManager_Sync_NoSourceOrInline(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "bad", Target: filepath.Join(t.TempDir(), "mcp.json")},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	err := m.Sync(context.Background())
 	if err == nil {
 		t.Fatal("expected error when no source or inline provided")
@@ -188,7 +188,7 @@ func TestManager_Status_Missing(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "srv", Target: "/no/such/file.json"},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -204,7 +204,7 @@ func TestManager_Status_Present(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "my-srv", Target: target},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -227,7 +227,7 @@ func TestManager_Sync_WithSource(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "my-srv", Source: srv.URL, Target: target},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync with source URL: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestManager_Sync_SkipsUninstalledAgentTarget(t *testing.T) {
 			Inline: &config.ConfigMcpItem{Command: "node"},
 		},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestManager_Status_InvalidJSON(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "srv", Target: target},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -404,7 +404,7 @@ func TestManager_Status_DirtyInline(t *testing.T) {
 			Inline: &config.ConfigMcpItem{Command: "new-cmd"},
 		},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -428,7 +428,7 @@ func TestManager_Status_CleanInline(t *testing.T) {
 			Inline: &config.ConfigMcpItem{Command: "node", Args: []string{"server.js"}},
 		},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -446,7 +446,7 @@ func TestManager_Status_SourceNoInline_NoDirtyCheck(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "srv", Target: target, Source: "https://example.com/mcp.json"},
 	}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -687,7 +687,7 @@ func TestManager_Status_ReadError(t *testing.T) {
 	t.Cleanup(func() { os.Chmod(tmp.Name(), 0o644) })
 
 	mcps := []config.ConfigMcp{{Name: "srv", Target: tmp.Name()}}
-	m := NewManager(mcps)
+	m := NewManager(mcps, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -702,5 +702,66 @@ func TestFetchRemoteEntry_InvalidURL(t *testing.T) {
 	_, err := fetchRemoteEntry(context.Background(), "http://\x00invalid", "any")
 	if err == nil {
 		t.Fatal("expected error for URL with null byte")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Prune
+// ---------------------------------------------------------------------------
+
+func TestMCPPrune_RemovesOrphanEntry(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "mcp.json")
+	// File has two entries: managed (kept) and orphan.
+	initial := `{"mcpServers":{"kept":{"command":"node"},"orphan":{"command":"python"}}}`
+	os.WriteFile(target, []byte(initial), 0o644)
+
+	// Config only declares "kept".
+	cfg := []config.ConfigMcp{
+		{Name: "kept", Target: target, Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	m := NewManager(cfg, "")
+	if err := m.Prune(context.Background()); err != nil {
+		t.Fatalf("Prune returned error: %v", err)
+	}
+
+	data, _ := os.ReadFile(target)
+	var doc struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	json.Unmarshal(data, &doc)
+	if _, ok := doc.MCPServers["orphan"]; ok {
+		t.Error("expected orphan entry to be removed")
+	}
+	if _, ok := doc.MCPServers["kept"]; !ok {
+		t.Error("expected kept entry to remain")
+	}
+}
+
+func TestMCPPrune_NoOpWhenAllManaged(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "mcp.json")
+	initial := `{"mcpServers":{"myserver":{"command":"node"}}}`
+	os.WriteFile(target, []byte(initial), 0o644)
+
+	cfg := []config.ConfigMcp{
+		{Name: "myserver", Target: target, Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	m := NewManager(cfg, "")
+	if err := m.Prune(context.Background()); err != nil {
+		t.Fatalf("Prune returned error: %v", err)
+	}
+	data, _ := os.ReadFile(target)
+	if string(data) != initial {
+		t.Errorf("file should be unchanged, got: %s", data)
+	}
+}
+
+func TestMCPPrune_MissingFileIsNoOp(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "nonexistent.json")
+	cfg := []config.ConfigMcp{
+		{Name: "x", Target: target, Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	m := NewManager(cfg, "")
+	if err := m.Prune(context.Background()); err != nil {
+		t.Fatalf("Prune returned error: %v", err)
 	}
 }

--- a/internal/repo/backends_test.go
+++ b/internal/repo/backends_test.go
@@ -12,14 +12,14 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestNewManager_Empty(t *testing.T) {
-	m := NewManager(nil)
+	m := NewManager(nil, "")
 	if m == nil {
 		t.Fatal("expected non-nil Manager")
 	}
 }
 
 func TestManager_Sync_Empty(t *testing.T) {
-	m := NewManager(nil)
+	m := NewManager(nil, "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync on empty manager: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestManager_Sync_ArchiveAlreadyCloned(t *testing.T) {
 	repos := map[string]config.ConfigRepo{
 		existing: {Type: "tar", URL: "https://example.com/x.tar.gz"},
 	}
-	m := NewManager(repos)
+	m := NewManager(repos, "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync with already-cloned archive: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestManager_Sync_UnknownType(t *testing.T) {
 	repos := map[string]config.ConfigRepo{
 		"/tmp/nope": {Type: "cvs", URL: "https://example.com/x"},
 	}
-	m := NewManager(repos)
+	m := NewManager(repos, "")
 	if err := m.Sync(context.Background()); err == nil {
 		t.Fatal("expected error for unknown VCS type")
 	}
@@ -51,7 +51,7 @@ func TestManager_Status_NotCloned(t *testing.T) {
 	repos := map[string]config.ConfigRepo{
 		"/tmp/not-cloned": {Type: "tar", URL: "https://example.com/x.tar.gz"},
 	}
-	m := NewManager(repos)
+	m := NewManager(repos, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -66,7 +66,7 @@ func TestManager_Status_Cloned(t *testing.T) {
 	repos := map[string]config.ConfigRepo{
 		existing: {Type: "tar", URL: "https://example.com/x.tar.gz"},
 	}
-	m := NewManager(repos)
+	m := NewManager(repos, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -82,7 +82,7 @@ func TestManager_Status_CurrentVersionError(t *testing.T) {
 	repos := map[string]config.ConfigRepo{
 		existing: {Type: "tar", URL: "https://example.com/x.tar.gz", Version: "v1"},
 	}
-	m := NewManager(repos)
+	m := NewManager(repos, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -101,7 +101,7 @@ func TestManager_Status_DirtyFalse_Archive(t *testing.T) {
 	repos := map[string]config.ConfigRepo{
 		existing: {Type: "tar", URL: "https://example.com/x.tar.gz"},
 	}
-	m := NewManager(repos)
+	m := NewManager(repos, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))

--- a/internal/repo/manager.go
+++ b/internal/repo/manager.go
@@ -24,12 +24,13 @@ type Status struct {
 
 // Manager handles the synchronisation of all repositories.
 type Manager struct {
-	repos map[string]config.ConfigRepo
+	repos    map[string]config.ConfigRepo
+	stateDir string // reserved for future snapshot use
 }
 
 // NewManager creates a new repository Manager.
-func NewManager(repos map[string]config.ConfigRepo) *Manager {
-	return &Manager{repos: repos}
+func NewManager(repos map[string]config.ConfigRepo, stateDir string) *Manager {
+	return &Manager{repos: repos, stateDir: stateDir}
 }
 
 // Sync clones or updates every repository in parallel.

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -569,11 +569,27 @@ func (m *Manager) Prune(ctx context.Context) error {
 			slog.Info("pruning orphan skill", "path", target)
 			if err := os.RemoveAll(target); err != nil {
 				slog.Warn("failed to prune skill", "path", target, "err", err)
+				continue
 			}
+			m.pruneSkillSnapshot(target)
 		}
 	}
 
 	return nil
+}
+
+// pruneSkillSnapshot removes the snapshot file for a skill directory that has
+// been deleted by Prune. Errors are logged but never returned.
+func (m *Manager) pruneSkillSnapshot(dest string) {
+	if m.stateDir == "" {
+		return
+	}
+	key := "skill-" + discover.WorkdirKey(dest)
+	path := discover.SnapshotPath(m.stateDir, key)
+	slog.Debug("removing stale skill snapshot", "path", path)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to remove stale skill snapshot", "path", path, "err", err)
+	}
 }
 
 // writeSkillSnapshot snapshots the installed skill directory at dest and

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -13,6 +13,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/core/vcs"
+	"gaal/internal/discover"
 )
 
 // buildDiscoveryDirs returns the deduplicated list of subdirectories to scan
@@ -81,16 +82,19 @@ type Manager struct {
 	cacheDir string // root of the local skill cache
 	home     string // expanded user home directory
 	workDir  string // project working directory (for project-scoped installs)
+	stateDir string // gaal state root (~/.cache/gaal/state) for snapshot writing
 }
 
 // NewManager creates a new skill Manager.
 // cacheDir is where remote sources are cloned/downloaded (e.g. ~/.cache/gaal/skills).
-func NewManager(skills []config.ConfigSkill, cacheDir, home, workDir string) *Manager {
+// stateDir is where post-sync snapshots are persisted (e.g. ~/.cache/gaal/state).
+func NewManager(skills []config.ConfigSkill, cacheDir, home, workDir, stateDir string) *Manager {
 	return &Manager{
 		skills:   skills,
 		cacheDir: cacheDir,
 		home:     home,
 		workDir:  workDir,
+		stateDir: stateDir,
 	}
 }
 
@@ -150,6 +154,7 @@ func (m *Manager) syncOne(ctx context.Context, sc config.ConfigSkill) error {
 				return fmt.Errorf("installing skill %q to agent %q: %w", sk.Name, agent, err)
 			}
 			slog.Info("installed skill", "name", sk.Name, "agent", agent, "dest", dest)
+			m.writeSkillSnapshot(dest)
 		}
 	}
 
@@ -508,4 +513,85 @@ func cachedSourcePath(cacheDir, source string) (string, error) {
 		return "", nil // not yet cached
 	}
 	return path, nil
+}
+
+// Prune removes skill directories that are present on disk under managed agent
+// skill directories but are no longer declared in any config entry. It is safe
+// to call after Sync: sources are already cached so no network access occurs.
+func (m *Manager) Prune(ctx context.Context) error {
+	slog.DebugContext(ctx, "pruning orphan skills")
+
+	// Build the set of expected skill dir-names per absolute skills directory.
+	expected := make(map[string]map[string]struct{})
+
+	for _, sc := range m.skills {
+		sourceDir, err := cachedSourcePath(m.cacheDir, sc.Source)
+		if err != nil || sourceDir == "" {
+			continue // source not yet cached — nothing to prune against it
+		}
+		available, err := discoverSkills(sourceDir)
+		if err != nil {
+			continue
+		}
+		selected := filterSkills(available, sc.Select)
+
+		for _, agent := range m.syncAgents(sc) {
+			skillsDir, ok := SkillDir(agent, sc.Global, m.home)
+			if !ok {
+				continue
+			}
+			if !sc.Global && !filepath.IsAbs(skillsDir) {
+				skillsDir = filepath.Join(m.workDir, skillsDir)
+			}
+			if expected[skillsDir] == nil {
+				expected[skillsDir] = make(map[string]struct{})
+			}
+			for _, sk := range selected {
+				expected[skillsDir][filepath.Base(sk.Dir)] = struct{}{}
+			}
+		}
+	}
+
+	// Walk each managed skills directory and remove entries absent from expected.
+	for skillsDir, keep := range expected {
+		entries, err := os.ReadDir(skillsDir)
+		if err != nil {
+			continue // directory may not exist
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			if _, ok := keep[entry.Name()]; ok {
+				continue
+			}
+			target := filepath.Join(skillsDir, entry.Name())
+			slog.Info("pruning orphan skill", "path", target)
+			if err := os.RemoveAll(target); err != nil {
+				slog.Warn("failed to prune skill", "path", target, "err", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// writeSkillSnapshot snapshots the installed skill directory at dest and
+// persists it to stateDir so that discover.DiffPath can use the fast path on
+// subsequent status checks. Errors are logged but never returned — snapshot
+// failures must never break the sync.
+func (m *Manager) writeSkillSnapshot(dest string) {
+	if m.stateDir == "" {
+		return
+	}
+	slog.Debug("writing skill snapshot", "dest", dest)
+	snap, err := discover.SnapshotDir(dest)
+	if err != nil {
+		slog.Warn("skill snapshot failed", "dest", dest, "err", err)
+		return
+	}
+	key := "skill-" + discover.WorkdirKey(dest)
+	if err := discover.Save(discover.SnapshotPath(m.stateDir, key), snap); err != nil {
+		slog.Warn("skill snapshot save failed", "dest", dest, "err", err)
+	}
 }

--- a/internal/skill/manager_helpers_test.go
+++ b/internal/skill/manager_helpers_test.go
@@ -96,7 +96,7 @@ func TestManager_Sync_LocalSource_WithSkills(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir)
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -111,14 +111,14 @@ func TestManager_Sync_NoSkillsFound(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir())
+	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync with no skills: %v", err)
 	}
 }
 
 func TestResolveAgents_ExplicitList(t *testing.T) {
-	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir())
+	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "")
 	sc := config.ConfigSkill{Agents: []string{"claude-code", "cursor"}}
 	agents := m.resolveAgents(sc)
 	if len(agents) != 2 {
@@ -129,7 +129,7 @@ func TestResolveAgents_ExplicitList(t *testing.T) {
 func TestResolveAgents_Wildcard(t *testing.T) {
 	workDir := t.TempDir()
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
-	m := NewManager(nil, t.TempDir(), "/home/user", workDir)
+	m := NewManager(nil, t.TempDir(), "/home/user", workDir, "")
 	sc := config.ConfigSkill{Agents: []string{"*"}}
 	agents := m.resolveAgents(sc)
 	found := false
@@ -146,7 +146,7 @@ func TestResolveAgents_Wildcard(t *testing.T) {
 func TestResolveAgents_Empty(t *testing.T) {
 	workDir := t.TempDir()
 	os.MkdirAll(filepath.Join(workDir, ".roo"), 0o755)
-	m := NewManager(nil, t.TempDir(), "/home/user", workDir)
+	m := NewManager(nil, t.TempDir(), "/home/user", workDir, "")
 	sc := config.ConfigSkill{Agents: nil}
 	agents := m.resolveAgents(sc)
 	found := false
@@ -161,7 +161,7 @@ func TestResolveAgents_Empty(t *testing.T) {
 }
 
 func TestManager_Status_Empty(t *testing.T) {
-	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir())
+	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 0 {
 		t.Errorf("expected 0 statuses for empty manager, got %d", len(statuses))
@@ -175,7 +175,7 @@ func TestManager_Status_Empty(t *testing.T) {
 func TestResolveSource_LocalNonGit_ReturnedAsIs(t *testing.T) {
 	// A plain directory (no .git) must be returned without any git operation.
 	src := t.TempDir()
-	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir())
+	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "")
 	got, err := m.resolveSource(context.Background(), src)
 	if err != nil {
 		t.Fatalf("resolveSource: %v", err)
@@ -191,7 +191,7 @@ func TestResolveSource_LocalGit_UpdateAttempted(t *testing.T) {
 	// still return the path (the failure is only a warning).
 	src := t.TempDir()
 	os.MkdirAll(filepath.Join(src, ".git"), 0o755)
-	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir())
+	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "")
 	// The git binary must be present; skip on machines without git in PATH.
 	got, err := m.resolveSource(context.Background(), src)
 	if err != nil {
@@ -227,7 +227,7 @@ func TestManager_Sync_PreCachedRemoteSource(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: "owner/pre-cached", Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, cacheDir, "/home/user", workDir)
+	m := NewManager(skills, cacheDir, "/home/user", workDir, "")
 
 	// git update will fail (not a real repo) but the error is swallowed by resolveSource.
 	// Sync should still succeed.
@@ -245,7 +245,7 @@ func TestManager_Sync_CloneError(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: "http://localhost:1/not-a-repo.git", Agents: []string{"claude-code"}},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir())
+	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "")
 	err := m.Sync(context.Background())
 	if err == nil {
 		t.Fatal("expected error when git clone fails (unreachable host)")

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -193,7 +193,7 @@ func TestDetectInstalledAgents_ProjectScope(t *testing.T) {
 	// Create the parent config dir for one known agent (claude-code uses .claude/).
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
 
-	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir)
+	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "")
 	found := m.detectInstalledAgents(false)
 
 	hadAgent := false
@@ -247,7 +247,7 @@ func TestManager_Status_UnknownAgent(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"unknown-agent-xyz"}},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir())
+	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -264,7 +264,7 @@ func TestManager_Status_SourceNotCached(t *testing.T) {
 	}
 	workDir := t.TempDir()
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir)
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -291,7 +291,7 @@ func TestManager_Status_InstalledAndMissing(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir)
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
 	statuses := m.Status(context.Background())
 
 	if len(statuses) != 1 {
@@ -336,7 +336,7 @@ func TestManager_Sync_UnknownAgent_SkipsWithWarn(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"unknown-agent-xyz"}},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir())
+	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "")
 	// Should not error — unknown agent is warned and skipped.
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync with unknown agent should succeed: %v", err)
@@ -398,7 +398,7 @@ func TestDetectInstalledAgents_GlobalScope(t *testing.T) {
 	// Claude global scope uses "~/.claude/skills" → parent is ~/.claude.
 	home := t.TempDir()
 	os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
-	m := NewManager(nil, t.TempDir(), home, t.TempDir())
+	m := NewManager(nil, t.TempDir(), home, t.TempDir(), "")
 	found := m.detectInstalledAgents(true)
 	hadAgent := false
 	for _, name := range found {
@@ -423,7 +423,7 @@ func TestSyncAgents_ExplicitList_ProjectScope_FiltersUninstalled(t *testing.T) {
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
 	// zencoder is NOT installed — .zencoder/ does not exist.
 
-	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir)
+	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "")
 	got := m.syncAgents(config.ConfigSkill{
 		Source: "owner/repo",
 		Agents: []string{"claude-code", "zencoder"},
@@ -447,7 +447,7 @@ func TestSyncAgents_ExplicitList_GlobalScope_FiltersUninstalled(t *testing.T) {
 	os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
 	// zencoder is NOT installed — ~/.zencoder/ does not exist.
 
-	m := NewManager(nil, t.TempDir(), home, t.TempDir())
+	m := NewManager(nil, t.TempDir(), home, t.TempDir(), "")
 	got := m.syncAgents(config.ConfigSkill{
 		Source: "owner/repo",
 		Agents: []string{"claude-code", "zencoder"},
@@ -464,7 +464,7 @@ func TestSyncAgents_ExplicitList_GlobalScope_FiltersUninstalled(t *testing.T) {
 
 func TestSyncAgents_ExplicitList_AllUninstalled_ReturnsEmpty(t *testing.T) {
 	workDir := t.TempDir() // fresh, no agent dirs
-	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir)
+	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "")
 	got := m.syncAgents(config.ConfigSkill{
 		Source: "owner/repo",
 		Agents: []string{"zencoder", "kilo"},
@@ -481,7 +481,7 @@ func TestSyncAgents_Wildcard_StillWorks(t *testing.T) {
 	// is a no-op.
 	workDir := t.TempDir()
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
-	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir)
+	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "")
 	got := m.syncAgents(config.ConfigSkill{
 		Source: "owner/repo",
 		Agents: []string{"*"},
@@ -577,7 +577,7 @@ func TestManager_Status_ModifiedSkill(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir)
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
 	statuses := m.Status(context.Background())
 
 	if len(statuses) != 1 {
@@ -615,7 +615,7 @@ func TestManager_Status_CleanSkill(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir)
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
 	statuses := m.Status(context.Background())
 
 	if len(statuses) != 1 {
@@ -678,5 +678,77 @@ func TestCopyFile_WriteError(t *testing.T) {
 	err := copyFile(srcFile, filepath.Join(parent, "dst.txt"))
 	if err == nil {
 		t.Fatal("expected error when destination parent is not writable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Prune
+// ---------------------------------------------------------------------------
+
+func TestPrune_RemovesOrphanSkill(t *testing.T) {
+	// Source has two skills: kept-skill and orphan-skill.
+	sourceDir := t.TempDir()
+	for _, name := range []string{"kept-skill", "orphan-skill"} {
+		dir := filepath.Join(sourceDir, name)
+		os.MkdirAll(dir, 0o755)
+		os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: "+name+"\n---\n"), 0o644)
+	}
+
+	// Agent dir simulates an already-installed state: both skills are present.
+	agentSkillsDir := t.TempDir()
+	agentParent := filepath.Dir(agentSkillsDir)
+	// workDir must have a subdirectory matching the agent's project_skills_dir.
+	// Use a local-path skill with an absolute skillsDir to avoid agent registry lookup.
+	for _, name := range []string{"kept-skill", "orphan-skill"} {
+		os.MkdirAll(filepath.Join(agentSkillsDir, name), 0o755)
+	}
+
+	// Config only selects kept-skill.
+	cfg := []config.ConfigSkill{
+		{Source: sourceDir, Select: []string{"kept-skill"}, Agents: []string{"claude-code"}, Global: true},
+	}
+
+	// Build a manager whose home points to agentParent so that SkillDir
+	// for claude-code global resolves to agentParent/.claude/skills.
+	// We pre-create the directory and redirect home to agentParent.
+	claudeSkillsDir := filepath.Join(agentParent, ".claude", "skills")
+	os.MkdirAll(claudeSkillsDir, 0o755)
+	for _, name := range []string{"kept-skill", "orphan-skill"} {
+		os.MkdirAll(filepath.Join(claudeSkillsDir, name), 0o755)
+	}
+
+	m := NewManager(cfg, t.TempDir(), agentParent, t.TempDir(), "")
+	if err := m.Prune(context.Background()); err != nil {
+		t.Fatalf("Prune returned error: %v", err)
+	}
+
+	// orphan-skill must be gone, kept-skill must remain.
+	if _, err := os.Stat(filepath.Join(claudeSkillsDir, "orphan-skill")); err == nil {
+		t.Error("expected orphan-skill to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(claudeSkillsDir, "kept-skill")); err != nil {
+		t.Errorf("expected kept-skill to remain: %v", err)
+	}
+}
+
+func TestPrune_NoOpWhenAllManaged(t *testing.T) {
+	sourceDir := t.TempDir()
+	skillDir := filepath.Join(sourceDir, "my-skill")
+	os.MkdirAll(skillDir, 0o755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: my-skill\n---\n"), 0o644)
+
+	home := t.TempDir()
+	claudeSkillsDir := filepath.Join(home, ".claude", "skills")
+	os.MkdirAll(filepath.Join(claudeSkillsDir, "my-skill"), 0o755)
+
+	cfg := []config.ConfigSkill{
+		{Source: sourceDir, Agents: []string{"claude-code"}, Global: true},
+	}
+	m := NewManager(cfg, t.TempDir(), home, t.TempDir(), "")
+	if err := m.Prune(context.Background()); err != nil {
+		t.Fatalf("Prune returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(claudeSkillsDir, "my-skill")); err != nil {
+		t.Errorf("expected my-skill to remain: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a new `internal/discover` package that provides **configuration-independent** resource discovery: gaal can now detect skills, repos, and MCP configs that are installed on disk regardless of whether they appear in `gaal.yaml`.

Inspired by the Git index model (stat → size+mtime fast-path → sha256 fallback).

---

## Changes

### New package `internal/discover`

| File | Description |
|------|-------------|
| `resource.go` | `ResourceType`, `Scope`, `DriftState`, `Resource` types |
| `snapshot.go` | `FileRecord`/`Snapshot`, atomic `Save`/`Load`, `DiffPath` (Git fast-path) |
| `scan.go` | Public `Scan()` entry point — `maxDepth=4`, `timeout=2s` |
| `global.go` | Scan agent-registry skill directories; VCS-native drift with snapshot fallback |
| `workspace.go` | Depth-limited FS walk for repos + skills in `workDir` |
| `mcp.go` | Scan agent MCP config files; hash-based drift |

Snapshots are stored in `$XDG_CACHE_HOME/gaal/state/` (fully sandbox-aware).

### FS-first `gaal status`

- `engine/ops/status.go`: `Collect()` runs `discover.Scan()` first, then reconciles config-declared resources on top
- Resources on disk but absent from config → `StatusUnmanaged` (`? unmanaged` in cyan)
- New `render.StatusUnmanaged` constant + table/JSON rendering

### Post-sync snapshot writes

- `skill/manager.go`: `writeSkillSnapshot()` after each `installSkill()`
- `mcp/manager.go`: `writeMCPSnapshot()` after each `mergeIntoTarget()`

### `gaal sync --prune`

Removes resources installed on disk that are no longer declared in config:

- **Skills**: deletes subdirs in managed agent skill directories
- **MCPs**: removes `mcpServers` entries from managed JSON files (atomic write)
- **Repos**: not pruned — deletion of cloned trees requires explicit user action
- Incompatible with `--service` (destructive, no loop)

### Bug fix

Engine tests (`TestRunOnce_WithMCP_Inline`, `TestRunOnce_WithSkills_LocalSource`) now pass `Options{StateDir: t.TempDir()}` to prevent writing snapshots into the real `~/.cache` during `make test`.

---

## Tests

- 53 new tests in `internal/discover`
- New `Prune` tests in `internal/skill` and `internal/mcp`
- All existing tests updated for new `NewManager` signatures
- `make test` — all green ✓

## Docs

- New `docs/discover.md` — full reference for `internal/discover`
- Updated `docs/architecture.md` — package tree + `internal/discover` section