### PR TITLE
feat(status,sync): add scope column, dedup fix, and --force flag

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	service  bool
-	interval time.Duration
-	dryRun   bool
-	prune    bool
+	service      bool
+	interval     time.Duration
+	dryRun       bool
+	prune        bool
+	forceSyncAll bool
 )
 
 var syncCmd = &cobra.Command{
@@ -40,6 +41,7 @@ func init() {
 	syncCmd.Flags().DurationVarP(&interval, "interval", "i", 5*time.Minute, "polling interval in service mode")
 	syncCmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview what sync would do without writing anything")
 	syncCmd.Flags().BoolVar(&prune, "prune", false, "remove skills and MCP entries no longer declared in config")
+	syncCmd.Flags().BoolVar(&forceSyncAll, "force", false, "install skills into all registered agents even when agent dirs don't exist yet (applies to agents: [\"*\"] wildcard)")
 	rootCmd.AddCommand(syncCmd)
 }
 
@@ -56,7 +58,9 @@ func runSync(_ *cobra.Command, _ []string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	eng := engine.NewWithOptions(cfg.Config, engineOpts)
+	opts := engineOpts
+	opts.Force = forceSyncAll
+	eng := engine.NewWithOptions(cfg.Config, opts)
 
 	if dryRun {
 		slog.Info("dry-run mode", "config", cfgFile)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -57,6 +57,10 @@ type Options struct {
 	// StateDir overrides the directory used to persist snapshot indexes.
 	// Defaults to <cacheRoot>/gaal/state.
 	StateDir string
+	// Force skips the agent-installation check for wildcard agent lists so
+	// that skills are installed into every registered agent regardless of
+	// whether the agent's config directory is already present on the machine.
+	Force bool
 }
 
 // Engine orchestrates repository, skill and MCP synchronisation.
@@ -104,7 +108,7 @@ func NewWithOptions(cfg *config.Config, opts Options) *Engine {
 	return &Engine{
 		cfg:       cfg,
 		repos:     repo.NewManager(cfg.Repositories, stateDir),
-		skills:    skill.NewManager(cfg.Skills, cacheDir, home, workDir, stateDir),
+		skills:    skill.NewManager(cfg.Skills, cacheDir, home, workDir, stateDir, opts.Force),
 		mcps:      mcp.NewManager(cfg.MCPs, stateDir),
 		home:      home,
 		workDir:   workDir,

--- a/internal/engine/ops/audit.go
+++ b/internal/engine/ops/audit.go
@@ -26,7 +26,7 @@ func Audit(ctx context.Context, home, workDir string, format render.OutputFormat
 		return err
 	}
 
-	report := &render.AuditReport{Skills: skills, MCPs: mcps}
+	report := &render.AuditReport{Home: home, Skills: skills, MCPs: mcps}
 	return render.NewAuditRenderer(format).Render(os.Stdout, report)
 }
 

--- a/internal/engine/ops/status.go
+++ b/internal/engine/ops/status.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"gaal/internal/discover"
 	"gaal/internal/engine/render"
@@ -41,7 +42,7 @@ func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mc
 	// Reconcile: mark config-declared resources as managed and merge
 	// FS-discovered unmanaged resources into the report.
 	repoEntries := reconcileRepos(configRepos, discovered)
-	skillEntries := reconcileSkills(configSkills, discovered)
+	skillEntries := reconcileSkills(configSkills, discovered, home, workDir)
 	mcpEntries := reconcileMCPs(configMCPs, discovered)
 
 	return &render.StatusReport{
@@ -95,25 +96,42 @@ func reconcileRepos(config []render.RepoEntry, resources []discover.Resource) []
 }
 
 // reconcileSkills merges config-driven skill entries with FS-discovered skills.
-// FS-discovered skills not covered by config are appended as unmanaged entries.
-func reconcileSkills(config []render.SkillEntry, resources []discover.Resource) []render.SkillEntry {
-	known := make(map[string]struct{}, len(config))
+// FS-discovered skills are suppressed when their parent directory is already
+// covered by a config-driven entry (same agent + same managed skills dir).
+// Remaining FS-discovered entries are appended as unmanaged.
+func reconcileSkills(config []render.SkillEntry, resources []discover.Resource, home, workDir string) []render.SkillEntry {
+	// Build the set of managed skill directories from config entries.
+	// Key: absolute skills directory that gaal writes to for this entry.
+	managedDirs := make(map[string]struct{}, len(config))
 	for _, e := range config {
-		known[e.Source+"/"+e.Agent] = struct{}{}
+		dir, ok := skill.SkillDir(e.Agent, e.Global, home)
+		if !ok {
+			continue
+		}
+		if !e.Global && !filepath.IsAbs(dir) {
+			dir = filepath.Join(workDir, dir)
+		}
+		managedDirs[filepath.Clean(dir)] = struct{}{}
 	}
+	slog.Debug("reconcileSkills managed dirs", "count", len(managedDirs))
+
 	out := append([]render.SkillEntry(nil), config...)
 	for _, r := range resources {
 		if r.Type != discover.ResourceSkill {
 			continue
 		}
-		agent := r.Meta["agent"]
-		key := r.Path + "/" + agent
-		if _, ok := known[key]; ok {
+		// If this skill's parent directory is already managed by a config
+		// entry, the skill is already accounted for — skip it to avoid
+		// showing the same skill twice (once managed, once unmanaged).
+		parent := filepath.Clean(filepath.Dir(r.Path))
+		if _, covered := managedDirs[parent]; covered {
 			continue
 		}
+		agent := r.Meta["agent"]
 		out = append(out, render.SkillEntry{
 			Source:    r.Path,
 			Agent:     agent,
+			Global:    r.Scope == discover.ScopeGlobal,
 			Status:    render.StatusUnmanaged,
 			Installed: []string{r.Name},
 			Missing:   []string{},
@@ -192,6 +210,7 @@ func collectSkills(stats []skill.Status) []render.SkillEntry {
 		e := render.SkillEntry{
 			Source:    st.Source,
 			Agent:     st.AgentName,
+			Global:    st.Global,
 			Installed: nonNil(st.Installed),
 			Missing:   nonNil(st.Missing),
 			Modified:  nonNil(st.Modified),

--- a/internal/engine/render/audit.go
+++ b/internal/engine/render/audit.go
@@ -46,10 +46,10 @@ func (tr *auditTableRenderer) Render(w io.Writer, r *AuditReport) error {
 		termW = 120
 	}
 
-	if err := tr.skillTable(w, r.Skills, termW); err != nil {
+	if err := tr.skillTable(w, r.Skills, r.Home, termW); err != nil {
 		return err
 	}
-	if err := tr.mcpTable(w, r.MCPs, termW); err != nil {
+	if err := tr.mcpTable(w, r.MCPs, r.Home, termW); err != nil {
 		return err
 	}
 	fmt.Fprintln(w)
@@ -61,7 +61,7 @@ func (tr *auditTableRenderer) section(w io.Writer, title string, count int) {
 	fmt.Fprintf(w, "\n%s\n", styled)
 }
 
-func (tr *auditTableRenderer) skillTable(w io.Writer, entries []AuditSkillEntry, termW int) error {
+func (tr *auditTableRenderer) skillTable(w io.Writer, entries []AuditSkillEntry, home string, termW int) error {
 	tr.section(w, "Discovered Skills", len(entries))
 
 	if len(entries) == 0 {
@@ -92,7 +92,7 @@ func (tr *auditTableRenderer) skillTable(w io.Writer, entries []AuditSkillEntry,
 			trunc(e.Name, nameMax),
 			e.Agent,
 			sourceCell(e.Source),
-			trunc(e.Path, pathMax),
+			trunc(shortenHome(e.Path, home), pathMax),
 		})
 	}
 
@@ -100,7 +100,7 @@ func (tr *auditTableRenderer) skillTable(w io.Writer, entries []AuditSkillEntry,
 	return tbl.ptermTable(w, data)
 }
 
-func (tr *auditTableRenderer) mcpTable(w io.Writer, entries []AuditMCPEntry, termW int) error {
+func (tr *auditTableRenderer) mcpTable(w io.Writer, entries []AuditMCPEntry, home string, termW int) error {
 	tr.section(w, "Discovered MCP Servers", len(entries))
 
 	if len(entries) == 0 {
@@ -119,13 +119,26 @@ func (tr *auditTableRenderer) mcpTable(w io.Writer, entries []AuditMCPEntry, ter
 		servers := strings.Join(e.Servers, ", ")
 		data = append(data, []string{
 			e.Agent,
-			trunc(e.ConfigFile, vw),
+			trunc(shortenHome(e.ConfigFile, home), vw),
 			trunc(servers, vw),
 		})
 	}
 
 	tbl := &tableRenderer{}
 	return tbl.ptermTable(w, data)
+}
+
+// shortenHome replaces the home directory prefix of a path with "~/".
+func shortenHome(path, home string) string {
+	if home == "" || path == "" {
+		return path
+	}
+	// Ensure home ends without separator for clean prefix matching.
+	prefix := strings.TrimRight(home, "/\\")
+	if strings.HasPrefix(path, prefix+"/") || strings.HasPrefix(path, prefix+"\\") {
+		return "~" + path[len(prefix):]
+	}
+	return path
 }
 
 // sourceCell renders a source label with a distinctive colour.

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -30,6 +30,7 @@ type RepoEntry struct {
 type SkillEntry struct {
 	Source    string     `json:"source"`
 	Agent     string     `json:"agent"`
+	Global    bool       `json:"global"`
 	Status    StatusCode `json:"status"`
 	Installed []string   `json:"installed"`
 	Missing   []string   `json:"missing"`

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -156,6 +156,7 @@ type AuditMCPEntry struct {
 
 // AuditReport aggregates all skills and MCP servers discovered on the machine.
 type AuditReport struct {
+	Home   string            `json:"-"`
 	Skills []AuditSkillEntry `json:"skills"`
 	MCPs   []AuditMCPEntry   `json:"mcps"`
 }

--- a/internal/engine/render/table.go
+++ b/internal/engine/render/table.go
@@ -94,9 +94,6 @@ func (tr *tableRenderer) Render(w io.Writer, r *StatusReport) error {
 		termW = 120
 	}
 
-	if err := tr.repoTable(w, r.Repositories, termW); err != nil {
-		return err
-	}
 	if err := tr.skillTable(w, r.Skills, termW); err != nil {
 		return err
 	}
@@ -104,6 +101,9 @@ func (tr *tableRenderer) Render(w io.Writer, r *StatusReport) error {
 		return err
 	}
 	if err := tr.agentTable(w, r.Agents, termW); err != nil {
+		return err
+	}
+	if err := tr.repoTable(w, r.Repositories, termW); err != nil {
 		return err
 	}
 	fmt.Fprintln(w)
@@ -240,7 +240,7 @@ func (tr *tableRenderer) repoTable(w io.Writer, entries []RepoEntry, termW int) 
 }
 
 // aggregatedSkill rolls up all per-(source, agent) SkillEntry rows for a
-// single skill name. See [aggregateSkillsByName] for semantics.
+// single skill name within one scope. See [aggregateSkillsByName] for semantics.
 type aggregatedSkill struct {
 	Name      string
 	Sources   []string
@@ -248,17 +248,27 @@ type aggregatedSkill struct {
 	Agents    []string
 	AllAgents bool
 	Error     string
+	Global    bool // true = user-global, false = workspace/project
 }
 
 // aggregateSkillsByName groups per-(source, agent) skill entries into one
-// row per unique skill name. The result is sorted alphabetically by name.
+// row per unique (skill name, scope) pair. Global and workspace entries with
+// the same skill name are kept as separate rows. The result is sorted: global
+// entries first, then workspace, each subset sorted alphabetically by name.
 //
-// For each skill name, "targeted agents" is the set of agents that list the
-// skill in Installed ∪ Missing ∪ Modified — i.e. agents gaal expected to
-// manage the skill for. AllAgents is true when the skill is installed in
-// every one of those targeted agents (including "installed but dirty"),
-// which the renderer shows as `*` in the AGENTS column.
+// For each (skill name, scope), "targeted agents" is the set of agents that
+// list the skill in Installed ∪ Missing ∪ Modified — i.e. agents gaal
+// expected to manage the skill for. AllAgents is true when the skill is
+// installed in every one of those targeted agents (including "installed but
+// dirty"), which the renderer shows as `*` in the AGENTS column.
+//
+// Entries that carry an error and have no skill names are rendered as a
+// placeholder row (name "—") so they remain visible to the user.
 func aggregateSkillsByName(entries []SkillEntry) []aggregatedSkill {
+	type skillKey struct {
+		name   string
+		global bool
+	}
 	type bucket struct {
 		sources   map[string]struct{}
 		targeted  map[string]struct{}
@@ -266,24 +276,27 @@ func aggregateSkillsByName(entries []SkillEntry) []aggregatedSkill {
 		dirty     bool
 		errored   bool
 		errMsg    string
+		global    bool
 	}
-	byName := map[string]*bucket{}
+	byKey := map[skillKey]*bucket{}
 
-	get := func(name string) *bucket {
-		b, ok := byName[name]
+	get := func(name string, global bool) *bucket {
+		k := skillKey{name, global}
+		b, ok := byKey[k]
 		if !ok {
 			b = &bucket{
 				sources:   map[string]struct{}{},
 				targeted:  map[string]struct{}{},
 				installed: map[string]struct{}{},
+				global:    global,
 			}
-			byName[name] = b
+			byKey[k] = b
 		}
 		return b
 	}
 
 	markEntry := func(e SkillEntry, name string, installed bool) {
-		b := get(name)
+		b := get(name, e.Global)
 		b.sources[e.Source] = struct{}{}
 		b.targeted[e.Agent] = struct{}{}
 		if installed {
@@ -298,6 +311,20 @@ func aggregateSkillsByName(entries []SkillEntry) []aggregatedSkill {
 	}
 
 	for _, e := range entries {
+		if len(e.Installed) == 0 && len(e.Missing) == 0 && len(e.Modified) == 0 {
+			// Error entry or unexpectedly empty: keep visible as a placeholder
+			// row so the user can see the source and its error status.
+			b := get("", e.Global)
+			b.sources[e.Source] = struct{}{}
+			b.targeted[e.Agent] = struct{}{}
+			if e.Error != "" {
+				b.errored = true
+				if b.errMsg == "" {
+					b.errMsg = e.Error
+				}
+			}
+			continue
+		}
 		for _, name := range e.Installed {
 			markEntry(e, name, true)
 		}
@@ -309,17 +336,18 @@ func aggregateSkillsByName(entries []SkillEntry) []aggregatedSkill {
 			// (status is reported as dirty, not ok). Track it as installed
 			// and flag the bucket as dirty.
 			markEntry(e, name, true)
-			get(name).dirty = true
+			get(name, e.Global).dirty = true
 		}
 	}
 
-	out := make([]aggregatedSkill, 0, len(byName))
-	for name, b := range byName {
+	out := make([]aggregatedSkill, 0, len(byKey))
+	for k, b := range byKey {
 		s := aggregatedSkill{
-			Name:    name,
+			Name:    k.name,
 			Sources: keysSorted(b.sources),
 			Agents:  keysSorted(b.installed),
 			Error:   b.errMsg,
+			Global:  b.global,
 		}
 		s.AllAgents = len(b.installed) > 0 && len(b.installed) == len(b.targeted)
 		switch {
@@ -334,7 +362,17 @@ func aggregateSkillsByName(entries []SkillEntry) []aggregatedSkill {
 		}
 		out = append(out, s)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	// Sort: global entries first, then workspace; within each group, sort
+	// alphabetically by name. Empty-name placeholder rows sort last.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Global != out[j].Global {
+			return out[i].Global // global (true) before workspace (false)
+		}
+		if (out[i].Name == "") != (out[j].Name == "") {
+			return out[j].Name == "" // empty name sorts last within scope
+		}
+		return out[i].Name < out[j].Name
+	})
 	return out
 }
 
@@ -351,26 +389,40 @@ func (tr *tableRenderer) skillTable(w io.Writer, entries []SkillEntry, termW int
 	aggregated := aggregateSkillsByName(entries)
 	tr.section(w, "Skills", len(aggregated))
 
-	// Fixed col: STATUS(14). SKILL, SOURCE, AGENTS share the rest.
-	vw := varColWidth(termW, 4, 3, 14)
+	// Fixed cols: STATUS(14) + SCOPE(11) = 25. SKILL, SOURCE, INSTALLED IN share the rest.
+	vw := varColWidth(termW, 5, 3, 25)
 	if vw < 12 {
 		vw = 12
 	}
 
-	data := pterm.TableData{{"SKILL", "SOURCE", "STATUS", "AGENTS"}}
+	data := pterm.TableData{{"SKILL", "SOURCE", "SCOPE", "STATUS", "AGENTS"}}
 	for _, s := range aggregated {
-		agents := "—"
+		var installedIn string
 		switch {
 		case s.AllAgents:
-			agents = "*"
+			// Skill is present in every agent that targets it.
+			installedIn = pterm.FgGreen.Sprint("all")
 		case len(s.Agents) > 0:
-			agents = strings.Join(s.Agents, ", ")
+			// Installed only in a subset of targeted agents.
+			installedIn = strings.Join(s.Agents, ", ")
+		default:
+			// Not installed in any agent yet.
+			installedIn = pterm.FgYellow.Sprint("none")
+		}
+		scope := "workspace"
+		if s.Global {
+			scope = "global"
+		}
+		name := s.Name
+		if name == "" {
+			name = "—"
 		}
 		data = append(data, []string{
-			trunc(s.Name, vw),
+			trunc(name, vw),
 			trunc(strings.Join(s.Sources, ", "), vw),
+			scope,
 			statusCell(s.Status, s.Error),
-			trunc(agents, vw),
+			trunc(installedIn, vw),
 		})
 	}
 	return tr.ptermTable(w, data)

--- a/internal/engine/render/table_test.go
+++ b/internal/engine/render/table_test.go
@@ -185,7 +185,7 @@ func TestAggregateSkillsByName_DirtyWhenAnyModified(t *testing.T) {
 	if s.Status != StatusDirty {
 		t.Errorf("status: got %q, want %q", s.Status, StatusDirty)
 	}
-	// Modified agents are still "installed" — show * when present everywhere.
+	// Modified agents are still "installed" — show "all" when present everywhere.
 	if !s.AllAgents {
 		t.Errorf("AllAgents: dirty-but-installed-everywhere should show *")
 	}
@@ -252,6 +252,92 @@ func TestAggregateSkillsByName_ErrorPropagates(t *testing.T) {
 	}
 }
 
+func TestAggregateSkillsByName_SeparatesGlobalFromWorkspace(t *testing.T) {
+	in := []SkillEntry{
+		// Same skill name in both scopes: must produce two separate rows.
+		{Source: "owner/repo", Agent: "cursor", Global: true, Status: StatusOK, Installed: []string{"shared"}},
+		{Source: "owner/repo", Agent: "cursor", Global: false, Status: StatusPartial, Missing: []string{"shared"}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 aggregated skills (one per scope), got %d: %+v", len(got), got)
+	}
+	// Global entry should come first.
+	if !got[0].Global {
+		t.Errorf("got[0].Global = false, want true (global sorts first)")
+	}
+	if got[0].Status != StatusOK {
+		t.Errorf("global entry status: got %q, want OK", got[0].Status)
+	}
+	if got[1].Global {
+		t.Errorf("got[1].Global = true, want false (workspace sorts second)")
+	}
+	if got[1].Status != StatusPartial {
+		t.Errorf("workspace entry status: got %q, want partial", got[1].Status)
+	}
+}
+
+func TestAggregateSkillsByName_ErrorEntryWithNoSkillsIsVisible(t *testing.T) {
+	in := []SkillEntry{
+		{Source: "owner/repo", Agent: "cursor", Global: false, Status: StatusError,
+			Error: "source not cached yet", Installed: []string{}, Missing: []string{}, Modified: []string{}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 placeholder row for error entry, got %d", len(got))
+	}
+	s := got[0]
+	if s.Name != "" {
+		t.Errorf("placeholder name: got %q, want empty string (rendered as '—')", s.Name)
+	}
+	if s.Status != StatusError {
+		t.Errorf("status: got %q, want error", s.Status)
+	}
+	if !strings.Contains(s.Error, "not cached") {
+		t.Errorf("error message: got %q, want to contain 'not cached'", s.Error)
+	}
+	if s.Global {
+		t.Errorf("Global: got true, want false")
+	}
+}
+
+func TestAggregateSkillsByName_GlobalSortsBeforeWorkspace(t *testing.T) {
+	in := []SkillEntry{
+		{Source: "ws/repo", Agent: "cursor", Global: false, Status: StatusOK, Installed: []string{"alpha"}},
+		{Source: "gl/repo", Agent: "cursor", Global: true, Status: StatusOK, Installed: []string{"beta"}},
+	}
+	got := aggregateSkillsByName(in)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 aggregated skills, got %d", len(got))
+	}
+	if !got[0].Global || got[0].Name != "beta" {
+		t.Errorf("got[0]: Global=%v Name=%q, want Global=true Name=beta", got[0].Global, got[0].Name)
+	}
+	if got[1].Global || got[1].Name != "alpha" {
+		t.Errorf("got[1]: Global=%v Name=%q, want Global=false Name=alpha", got[1].Global, got[1].Name)
+	}
+}
+
+func TestTableRenderer_SkillsScopeColumn(t *testing.T) {
+	var buf bytes.Buffer
+	r := &tableRenderer{}
+	report := &StatusReport{
+		Skills: []SkillEntry{
+			{Source: "gl/repo", Agent: "cursor", Global: true, Status: StatusOK, Installed: []string{"global-skill"}},
+			{Source: "ws/repo", Agent: "cursor", Global: false, Status: StatusOK, Installed: []string{"ws-skill"}},
+		},
+	}
+	if err := r.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"SCOPE", "global", "workspace", "global-skill", "ws-skill"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output\ngot:\n%s", want, out)
+		}
+	}
+}
+
 func TestAggregateSkillsByName_SortedByName(t *testing.T) {
 	in := []SkillEntry{
 		{Source: "owner/repo", Agent: "cursor", Status: StatusOK, Installed: []string{"zebra", "apple", "mango"}},
@@ -285,7 +371,7 @@ func TestTableRenderer_SkillsByName_RendersStar(t *testing.T) {
 		t.Error("expected skill name in output")
 	}
 	if !strings.Contains(out, "SKILL") || !strings.Contains(out, "AGENTS") {
-		t.Errorf("expected new column headers SKILL and AGENTS, got:\n%s", out)
+		t.Errorf("expected column headers SKILL and AGENTS, got:\n%s", out)
 	}
 	// Exactly one data row (not one per agent).
 	if strings.Count(out, "code-reviewer") != 1 {

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -83,18 +83,22 @@ type Manager struct {
 	home     string // expanded user home directory
 	workDir  string // project working directory (for project-scoped installs)
 	stateDir string // gaal state root (~/.cache/gaal/state) for snapshot writing
+	force    bool   // when true, wildcard agent lists target all known agents
 }
 
 // NewManager creates a new skill Manager.
 // cacheDir is where remote sources are cloned/downloaded (e.g. ~/.cache/gaal/skills).
 // stateDir is where post-sync snapshots are persisted (e.g. ~/.cache/gaal/state).
-func NewManager(skills []config.ConfigSkill, cacheDir, home, workDir, stateDir string) *Manager {
+// force makes wildcard agent lists install into every registered agent,
+// creating directories as needed instead of restricting to already-installed agents.
+func NewManager(skills []config.ConfigSkill, cacheDir, home, workDir, stateDir string, force bool) *Manager {
 	return &Manager{
 		skills:   skills,
 		cacheDir: cacheDir,
 		home:     home,
 		workDir:  workDir,
 		stateDir: stateDir,
+		force:    force,
 	}
 }
 
@@ -146,6 +150,11 @@ func (m *Manager) syncOne(ctx context.Context, sc config.ConfigSkill) error {
 		// Project-relative path needs workDir prefix.
 		if !sc.Global && !filepath.IsAbs(skillsDir) {
 			skillsDir = filepath.Join(m.workDir, skillsDir)
+		}
+
+		// Create the skills directory if it does not exist yet.
+		if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+			return fmt.Errorf("creating skills dir for agent %q: %w", agent, err)
 		}
 
 		for _, sk := range selected {
@@ -217,22 +226,25 @@ func (m *Manager) resolveAgents(sc config.ConfigSkill) []string {
 	return sc.Agents
 }
 
-// syncAgents returns the subset of resolveAgents that are actually installed
-// on this machine. Sync uses this to guarantee it never materialises an
-// agent-owned directory as a side effect — uninstalled entries in an
-// explicit list are dropped with a warning.
+// syncAgents returns the agents to target during sync.
+//
+// For the wildcard ("*" or empty list):
+//   - Normal mode: only already-installed agents (safe default, never creates dirs).
+//   - Force mode (--force): all registered agents, creating directories as needed.
+//
+// For explicitly named agents, all entries are returned regardless of
+// whether the agent directory exists yet: sync creates it as needed.
 func (m *Manager) syncAgents(sc config.ConfigSkill) []string {
-	resolved := m.resolveAgents(sc)
-	out := make([]string, 0, len(resolved))
-	for _, a := range resolved {
-		if m.isAgentInstalled(a, sc.Global) {
-			out = append(out, a)
-			continue
+	// Wildcard: respect force flag.
+	if len(sc.Agents) == 0 || (len(sc.Agents) == 1 && sc.Agents[0] == "*") {
+		if m.force {
+			slog.Debug("force mode: targeting all registered agents", "source", sc.Source)
+			return AgentNames()
 		}
-		slog.Warn("skill: skipping uninstalled agent",
-			"agent", a, "source", sc.Source, "global", sc.Global)
+		return m.detectInstalledAgents(sc.Global)
 	}
-	return out
+	// Explicit list: return all named agents; sync creates directories as needed.
+	return sc.Agents
 }
 
 // isAgentInstalled reports whether the directory that would own the agent's

--- a/internal/skill/manager_helpers_test.go
+++ b/internal/skill/manager_helpers_test.go
@@ -96,7 +96,7 @@ func TestManager_Sync_LocalSource_WithSkills(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "", false)
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -111,14 +111,14 @@ func TestManager_Sync_NoSkillsFound(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "")
+	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "", false)
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync with no skills: %v", err)
 	}
 }
 
 func TestResolveAgents_ExplicitList(t *testing.T) {
-	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "")
+	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "", false)
 	sc := config.ConfigSkill{Agents: []string{"claude-code", "cursor"}}
 	agents := m.resolveAgents(sc)
 	if len(agents) != 2 {
@@ -129,7 +129,7 @@ func TestResolveAgents_ExplicitList(t *testing.T) {
 func TestResolveAgents_Wildcard(t *testing.T) {
 	workDir := t.TempDir()
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
-	m := NewManager(nil, t.TempDir(), "/home/user", workDir, "")
+	m := NewManager(nil, t.TempDir(), "/home/user", workDir, "", false)
 	sc := config.ConfigSkill{Agents: []string{"*"}}
 	agents := m.resolveAgents(sc)
 	found := false
@@ -146,7 +146,7 @@ func TestResolveAgents_Wildcard(t *testing.T) {
 func TestResolveAgents_Empty(t *testing.T) {
 	workDir := t.TempDir()
 	os.MkdirAll(filepath.Join(workDir, ".roo"), 0o755)
-	m := NewManager(nil, t.TempDir(), "/home/user", workDir, "")
+	m := NewManager(nil, t.TempDir(), "/home/user", workDir, "", false)
 	sc := config.ConfigSkill{Agents: nil}
 	agents := m.resolveAgents(sc)
 	found := false
@@ -161,7 +161,7 @@ func TestResolveAgents_Empty(t *testing.T) {
 }
 
 func TestManager_Status_Empty(t *testing.T) {
-	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "")
+	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "", false)
 	statuses := m.Status(context.Background())
 	if len(statuses) != 0 {
 		t.Errorf("expected 0 statuses for empty manager, got %d", len(statuses))
@@ -175,7 +175,7 @@ func TestManager_Status_Empty(t *testing.T) {
 func TestResolveSource_LocalNonGit_ReturnedAsIs(t *testing.T) {
 	// A plain directory (no .git) must be returned without any git operation.
 	src := t.TempDir()
-	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "")
+	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "", false)
 	got, err := m.resolveSource(context.Background(), src)
 	if err != nil {
 		t.Fatalf("resolveSource: %v", err)
@@ -191,7 +191,7 @@ func TestResolveSource_LocalGit_UpdateAttempted(t *testing.T) {
 	// still return the path (the failure is only a warning).
 	src := t.TempDir()
 	os.MkdirAll(filepath.Join(src, ".git"), 0o755)
-	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "")
+	m := NewManager(nil, t.TempDir(), "/home/user", t.TempDir(), "", false)
 	// The git binary must be present; skip on machines without git in PATH.
 	got, err := m.resolveSource(context.Background(), src)
 	if err != nil {
@@ -227,7 +227,7 @@ func TestManager_Sync_PreCachedRemoteSource(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: "owner/pre-cached", Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, cacheDir, "/home/user", workDir, "")
+	m := NewManager(skills, cacheDir, "/home/user", workDir, "", false)
 
 	// git update will fail (not a real repo) but the error is swallowed by resolveSource.
 	// Sync should still succeed.
@@ -245,7 +245,7 @@ func TestManager_Sync_CloneError(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: "http://localhost:1/not-a-repo.git", Agents: []string{"claude-code"}},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "")
+	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "", false)
 	err := m.Sync(context.Background())
 	if err == nil {
 		t.Fatal("expected error when git clone fails (unreachable host)")

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -193,7 +193,7 @@ func TestDetectInstalledAgents_ProjectScope(t *testing.T) {
 	// Create the parent config dir for one known agent (claude-code uses .claude/).
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
 
-	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "")
+	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "", false)
 	found := m.detectInstalledAgents(false)
 
 	hadAgent := false
@@ -247,7 +247,7 @@ func TestManager_Status_UnknownAgent(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"unknown-agent-xyz"}},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "")
+	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "", false)
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -264,7 +264,7 @@ func TestManager_Status_SourceNotCached(t *testing.T) {
 	}
 	workDir := t.TempDir()
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "", false)
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -291,7 +291,7 @@ func TestManager_Status_InstalledAndMissing(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "", false)
 	statuses := m.Status(context.Background())
 
 	if len(statuses) != 1 {
@@ -336,7 +336,7 @@ func TestManager_Sync_UnknownAgent_SkipsWithWarn(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"unknown-agent-xyz"}},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "")
+	m := NewManager(skills, t.TempDir(), "/home/user", t.TempDir(), "", false)
 	// Should not error — unknown agent is warned and skipped.
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync with unknown agent should succeed: %v", err)
@@ -398,7 +398,7 @@ func TestDetectInstalledAgents_GlobalScope(t *testing.T) {
 	// Claude global scope uses "~/.claude/skills" → parent is ~/.claude.
 	home := t.TempDir()
 	os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
-	m := NewManager(nil, t.TempDir(), home, t.TempDir(), "")
+	m := NewManager(nil, t.TempDir(), home, t.TempDir(), "", false)
 	found := m.detectInstalledAgents(true)
 	hadAgent := false
 	for _, name := range found {
@@ -412,66 +412,56 @@ func TestDetectInstalledAgents_GlobalScope(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Manager.syncAgents — the sync-time agent resolver. Explicit agent lists
-// must filter out uninstalled agents so sync never materialises an
-// agent-owned directory as a side effect.
+// Manager.syncAgents — the sync-time agent resolver.
+//
+// Wildcard ("*" or empty) → only installed agents (never creates dirs).
+// Explicit list          → all named agents (sync creates dirs as needed).
 // ---------------------------------------------------------------------------
 
-func TestSyncAgents_ExplicitList_ProjectScope_FiltersUninstalled(t *testing.T) {
+func TestSyncAgents_ExplicitList_ProjectScope_ReturnsAll(t *testing.T) {
 	workDir := t.TempDir()
-	// claude-code is "installed" in this project (its .claude/ dir exists).
+	// claude-code has its dir, zencoder does not — both must be returned.
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
-	// zencoder is NOT installed — .zencoder/ does not exist.
 
-	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "")
+	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "", false)
 	got := m.syncAgents(config.ConfigSkill{
 		Source: "owner/repo",
 		Agents: []string{"claude-code", "zencoder"},
 		Global: false,
 	})
 
-	if len(got) != 1 || got[0] != "claude-code" {
-		t.Errorf("expected [claude-code], got %v", got)
-	}
-
-	// Critical invariant: the filter must not have created the zencoder dir
-	// as a side effect of checking.
-	if _, err := os.Stat(filepath.Join(workDir, ".zencoder")); err == nil {
-		t.Error("syncAgents must not create .zencoder as a side effect")
+	if len(got) != 2 {
+		t.Errorf("expected [claude-code zencoder], got %v", got)
 	}
 }
 
-func TestSyncAgents_ExplicitList_GlobalScope_FiltersUninstalled(t *testing.T) {
+func TestSyncAgents_ExplicitList_GlobalScope_ReturnsAll(t *testing.T) {
 	home := t.TempDir()
-	// claude-code is "installed" globally (its ~/.claude/ dir exists).
+	// claude-code is "installed" globally, zencoder is not — both must be returned.
 	os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
-	// zencoder is NOT installed — ~/.zencoder/ does not exist.
 
-	m := NewManager(nil, t.TempDir(), home, t.TempDir(), "")
+	m := NewManager(nil, t.TempDir(), home, t.TempDir(), "", false)
 	got := m.syncAgents(config.ConfigSkill{
 		Source: "owner/repo",
 		Agents: []string{"claude-code", "zencoder"},
 		Global: true,
 	})
 
-	if len(got) != 1 || got[0] != "claude-code" {
-		t.Errorf("expected [claude-code], got %v", got)
-	}
-	if _, err := os.Stat(filepath.Join(home, ".zencoder")); err == nil {
-		t.Error("syncAgents must not create ~/.zencoder as a side effect")
+	if len(got) != 2 {
+		t.Errorf("expected [claude-code zencoder], got %v", got)
 	}
 }
 
-func TestSyncAgents_ExplicitList_AllUninstalled_ReturnsEmpty(t *testing.T) {
+func TestSyncAgents_ExplicitList_AllUninstalled_ReturnsAll(t *testing.T) {
 	workDir := t.TempDir() // fresh, no agent dirs
-	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "")
+	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "", false)
 	got := m.syncAgents(config.ConfigSkill{
 		Source: "owner/repo",
 		Agents: []string{"zencoder", "kilo"},
 		Global: false,
 	})
-	if len(got) != 0 {
-		t.Errorf("expected empty slice, got %v", got)
+	if len(got) != 2 {
+		t.Errorf("expected [zencoder kilo], got %v", got)
 	}
 }
 
@@ -481,7 +471,7 @@ func TestSyncAgents_Wildcard_StillWorks(t *testing.T) {
 	// is a no-op.
 	workDir := t.TempDir()
 	os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755)
-	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "")
+	m := NewManager(nil, t.TempDir(), "/home/testuser", workDir, "", false)
 	got := m.syncAgents(config.ConfigSkill{
 		Source: "owner/repo",
 		Agents: []string{"*"},
@@ -577,7 +567,7 @@ func TestManager_Status_ModifiedSkill(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "", false)
 	statuses := m.Status(context.Background())
 
 	if len(statuses) != 1 {
@@ -615,7 +605,7 @@ func TestManager_Status_CleanSkill(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}, Global: false},
 	}
-	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "")
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "", false)
 	statuses := m.Status(context.Background())
 
 	if len(statuses) != 1 {
@@ -717,7 +707,7 @@ func TestPrune_RemovesOrphanSkill(t *testing.T) {
 		os.MkdirAll(filepath.Join(claudeSkillsDir, name), 0o755)
 	}
 
-	m := NewManager(cfg, t.TempDir(), agentParent, t.TempDir(), "")
+	m := NewManager(cfg, t.TempDir(), agentParent, t.TempDir(), "", false)
 	if err := m.Prune(context.Background()); err != nil {
 		t.Fatalf("Prune returned error: %v", err)
 	}
@@ -744,7 +734,7 @@ func TestPrune_NoOpWhenAllManaged(t *testing.T) {
 	cfg := []config.ConfigSkill{
 		{Source: sourceDir, Agents: []string{"claude-code"}, Global: true},
 	}
-	m := NewManager(cfg, t.TempDir(), home, t.TempDir(), "")
+	m := NewManager(cfg, t.TempDir(), home, t.TempDir(), "", false)
 	if err := m.Prune(context.Background()); err != nil {
 		t.Fatalf("Prune returned error: %v", err)
 	}


### PR DESCRIPTION
## Summary

Add several improvements to `gaal status` output and `gaal sync` behaviour.

## Changes

### `gaal status` — Skills table
- Add `Global` field to `SkillEntry` and a **SCOPE** column (`global` / `workspace`) to the skills table so workspace-scoped skills are no longer invisible
- Fix skill deduplication: `reconcileSkills` now builds a set of managed directories via `skill.SkillDir` to suppress duplicate FS entries
- Key aggregation by `(name, scope)` instead of name only, so a skill present at both scopes is displayed as two distinct rows
- **AGENTS** column now shows `all` / `none` / comma-separated list instead of `*` / `—`
- Reorder status sections: **Skills → MCP Configs → Supported Agents → Repositories**

### `gaal sync` — Agent dir creation
- Explicit `agents` lists now always install into every named agent, creating the agent directory with `os.MkdirAll` if it does not exist yet

### `gaal sync --force`
- New `--force` flag: when wildcard `agents: ["*"]` is configured, install into **all registered agents** regardless of whether their directory is detected, creating missing dirs

## Testing
- Unit tests updated / added for new `syncAgents` semantics and `NewManager` signature
- All tests pass: `make test`