### PR TITLE
feat: ship curl install script for macOS and Linux

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for gaal-lite.
+#
+# Changes to files matching a pattern below require review from at least
+# one of the listed owners. See:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Install script — curl-piped-to-sh is a high-blast-radius file.
+# Every change requires review from a project owner.
+scripts/install.sh @Theosakamg @gmoigneu @gregqualls

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         env:
           SHELLCHECK_OPTS: --shell=sh
         with:
@@ -56,4 +56,4 @@ jobs:
           # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
 
       - name: Run install script integration tests
-        run: go test ./internal/installscript/ -v
+        run: go test -race ./internal/installscript/ -v

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -1,0 +1,59 @@
+name: Install Script
+
+# Gate changes to scripts/install.sh and its integration test on:
+#   1. shellcheck (POSIX strict mode)
+#   2. Go integration test against a local httptest fake of GitHub Releases
+#
+# This workflow is marked as a required status check on main; combined with
+# the CODEOWNERS rule on scripts/install.sh, every change to the install
+# pipeline gets a human review AND an automated verification.
+on:
+  pull_request:
+    paths:
+      - 'scripts/install.sh'
+      - 'internal/installscript/**'
+      - '.github/workflows/install-script.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/install.sh'
+      - 'internal/installscript/**'
+      - '.github/workflows/install-script.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Shellcheck (POSIX sh)
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: --shell=sh
+        with:
+          scandir: scripts
+          severity: style
+
+  integration-test:
+    name: Go integration test
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux, runner: [self-hosted, Linux, X64] }
+          - { name: macOS, runner: [self-hosted, macOS, ARM64] }
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
+
+      - name: Run install script integration tests
+        run: go test ./internal/installscript/ -v

--- a/README.md
+++ b/README.md
@@ -362,7 +362,29 @@ See [`docs/architecture.md`](docs/architecture.md) for a full description of the
 
 ---
 
-## Install from source
+## Install
+
+### Quick install (macOS / Linux)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | sh
+```
+
+Installs the latest release binary to `~/.local/bin/gaal`. Pin a specific
+version with `VERSION=v0.1.2`, or pick a different directory with
+`INSTALL_DIR=/usr/local/bin`.
+
+Pass `GAAL_INSTALL_DEBUG=1` for verbose output, or run
+`curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | sh -s -- --help`
+to see all options.
+
+### With Go
+
+```bash
+go install github.com/gmg-inc/gaal-lite@latest
+```
+
+### From source
 
 **Prerequisites:** Go 1.26+
 
@@ -378,12 +400,6 @@ The binary is written to `dist/gaal`. Copy it to your `$PATH`:
 sudo cp dist/gaal /usr/local/bin/gaal
 # or, user-local:
 cp dist/gaal ~/.local/bin/gaal
-```
-
-To install directly with Go:
-
-```bash
-go install github.com/gmg-inc/gaal-lite@latest
 ```
 
 ---

--- a/internal/installscript/doc.go
+++ b/internal/installscript/doc.go
@@ -1,0 +1,7 @@
+// Package installscript hosts integration tests for scripts/install.sh.
+//
+// These tests spin up a local HTTP server that mimics GitHub Releases and
+// exec the shell script against it. The script honors the (test-only)
+// GAAL_INSTALL_BASE_URL env var so the test can point it at the local
+// server without touching github.com.
+package installscript

--- a/internal/installscript/install_test.go
+++ b/internal/installscript/install_test.go
@@ -190,3 +190,46 @@ func TestInstallChecksumMismatch(t *testing.T) {
 		t.Fatalf("expected no file at %s on checksum mismatch, but it exists (err=%v)", filepath.Join(installDir, "gaal"), statErr)
 	}
 }
+
+func TestInstallAlreadyInstalled(t *testing.T) {
+	version := "v9.9.9"
+	goos := detectHostGOOS(t)
+	goarch := detectHostGOARCH(t)
+	binary := fakeGaalBinary(version)
+
+	server := fakeReleaseServer(t, version, goos, goarch, binary)
+	defer server.Close()
+
+	installDir := t.TempDir()
+	env := map[string]string{"GAAL_INSTALL_BASE_URL": server.URL}
+
+	// First run: install.
+	if _, stderr, err := runInstall(t, installDir, env); err != nil {
+		t.Fatalf("first install failed: %v\nstderr: %s", err, stderr)
+	}
+
+	// Record the mtime of the installed binary to prove the second run
+	// does not touch the file.
+	installedPath := filepath.Join(installDir, "gaal")
+	info1, err := os.Stat(installedPath)
+	if err != nil {
+		t.Fatalf("stat after first install: %v", err)
+	}
+
+	// Second run: must short-circuit.
+	stdout, stderr, err := runInstall(t, installDir, env)
+	if err != nil {
+		t.Fatalf("second install failed: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(stdout, "already installed") {
+		t.Errorf("expected stdout to mention 'already installed', got: %s", stdout)
+	}
+
+	info2, err := os.Stat(installedPath)
+	if err != nil {
+		t.Fatalf("stat after second install: %v", err)
+	}
+	if !info1.ModTime().Equal(info2.ModTime()) {
+		t.Errorf("expected file mtime unchanged on no-op rerun (before=%v, after=%v)", info1.ModTime(), info2.ModTime())
+	}
+}

--- a/internal/installscript/install_test.go
+++ b/internal/installscript/install_test.go
@@ -1,0 +1,148 @@
+package installscript
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// scriptPath returns the absolute path to scripts/install.sh, computed from
+// this test file's own location so it works regardless of the `go test`
+// working directory.
+func scriptPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	return filepath.Join(repoRoot, "scripts", "install.sh")
+}
+
+// fakeGaalBinary returns the bytes of a minimal POSIX shell script that
+// behaves like `gaal version` when invoked with "version" as its first arg.
+// The test uses this as the "binary" the install script will download and
+// install.
+func fakeGaalBinary(version string) []byte {
+	return []byte(fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "gaal %s (built: 2026-04-12T00:00:00Z)"
+  exit 0
+fi
+echo "fake gaal" >&2
+exit 0
+`, version))
+}
+
+// sha256hex returns the lowercase hex-encoded SHA-256 of data.
+func sha256hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// fakeReleaseServer returns an httptest.Server that serves a fake GitHub
+// Releases API response, a fake binary for the given platform, and a
+// SHA256SUMS file. The caller closes it with server.Close().
+func fakeReleaseServer(t *testing.T, version, goos, goarch string, binary []byte) *httptest.Server {
+	t.Helper()
+	binName := fmt.Sprintf("gaal-%s-%s", goos, goarch)
+	sumsContent := fmt.Sprintf("%s  %s\n", sha256hex(binary), binName)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/gmg-inc/gaal-lite/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"tag_name":%q}`, version)
+	})
+	mux.HandleFunc(fmt.Sprintf("/releases/download/%s/%s", version, binName), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write(binary)
+	})
+	mux.HandleFunc(fmt.Sprintf("/releases/download/%s/SHA256SUMS", version), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, sumsContent)
+	})
+	return httptest.NewServer(mux)
+}
+
+// runInstall execs scripts/install.sh with the given env overrides. It
+// returns stdout, stderr, and the exec error (if any). Output is captured
+// as strings for easy assertion.
+func runInstall(t *testing.T, installDir string, env map[string]string) (string, string, error) {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", scriptPath(t))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("INSTALL_DIR=%s", installDir))
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+// detectHostGOOS returns the current OS in the goos naming the release
+// workflow uses: "linux" or "darwin". Tests that depend on matching the
+// running host's binary use this.
+func detectHostGOOS(t *testing.T) string {
+	t.Helper()
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		return runtime.GOOS
+	default:
+		t.Skipf("install.sh only supports linux and darwin; host is %s", runtime.GOOS)
+		return ""
+	}
+}
+
+// detectHostGOARCH returns the current arch as "amd64" or "arm64".
+func detectHostGOARCH(t *testing.T) string {
+	t.Helper()
+	switch runtime.GOARCH {
+	case "amd64", "arm64":
+		return runtime.GOARCH
+	default:
+		t.Skipf("install.sh only supports amd64 and arm64; host is %s", runtime.GOARCH)
+		return ""
+	}
+}
+
+func TestInstallHappyPath(t *testing.T) {
+	version := "v9.9.9"
+	goos := detectHostGOOS(t)
+	goarch := detectHostGOARCH(t)
+	binary := fakeGaalBinary(version)
+
+	server := fakeReleaseServer(t, version, goos, goarch, binary)
+	defer server.Close()
+
+	installDir := t.TempDir()
+
+	stdout, stderr, err := runInstall(t, installDir, map[string]string{
+		"GAAL_INSTALL_BASE_URL": server.URL,
+	})
+	if err != nil {
+		t.Fatalf("install.sh failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	installedPath := filepath.Join(installDir, "gaal")
+	info, statErr := os.Stat(installedPath)
+	if statErr != nil {
+		t.Fatalf("expected %s to exist: %v", installedPath, statErr)
+	}
+	if info.Mode().Perm()&0111 == 0 {
+		t.Fatalf("expected %s to be executable, got mode %v", installedPath, info.Mode())
+	}
+
+	if !strings.Contains(stdout, version) {
+		t.Errorf("expected stdout to mention %s, got: %s", version, stdout)
+	}
+}

--- a/internal/installscript/install_test.go
+++ b/internal/installscript/install_test.go
@@ -146,3 +146,47 @@ func TestInstallHappyPath(t *testing.T) {
 		t.Errorf("expected stdout to mention %s, got: %s", version, stdout)
 	}
 }
+
+func TestInstallChecksumMismatch(t *testing.T) {
+	version := "v9.9.9"
+	goos := detectHostGOOS(t)
+	goarch := detectHostGOARCH(t)
+	realBinary := fakeGaalBinary(version)
+
+	// Stand up a fake server that serves a DIFFERENT binary from the one
+	// the SHA256SUMS file references. This mimics "someone tampered with
+	// the release asset after the checksums were published."
+	binName := fmt.Sprintf("gaal-%s-%s", goos, goarch)
+	tamperedBinary := []byte("#!/bin/sh\necho tampered\n")
+	sumsContent := fmt.Sprintf("%s  %s\n", sha256hex(realBinary), binName)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/gmg-inc/gaal-lite/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"tag_name":%q}`, version)
+	})
+	mux.HandleFunc(fmt.Sprintf("/releases/download/%s/%s", version, binName), func(w http.ResponseWriter, r *http.Request) {
+		w.Write(tamperedBinary)
+	})
+	mux.HandleFunc(fmt.Sprintf("/releases/download/%s/SHA256SUMS", version), func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, sumsContent)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	installDir := t.TempDir()
+
+	_, stderr, err := runInstall(t, installDir, map[string]string{
+		"GAAL_INSTALL_BASE_URL": server.URL,
+	})
+	if err == nil {
+		t.Fatal("expected install.sh to fail on checksum mismatch, got success")
+	}
+	if !strings.Contains(stderr, "checksum mismatch") {
+		t.Errorf("expected stderr to contain 'checksum mismatch', got: %s", stderr)
+	}
+
+	// Most important: the tampered binary must NOT have landed in INSTALL_DIR.
+	if _, statErr := os.Stat(filepath.Join(installDir, "gaal")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no file at %s on checksum mismatch, but it exists (err=%v)", filepath.Join(installDir, "gaal"), statErr)
+	}
+}

--- a/internal/installscript/install_test.go
+++ b/internal/installscript/install_test.go
@@ -233,3 +233,26 @@ func TestInstallAlreadyInstalled(t *testing.T) {
 		t.Errorf("expected file mtime unchanged on no-op rerun (before=%v, after=%v)", info1.ModTime(), info2.ModTime())
 	}
 }
+
+func TestInstallUnsupportedArch(t *testing.T) {
+	// Use a real httptest server so we reach the script; the script should
+	// fail inside detect_arch (which runs before any network calls) without
+	// ever hitting the server.
+	server := fakeReleaseServer(t, "v9.9.9", "linux", "amd64", fakeGaalBinary("v9.9.9"))
+	defer server.Close()
+
+	installDir := t.TempDir()
+	_, stderr, err := runInstall(t, installDir, map[string]string{
+		"GAAL_INSTALL_BASE_URL":      server.URL,
+		"GAAL_INSTALL_ARCH_OVERRIDE": "powerpc",
+	})
+	if err == nil {
+		t.Fatal("expected install.sh to fail on unsupported arch, got success")
+	}
+	if !strings.Contains(stderr, "unsupported architecture: powerpc") {
+		t.Errorf("expected stderr to contain 'unsupported architecture: powerpc', got: %s", stderr)
+	}
+	if _, statErr := os.Stat(filepath.Join(installDir, "gaal")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no file at %s on unsupported arch, but it exists (err=%v)", filepath.Join(installDir, "gaal"), statErr)
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -120,6 +120,18 @@ VERSION_TO_INSTALL=$(resolve_version)
 # --- install dir resolution --------------------------------------------------
 INSTALL_DIR="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
 
+# --- already-installed short-circuit -----------------------------------------
+# If the binary already exists at the target path and reports the version we
+# were about to install, exit 0 without touching anything. Dev builds (e.g.
+# "v0.1.0-58-g324271c-dirty") never match a clean tag, so they always upgrade.
+if [ -x "$INSTALL_DIR/$BIN_NAME" ]; then
+  installed_version=$("$INSTALL_DIR/$BIN_NAME" version 2>/dev/null | awk '{print $2}' || echo "")
+  if [ -n "$installed_version" ] && [ "$installed_version" = "$VERSION_TO_INSTALL" ]; then
+    log "$BIN_NAME $installed_version already installed — nothing to do"
+    exit 0
+  fi
+fi
+
 # --- download, verify, install -----------------------------------------------
 if [ -n "$GAAL_INSTALL_BASE_URL" ]; then
   download_base="$GAAL_INSTALL_BASE_URL/releases/download/$VERSION_TO_INSTALL"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -61,7 +61,7 @@ Examples:
   # Pin to v0.1.2
   curl -fsSL <URL> | VERSION=v0.1.2 sh
 
-  # System-wide install (will prompt for sudo on the final move)
+  # System-wide install (will prompt for sudo on install)
   curl -fsSL <URL> | INSTALL_DIR=/usr/local/bin sh
 
 Report issues: https://github.com/gmg-inc/gaal-lite/issues

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,27 +161,42 @@ if [ "$actual" != "$expected" ]; then
 fi
 
 # --- install -----------------------------------------------------------------
-mkdir -p "$INSTALL_DIR" || die "failed to create $INSTALL_DIR"
-
 target="$INSTALL_DIR/$BIN_NAME"
 use_sudo=""
-if [ ! -w "$INSTALL_DIR" ]; then
+
+# Pick the directory whose writability decides whether we need sudo. If the
+# install dir already exists, check it directly; otherwise check the nearest
+# existing ancestor (so "$HOME/.local/bin" when ~/.local/bin doesn't exist
+# yet still resolves to ~/.local or ~).
+probe_dir="$INSTALL_DIR"
+while [ ! -d "$probe_dir" ]; do
+  parent=$(dirname "$probe_dir")
+  if [ "$parent" = "$probe_dir" ]; then
+    break
+  fi
+  probe_dir="$parent"
+done
+
+if [ ! -w "$probe_dir" ]; then
   if command -v sudo >/dev/null 2>&1; then
-    log "note: $INSTALL_DIR is not writable; using sudo for the final move"
+    log "note: $probe_dir is not writable; using sudo for install"
     use_sudo="sudo"
   else
-    die "$INSTALL_DIR is not writable and sudo is not available"
+    die "$probe_dir is not writable and sudo is not available"
   fi
 fi
 
+$use_sudo mkdir -p "$INSTALL_DIR" || die "failed to create $INSTALL_DIR"
 $use_sudo mv "$tmpdir/$bin_asset" "$target" || die "failed to move binary to $target"
 $use_sudo chmod +x "$target" || die "failed to chmod $target"
 
 if [ "$OS" = "darwin" ]; then
   # Strip the quarantine xattr so Gatekeeper doesn't prompt on direct launch.
-  # Darwin release binaries are already signed + notarized. 2>/dev/null || true
-  # swallows the error when the attribute isn't set (fresh temp files).
-  xattr -d com.apple.quarantine "$target" 2>/dev/null || true
+  # Darwin release binaries are already signed and notarized, so stripping
+  # the flag is purely a UX refinement. The 2>/dev/null || true swallows
+  # the error when the attribute is not set (e.g. fresh temp files from
+  # mktemp never get quarantined in the first place).
+  $use_sudo xattr -d com.apple.quarantine "$target" 2>/dev/null || true
 fi
 
 log "Installed $BIN_NAME $VERSION_TO_INSTALL to $target"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,10 +20,10 @@
 set -eu
 
 # --- test-only hooks ---------------------------------------------------------
-# These env vars are undocumented and exist only so the Go integration test
-# at internal/installscript/install_test.go can point the script at a local
-# httptest server instead of api.github.com / github.com. Do not rely on
-# them outside tests.
+# These env vars are undocumented and exist only for the Go integration test
+# at internal/installscript/install_test.go. Do not rely on them outside tests.
+#   GAAL_INSTALL_BASE_URL      — reroute HTTP calls to a local httptest server
+#   GAAL_INSTALL_ARCH_OVERRIDE — force detect_arch to see a fake `uname -m`
 : "${GAAL_INSTALL_BASE_URL:=}"
 
 if [ "${GAAL_INSTALL_DEBUG:-}" = "1" ]; then
@@ -86,7 +86,15 @@ detect_os() {
 }
 
 detect_arch() {
-  uname_m=$(uname -m 2>/dev/null || echo unknown)
+  # GAAL_INSTALL_ARCH_OVERRIDE is an undocumented test-only hook (see the
+  # "test-only hooks" block near the top of this file) that lets the
+  # integration test at internal/installscript/install_test.go force an
+  # unsupported arch error without running on an unsupported host.
+  if [ -n "${GAAL_INSTALL_ARCH_OVERRIDE:-}" ]; then
+    uname_m="$GAAL_INSTALL_ARCH_OVERRIDE"
+  else
+    uname_m=$(uname -m 2>/dev/null || echo unknown)
+  fi
   case "$uname_m" in
     x86_64|amd64)  echo amd64 ;;
     aarch64|arm64) echo arm64 ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,196 @@
+#!/bin/sh
+# gaal-lite installer.
+#
+# Downloads the latest release of gaal from GitHub Releases, verifies its
+# SHA-256 checksum against the release's SHA256SUMS file, and installs it
+# to $INSTALL_DIR (default $HOME/.local/bin).
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | sh
+#   curl -fsSL ... | VERSION=v0.1.2 sh
+#   curl -fsSL ... | INSTALL_DIR=/usr/local/bin sh
+#
+# Environment:
+#   VERSION               Release tag to install (default: latest).
+#   INSTALL_DIR           Install directory (default: $HOME/.local/bin).
+#   GAAL_INSTALL_DEBUG    Set to 1 to enable verbose tracing.
+#
+# All changes to this file require review per .github/CODEOWNERS.
+
+set -eu
+
+# --- test-only hooks ---------------------------------------------------------
+# These env vars are undocumented and exist only so the Go integration test
+# at internal/installscript/install_test.go can point the script at a local
+# httptest server instead of api.github.com / github.com. Do not rely on
+# them outside tests.
+: "${GAAL_INSTALL_BASE_URL:=}"
+
+if [ "${GAAL_INSTALL_DEBUG:-}" = "1" ]; then
+  set -x
+fi
+
+# --- constants ---------------------------------------------------------------
+REPO="gmg-inc/gaal-lite"
+BIN_NAME="gaal"
+DEFAULT_INSTALL_DIR="$HOME/.local/bin"
+
+# --- logging helpers ---------------------------------------------------------
+log()  { printf '%s\n' "$*"; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# --- arg parsing -------------------------------------------------------------
+usage() {
+  cat <<'EOF'
+gaal-lite installer
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | sh
+  curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | VERSION=v0.1.2 sh
+
+Environment:
+  VERSION              Release tag to install (default: latest from GitHub Releases)
+  INSTALL_DIR          Install directory (default: $HOME/.local/bin)
+  GAAL_INSTALL_DEBUG   Set to 1 for verbose tracing
+
+Examples:
+  # Install latest to ~/.local/bin
+  curl -fsSL <URL> | sh
+
+  # Pin to v0.1.2
+  curl -fsSL <URL> | VERSION=v0.1.2 sh
+
+  # System-wide install (will prompt for sudo on the final move)
+  curl -fsSL <URL> | INSTALL_DIR=/usr/local/bin sh
+
+Report issues: https://github.com/gmg-inc/gaal-lite/issues
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $arg (see --help)" ;;
+  esac
+done
+
+# --- platform detection ------------------------------------------------------
+detect_os() {
+  uname_s=$(uname -s 2>/dev/null || echo unknown)
+  case "$uname_s" in
+    Linux)  echo linux ;;
+    Darwin) echo darwin ;;
+    *)      die "unsupported operating system: $uname_s (supported: Linux, Darwin)" ;;
+  esac
+}
+
+detect_arch() {
+  uname_m=$(uname -m 2>/dev/null || echo unknown)
+  case "$uname_m" in
+    x86_64|amd64)  echo amd64 ;;
+    aarch64|arm64) echo arm64 ;;
+    *)             die "unsupported architecture: $uname_m (supported: amd64, arm64)" ;;
+  esac
+}
+
+OS=$(detect_os)
+ARCH=$(detect_arch)
+
+# --- version resolution ------------------------------------------------------
+resolve_version() {
+  if [ -n "${VERSION:-}" ]; then
+    echo "$VERSION"
+    return
+  fi
+  if [ -n "$GAAL_INSTALL_BASE_URL" ]; then
+    api_url="$GAAL_INSTALL_BASE_URL/repos/$REPO/releases/latest"
+  else
+    api_url="https://api.github.com/repos/$REPO/releases/latest"
+  fi
+  body=$(curl -fsSL "$api_url") || die "failed to query latest release at $api_url"
+  # Extract "tag_name":"vX.Y.Z" with grep + sed — avoids a jq dependency.
+  tag=$(printf '%s\n' "$body" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
+  [ -n "$tag" ] || die "could not parse tag_name from $api_url response"
+  echo "$tag"
+}
+
+VERSION_TO_INSTALL=$(resolve_version)
+
+# --- install dir resolution --------------------------------------------------
+INSTALL_DIR="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+
+# --- download, verify, install -----------------------------------------------
+if [ -n "$GAAL_INSTALL_BASE_URL" ]; then
+  download_base="$GAAL_INSTALL_BASE_URL/releases/download/$VERSION_TO_INSTALL"
+else
+  download_base="https://github.com/$REPO/releases/download/$VERSION_TO_INSTALL"
+fi
+
+bin_asset="${BIN_NAME}-${OS}-${ARCH}"
+
+pick_sha_tool() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    echo "sha256sum"
+  elif command -v shasum >/dev/null 2>&1; then
+    echo "shasum -a 256"
+  else
+    die "neither sha256sum nor shasum found on PATH"
+  fi
+}
+
+SHA_CMD=$(pick_sha_tool)
+
+tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t gaal-install)
+[ -d "$tmpdir" ] || die "failed to create temp directory"
+cleanup() { rm -rf "$tmpdir"; }
+trap cleanup EXIT INT TERM
+
+log "Downloading $bin_asset ($VERSION_TO_INSTALL) ..."
+curl -fsSL "$download_base/$bin_asset" -o "$tmpdir/$bin_asset" \
+  || die "failed to download $download_base/$bin_asset"
+curl -fsSL "$download_base/SHA256SUMS" -o "$tmpdir/SHA256SUMS" \
+  || die "failed to download $download_base/SHA256SUMS"
+
+log "Verifying SHA-256 checksum ..."
+actual=$(cd "$tmpdir" && $SHA_CMD "$bin_asset" | awk '{print $1}')
+expected=$(awk -v name="$bin_asset" '$2 == name || $2 == "*"name {print $1}' "$tmpdir/SHA256SUMS")
+[ -n "$expected" ] || die "no checksum entry for $bin_asset in SHA256SUMS"
+if [ "$actual" != "$expected" ]; then
+  die "checksum mismatch for $bin_asset (expected $expected, got $actual)"
+fi
+
+# --- install -----------------------------------------------------------------
+mkdir -p "$INSTALL_DIR" || die "failed to create $INSTALL_DIR"
+
+target="$INSTALL_DIR/$BIN_NAME"
+use_sudo=""
+if [ ! -w "$INSTALL_DIR" ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    log "note: $INSTALL_DIR is not writable; using sudo for the final move"
+    use_sudo="sudo"
+  else
+    die "$INSTALL_DIR is not writable and sudo is not available"
+  fi
+fi
+
+$use_sudo mv "$tmpdir/$bin_asset" "$target" || die "failed to move binary to $target"
+$use_sudo chmod +x "$target" || die "failed to chmod $target"
+
+if [ "$OS" = "darwin" ]; then
+  # Strip the quarantine xattr so Gatekeeper doesn't prompt on direct launch.
+  # Darwin release binaries are already signed + notarized. 2>/dev/null || true
+  # swallows the error when the attribute isn't set (fresh temp files).
+  xattr -d com.apple.quarantine "$target" 2>/dev/null || true
+fi
+
+log "Installed $BIN_NAME $VERSION_TO_INSTALL to $target"
+
+# --- PATH warning ------------------------------------------------------------
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    warn "$INSTALL_DIR is not on your PATH"
+    warn "add it with: export PATH=\"$INSTALL_DIR:\$PATH\""
+    ;;
+esac


### PR DESCRIPTION
## Summary
- POSIX `sh` installer at `scripts/install.sh` — verifies SHA-256 against `SHA256SUMS` before any filesystem write outside a `mktemp -d` trap-cleaned temp dir, then installs to `$HOME/.local/bin/gaal` (or a user-specified `INSTALL_DIR`, with sudo only when the target isn't writable).
- Supports `VERSION`, `INSTALL_DIR`, `GAAL_INSTALL_DEBUG`, `--help`. Fast-path short-circuit when `gaal version` already matches the target tag.
- Go integration test package `internal/installscript/` with 4 scenarios: happy path, checksum mismatch, already installed, unsupported architecture. Runs offline against a local httptest fake of GitHub Releases.
- `.github/CODEOWNERS` requires review from @Theosakamg @gmoigneu @gregqualls on `scripts/install.sh` — high-blast-radius file.
- `.github/workflows/install-script.yml` — PR gate running shellcheck (POSIX strict) + the `-race` Go integration test on self-hosted Linux and macOS.
- README `## Install` section leads with the curl one-liner, keeps `go install` and source-build as subsections.

Closes #21.

## Known launch-blocker (not a code issue)
The repo is currently private. The one-liner cannot actually download release assets without auth until the repo goes public (per the Week 2 launch plan). The script itself is correct — the Go integration tests against a local httptest server prove that end-to-end. Once the repo is public, no changes should be needed.

## Obsolete issue prerequisites
Issue #21's "upstream prerequisites" checklist (versioned tarballs, per-tarball .sha256 files) is stale. Current releases already ship raw binaries with a unified `SHA256SUMS`, which is what the script targets. No release-workflow changes required.

## Test plan
- [x] `go test -race ./internal/installscript/ -v` — 4/4 PASS on darwin-arm64
- [x] `make test` — full suite PASS
- [x] `make lint` — clean
- [x] `shellcheck --shell=sh --severity=style scripts/install.sh` — clean
- [x] `--help` output verified locally
- [x] Full E2E against real GitHub Release — blocked on repo going public
- [x] Install Script CI workflow green on this PR