### PR TITLE
feat: check required tools on PATH (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | **Repositories** | Clone or update multi-protocol repos (git, hg, svn, bzr, tar, zip) from a single YAML file |
 | **Skills** | Download and install `SKILL.md` collections into your local AI agent directories (Claude, Copilot, Cursor, …) |
 | **MCPs** | Upsert MCP server entries into agent JSON config files without overwriting your existing configuration |
+| **Tools** | Check that required CLI binaries (e.g. `gh`, `fnm`) are on PATH and surface install hints when they are missing |
 
 ---
 
@@ -82,7 +83,17 @@ mcps:
     inline:
       command: uvx
       args: [mcp-server-filesystem, /home/user/projects]
+
+tools:
+  - gh                       # bare string — required on PATH, no install hint
+  - name: rtk                # full form with an install hint
+    hint: "cargo install rtk"
 ```
+
+The `tools:` block can also appear inside an individual `skills:` entry to
+document tools required by that specific skill. `gaal doctor` reports each
+tool as `✓` (on PATH) or `⚠` (missing); `gaal sync` prints a one-line
+banner per missing tool but never blocks.
 
 Then run:
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -80,9 +80,10 @@ func renderDoctorTable(report *ops.DoctorReport) {
 		"telemetry": "Telemetry",
 		"skills":    "Skills",
 		"mcps":      "MCP",
+		"tools":     "Tools",
 		"agents":    "Agents",
 	}
-	sections := []string{"config", "telemetry", "skills", "mcps", "agents"}
+	sections := []string{"config", "telemetry", "skills", "mcps", "tools", "agents"}
 	for _, section := range sections {
 		var sectionFindings []ops.Finding
 		for _, f := range report.Findings {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"gaal/internal/config"
 	"gaal/internal/engine"
 	"gaal/internal/telemetry"
+	"gaal/internal/tools"
 )
 
 var (
@@ -54,6 +56,8 @@ func runSync(_ *cobra.Command, _ []string) error {
 	}
 
 	cfg := resolvedCfg
+
+	warnMissingTools(cfg.Config)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -101,4 +105,38 @@ func runSync(_ *cobra.Command, _ []string) error {
 	telemetry.Track("sync")
 	telemetry.TrackFirstSync(0)
 	return nil
+}
+
+// warnMissingTools prints a compact stderr banner listing required tools that
+// are missing from PATH. Sync never blocks on missing tools — full attribution
+// and exit-code semantics live in `gaal doctor`. The per-line rule: show the
+// install hint when set, otherwise show "(required by <source>)".
+func warnMissingTools(cfg *config.Config) {
+	statuses := tools.Check(tools.Collect(cfg))
+	missing := statuses[:0]
+	for _, st := range statuses {
+		if !st.Found {
+			missing = append(missing, st)
+		}
+	}
+	if len(missing) == 0 {
+		return
+	}
+
+	maxName := 0
+	for _, st := range missing {
+		if n := len(st.Entry.Tool.Name); n > maxName {
+			maxName = n
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "⚠ Required tools missing from PATH:")
+	for _, st := range missing {
+		detail := fmt.Sprintf("(required by %s)", st.Entry.Source)
+		if st.Entry.Tool.Hint != "" {
+			detail = st.Entry.Tool.Hint
+		}
+		fmt.Fprintf(os.Stderr, "    %-*s  — %s\n", maxName, st.Entry.Tool.Name, detail)
+	}
+	fmt.Fprintln(os.Stderr, "  Run `gaal doctor` for details.")
 }

--- a/example.gaal.yaml
+++ b/example.gaal.yaml
@@ -74,12 +74,18 @@ skills:
       - github-copilot
     global: true
 
-  # Install from a local directory.
+  # Install from a local directory. Per-skill `tools:` lists CLI binaries
+  # that this skill expects to find on PATH; gaal doctor warns when any
+  # are missing.
   - source: ./company-skills
     agents:
       - claude-code
       - cursor
     global: false
+    tools:
+      - tree-sitter
+      - name: rg
+        hint: "brew install ripgrep"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # mcps
@@ -128,3 +134,31 @@ mcps:
       args:
         - -y
         - "@modelcontextprotocol/server-sequential-thinking"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# tools
+#
+# CLI executables your workspace expects to find on PATH. gaal does not
+# install tools — it checks for their presence and surfaces an optional hint
+# when any are missing.
+#
+# Two shapes are accepted in a tools list:
+#   - bare string:  `- gh`
+#   - full mapping: `- {name: gh, hint: "brew install gh"}`
+#
+# Tool entries can also live inside an individual `skills:` entry above to
+# document tools required by that specific skill. Top-level entries always
+# win attribution if the same name appears in both places.
+#
+# Behaviour:
+#   - `gaal doctor` reports each tool as ✓ (on PATH) or ⚠ (missing); any
+#     missing tool raises doctor's exit code to 1.
+#   - `gaal sync` prints a one-line banner per missing tool to stderr but
+#     never blocks. Use `gaal doctor` to gate CI.
+# ─────────────────────────────────────────────────────────────────────────────
+tools:
+  - gh                       # GitHub CLI — bare string, no hint
+  - name: rtk                # Token-killer proxy
+    hint: "cargo install rtk"
+  - name: fnm                # Fast Node manager
+    hint: "https://github.com/Schniz/fnm#installation"

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -24,6 +24,7 @@ type Config struct {
 	Repositories map[string]ConfigRepo `yaml:"repositories" json:"repositories,omitempty" jsonschema:"description=Map of workspace-relative paths to repository entries" validate:"dive"`
 	Skills       []ConfigSkill         `yaml:"skills"       json:"skills,omitempty"       jsonschema:"description=Skill sources to install into agent skill directories"   validate:"dive"`
 	MCPs         []ConfigMcp           `yaml:"mcps"         json:"mcps,omitempty"         jsonschema:"description=MCP server configuration entries to merge"             validate:"dive"`
+	Tools        []ConfigTool          `yaml:"tools,omitempty" json:"tools,omitempty"    jsonschema:"description=CLI tools expected to be on PATH; gaal doctor/sync report any missing ones" validate:"dive"`
 	Telemetry    *bool                 `yaml:"telemetry,omitempty" json:"telemetry,omitempty" jsonschema:"description=Opt-in anonymous usage telemetry (true/false)" gaal:"maxscope=user"`
 
 	// SourcePath is populated at runtime by Load and never written to disk.
@@ -40,10 +41,19 @@ type ConfigRepo struct {
 
 // ConfigSkill defines a skill source to install.
 type ConfigSkill struct {
-	Source string   `yaml:"source"           json:"source"           jsonschema:"description=Skill source: GitHub shorthand (owner/repo), HTTPS URL, or local path" validate:"required"`
-	Agents []string `yaml:"agents,omitempty" json:"agents,omitempty" jsonschema:"description=Target agent identifiers; use [\"*\"] to target all detected agents"`
-	Global bool     `yaml:"global,omitempty" json:"global,omitempty" jsonschema:"description=When true the skill is installed globally under ~/.<agent>/skills/ instead of the project directory"`
-	Select []string `yaml:"select,omitempty" json:"select,omitempty" jsonschema:"description=Specific skill names to include; empty list installs all skills from the source"`
+	Source string       `yaml:"source"           json:"source"           jsonschema:"description=Skill source: GitHub shorthand (owner/repo), HTTPS URL, or local path" validate:"required"`
+	Agents []string     `yaml:"agents,omitempty" json:"agents,omitempty" jsonschema:"description=Target agent identifiers; use [\"*\"] to target all detected agents"`
+	Global bool         `yaml:"global,omitempty" json:"global,omitempty" jsonschema:"description=When true the skill is installed globally under ~/.<agent>/skills/ instead of the project directory"`
+	Select []string     `yaml:"select,omitempty" json:"select,omitempty" jsonschema:"description=Specific skill names to include; empty list installs all skills from the source"`
+	Tools  []ConfigTool `yaml:"tools,omitempty"  json:"tools,omitempty"  jsonschema:"description=CLI tools required by this skill; gaal doctor reports any missing ones"                             validate:"dive"`
+}
+
+// ConfigTool declares a CLI executable that is expected to be present on PATH.
+// gaal does not install tools; it only checks for their presence and, when a
+// tool is missing, surfaces the optional Hint to help the user install it.
+type ConfigTool struct {
+	Name string `yaml:"name"           json:"name"           jsonschema:"description=Executable name to look up on PATH (e.g. gh, fnm, rtk)" validate:"required"`
+	Hint string `yaml:"hint,omitempty" json:"hint,omitempty" jsonschema:"description=Free-form install hint shown when the tool is missing"`
 }
 
 // ConfigMcp defines an MCP server configuration entry.
@@ -305,10 +315,11 @@ func (c *Config) validate() error {
 // []string so downstream code does not need to care.
 func (s *ConfigSkill) UnmarshalYAML(node *yaml.Node) error {
 	type rawSkill struct {
-		Source string    `yaml:"source"`
-		Agents yaml.Node `yaml:"agents,omitempty"`
-		Global bool      `yaml:"global,omitempty"`
-		Select []string  `yaml:"select,omitempty"`
+		Source string       `yaml:"source"`
+		Agents yaml.Node    `yaml:"agents,omitempty"`
+		Global bool         `yaml:"global,omitempty"`
+		Select []string     `yaml:"select,omitempty"`
+		Tools  []ConfigTool `yaml:"tools,omitempty"`
 	}
 	var raw rawSkill
 	if err := node.Decode(&raw); err != nil {
@@ -318,6 +329,7 @@ func (s *ConfigSkill) UnmarshalYAML(node *yaml.Node) error {
 	s.Source = raw.Source
 	s.Global = raw.Global
 	s.Select = raw.Select
+	s.Tools = raw.Tools
 
 	agents, err := decodeAgents(&raw.Agents)
 	if err != nil {
@@ -368,4 +380,34 @@ func (mc ConfigMcp) MergeEnabled() bool {
 		return true
 	}
 	return *mc.Merge
+}
+
+// ── ConfigTool methods ────────────────────────────────────────────────────────
+
+// UnmarshalYAML accepts tool entries in two shapes:
+//   - scalar:  tools: [gh, fnm]
+//   - mapping: tools: [{name: gh, hint: "brew install gh"}]
+//
+// Bare strings are the common case for tools without install hints; the mapping
+// form is used when a hint is provided.
+func (t *ConfigTool) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		t.Name = node.Value
+		return nil
+	case yaml.MappingNode:
+		type rawTool struct {
+			Name string `yaml:"name"`
+			Hint string `yaml:"hint,omitempty"`
+		}
+		var raw rawTool
+		if err := node.Decode(&raw); err != nil {
+			return err
+		}
+		t.Name = raw.Name
+		t.Hint = raw.Hint
+		return nil
+	default:
+		return fmt.Errorf("line %d: expected a tool name string or a {name, hint} mapping", node.Line)
+	}
 }

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -289,13 +289,23 @@ func (c *Config) mergeFrom(src *Config, scope ConfigScope) {
 			c.MCPs = append(c.MCPs, mc)
 		}
 	}
+
+	for _, tl := range src.Tools {
+		if i := indexOf(c.Tools, func(t ConfigTool) bool { return t.Name == tl.Name }); i >= 0 {
+			c.Tools[i] = tl // higher-priority src wins
+		} else {
+			c.Tools = append(c.Tools, tl)
+		}
+	}
 }
 
 // deduplicate removes duplicate entries within this Config, keeping the first
-// occurrence. Skills are keyed by Source; MCPs are keyed by Name.
+// occurrence. Skills are keyed by Source; MCPs are keyed by Name; Tools are
+// keyed by Name.
 func (c *Config) deduplicate() {
 	c.Skills = deduplicate(c.Skills, func(s ConfigSkill) string { return s.Source })
 	c.MCPs = deduplicate(c.MCPs, func(m ConfigMcp) string { return m.Name })
+	c.Tools = deduplicate(c.Tools, func(t ConfigTool) string { return t.Name })
 }
 
 func (c *Config) validate() error {

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -981,5 +981,138 @@ func repoKeys(cfg *Config) []string {
 	return keys
 }
 
+// ---------------------------------------------------------------------------
+// Tools — top-level and per-skill
+// ---------------------------------------------------------------------------
+
+func TestLoad_Tools_TopLevel_Shorthand(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - gh
+  - fnm
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Tools) != 2 {
+		t.Fatalf("want 2 tools, got %d", len(cfg.Tools))
+	}
+	if cfg.Tools[0].Name != "gh" || cfg.Tools[0].Hint != "" {
+		t.Errorf("tool[0] = %+v, want {gh, \"\"}", cfg.Tools[0])
+	}
+	if cfg.Tools[1].Name != "fnm" {
+		t.Errorf("tool[1] name = %q, want %q", cfg.Tools[1].Name, "fnm")
+	}
+}
+
+func TestLoad_Tools_TopLevel_FullMap(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - name: gh
+    hint: "brew install gh"
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Tools) != 1 {
+		t.Fatalf("want 1 tool, got %d", len(cfg.Tools))
+	}
+	if cfg.Tools[0].Name != "gh" || cfg.Tools[0].Hint != "brew install gh" {
+		t.Errorf("tool = %+v", cfg.Tools[0])
+	}
+}
+
+func TestLoad_Tools_TopLevel_MixedShorthandAndMap(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - gh
+  - name: rtk
+    hint: "cargo install rtk"
+  - fnm
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Tools) != 3 {
+		t.Fatalf("want 3 tools, got %d", len(cfg.Tools))
+	}
+	names := []string{cfg.Tools[0].Name, cfg.Tools[1].Name, cfg.Tools[2].Name}
+	wantNames := []string{"gh", "rtk", "fnm"}
+	for i, n := range wantNames {
+		if names[i] != n {
+			t.Errorf("tool[%d] name = %q, want %q", i, names[i], n)
+		}
+	}
+	if cfg.Tools[1].Hint != "cargo install rtk" {
+		t.Errorf("tool[1] hint = %q, want %q", cfg.Tools[1].Hint, "cargo install rtk")
+	}
+}
+
+func TestLoad_Tools_PerSkill_Shorthand(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    tools:
+      - gh
+      - tree-sitter
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Skills) != 1 {
+		t.Fatalf("want 1 skill, got %d", len(cfg.Skills))
+	}
+	if got := len(cfg.Skills[0].Tools); got != 2 {
+		t.Fatalf("want 2 skill tools, got %d", got)
+	}
+	if cfg.Skills[0].Tools[0].Name != "gh" {
+		t.Errorf("skill tool[0] = %q", cfg.Skills[0].Tools[0].Name)
+	}
+}
+
+func TestLoad_Tools_PerSkill_FullMap(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    tools:
+      - name: tree-sitter
+        hint: "brew install tree-sitter"
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	tools := cfg.Skills[0].Tools
+	if len(tools) != 1 || tools[0].Name != "tree-sitter" || tools[0].Hint != "brew install tree-sitter" {
+		t.Errorf("skill tool = %+v", tools)
+	}
+}
+
+func TestLoad_Tools_MissingName_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - hint: "nameless"
+`)
+	if _, err := Load(p); err == nil {
+		t.Fatal("expected validation error for tool without name")
+	}
+}
+
+func TestLoad_Tools_InvalidNodeKind_Rejected(t *testing.T) {
+	// A list-of-list is a sequence under a sequence; each sub-item is rejected
+	// by ConfigTool.UnmarshalYAML because it is neither scalar nor mapping.
+	p := writeYAML(t, `
+tools:
+  - [gh]
+`)
+	if _, err := Load(p); err == nil {
+		t.Fatal("expected error for non-scalar/non-mapping tool entry")
+	}
+}
+
 // Ensure fmt is used (suppress unused import).
 var _ = fmt.Sprintf

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -868,6 +868,78 @@ func TestMergeFrom_MCPsDeduplicated(t *testing.T) {
 	}
 }
 
+func TestMergeFrom_ToolsUpsertByName(t *testing.T) {
+	lower := &Config{Tools: []ConfigTool{
+		{Name: "gh", Hint: "user-hint"},
+		{Name: "fnm"},
+	}}
+	higher := &Config{Tools: []ConfigTool{
+		{Name: "gh", Hint: "workspace-hint"}, // same name → replaces
+		{Name: "rtk", Hint: "cargo install rtk"},
+	}}
+
+	merged := &Config{}
+	merged.mergeFrom(lower, ScopeUser)
+	merged.mergeFrom(higher, ScopeWorkspace)
+
+	if len(merged.Tools) != 3 {
+		t.Fatalf("want 3 tools, got %d: %+v", len(merged.Tools), merged.Tools)
+	}
+	// gh should carry the higher-priority hint.
+	var ghHint string
+	for _, tl := range merged.Tools {
+		if tl.Name == "gh" {
+			ghHint = tl.Hint
+		}
+	}
+	if ghHint != "workspace-hint" {
+		t.Errorf("gh hint = %q, want workspace-hint", ghHint)
+	}
+}
+
+func TestLoad_ToolsDeduplicatedWithinFile(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - name: gh
+    hint: first
+  - name: gh
+    hint: second
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Tools) != 1 {
+		t.Fatalf("want 1 tool after dedup, got %d", len(cfg.Tools))
+	}
+	if cfg.Tools[0].Hint != "first" {
+		t.Errorf("kept hint = %q, want first (first-occurrence wins)", cfg.Tools[0].Hint)
+	}
+}
+
+func TestMergeFrom_SkillLevelToolsCarriedThrough(t *testing.T) {
+	// When a higher-priority level replaces a skill entry by Source, the
+	// replacement's nested Tools come along with it (no special-case needed
+	// — skill upsert already replaces the whole entry).
+	lower := &Config{Skills: []ConfigSkill{
+		{Source: "owner/repo", Tools: []ConfigTool{{Name: "old"}}},
+	}}
+	higher := &Config{Skills: []ConfigSkill{
+		{Source: "owner/repo", Tools: []ConfigTool{{Name: "new1"}, {Name: "new2"}}},
+	}}
+	merged := &Config{}
+	merged.mergeFrom(lower, ScopeUser)
+	merged.mergeFrom(higher, ScopeWorkspace)
+
+	if len(merged.Skills) != 1 {
+		t.Fatalf("want 1 skill, got %d", len(merged.Skills))
+	}
+	got := merged.Skills[0].Tools
+	if len(got) != 2 || got[0].Name != "new1" || got[1].Name != "new2" {
+		t.Errorf("skill tools = %+v, want [new1, new2]", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // LoadChain + ConfigLevels
 // ---------------------------------------------------------------------------

--- a/internal/engine/ops/doctor.go
+++ b/internal/engine/ops/doctor.go
@@ -14,6 +14,7 @@ import (
 	"gaal/internal/core/agent"
 	"gaal/internal/skill"
 	"gaal/internal/telemetry"
+	"gaal/internal/tools"
 )
 
 // Severity indicates the importance level of a doctor finding.
@@ -66,6 +67,7 @@ func RunDoctor(cfg *config.Config, opts DoctorOptions) *DoctorReport {
 	findings = append(findings, checkTelemetry(cfg)...)
 	findings = append(findings, checkSkillSources(cfg, opts.Offline)...)
 	findings = append(findings, checkMCPTargets(cfg)...)
+	findings = append(findings, checkTools(cfg)...)
 	findings = append(findings, checkAgents()...)
 
 	exitCode := 0
@@ -357,4 +359,39 @@ func countInstalledAgents() int {
 		}
 	}
 	return count
+}
+
+// checkTools reports, for each tool declared at the top level or under a
+// skill, whether it is available on PATH. Missing tools produce warnings
+// (doctor exit code becomes 1); present tools produce info findings.
+// Returns nil when no tools are declared anywhere so the Tools section
+// stays hidden for configs that don't use the feature.
+func checkTools(cfg *config.Config) []Finding {
+	entries := tools.Collect(cfg)
+	if len(entries) == 0 {
+		return nil
+	}
+
+	findings := make([]Finding, 0, len(entries))
+	for _, st := range tools.Check(entries) {
+		if st.Found {
+			findings = append(findings, Finding{
+				Section:  "tools",
+				Severity: SeverityInfo,
+				Message:  fmt.Sprintf("%s (on PATH: %s)", st.Entry.Tool.Name, st.Resolved),
+			})
+			continue
+		}
+		msg := fmt.Sprintf("%s — missing from PATH (required by: %s", st.Entry.Tool.Name, st.Entry.Source)
+		if st.Entry.Tool.Hint != "" {
+			msg += fmt.Sprintf("; hint: %s", st.Entry.Tool.Hint)
+		}
+		msg += ")"
+		findings = append(findings, Finding{
+			Section:  "tools",
+			Severity: SeverityWarning,
+			Message:  msg,
+		})
+	}
+	return findings
 }

--- a/internal/engine/ops/doctor_test.go
+++ b/internal/engine/ops/doctor_test.go
@@ -459,3 +459,91 @@ func TestDoctorSkillSources_DuplicateSource(t *testing.T) {
 		t.Errorf("expected warning for duplicate skill source; findings: %+v", report.Findings)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tools section
+// ---------------------------------------------------------------------------
+
+func toolsFindings(findings []Finding) []Finding {
+	var out []Finding
+	for _, f := range findings {
+		if f.Section == "tools" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func TestDoctorTools_NoToolsDeclared_NoSection(t *testing.T) {
+	cfg := &config.Config{}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+	if got := toolsFindings(report.Findings); len(got) != 0 {
+		t.Errorf("expected no tools findings, got %+v", got)
+	}
+}
+
+func TestDoctorTools_Missing_WarnsWithHint(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{
+			{Name: "gaal-definitely-missing-xyz", Hint: "cargo install gaal-ghost"},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+	got := toolsFindings(report.Findings)
+	if len(got) != 1 {
+		t.Fatalf("want 1 tools finding, got %d: %+v", len(got), got)
+	}
+	if got[0].Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", got[0].Severity)
+	}
+	if !strings.Contains(got[0].Message, "missing from PATH") {
+		t.Errorf("message missing 'missing from PATH': %q", got[0].Message)
+	}
+	if !strings.Contains(got[0].Message, "required by: workspace") {
+		t.Errorf("message missing attribution: %q", got[0].Message)
+	}
+	if !strings.Contains(got[0].Message, "cargo install gaal-ghost") {
+		t.Errorf("message missing hint: %q", got[0].Message)
+	}
+	if report.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1 (warning)", report.ExitCode)
+	}
+}
+
+func TestDoctorTools_PresentAndMissing(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{
+			{Name: "go"},                          // guaranteed present
+			{Name: "gaal-definitely-missing-xyz"}, // guaranteed missing
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+	got := toolsFindings(report.Findings)
+	if len(got) != 2 {
+		t.Fatalf("want 2 tools findings, got %d: %+v", len(got), got)
+	}
+	if got[0].Severity != SeverityInfo || !strings.Contains(got[0].Message, "on PATH:") {
+		t.Errorf("first finding = %+v, want info with 'on PATH:'", got[0])
+	}
+	if got[1].Severity != SeverityWarning {
+		t.Errorf("second severity = %q, want warning", got[1].Severity)
+	}
+}
+
+func TestDoctorTools_PerSkillAttribution(t *testing.T) {
+	cfg := &config.Config{
+		Skills: []config.ConfigSkill{
+			{Source: "owner/repo", Tools: []config.ConfigTool{
+				{Name: "gaal-definitely-missing-xyz"},
+			}},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+	got := toolsFindings(report.Findings)
+	if len(got) != 1 {
+		t.Fatalf("want 1 tools finding, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Message, "required by: skill: owner/repo") {
+		t.Errorf("message lacks skill attribution: %q", got[0].Message)
+	}
+}

--- a/internal/tools/check.go
+++ b/internal/tools/check.go
@@ -1,0 +1,81 @@
+// Package tools checks whether CLI executables declared in gaal.yaml are
+// present on the user's PATH. It is intentionally scope-limited to detection:
+// installation, version parsing, and per-OS install hints are out of scope
+// for now (see issue #49 discussion).
+package tools
+
+import (
+	"fmt"
+	"os/exec"
+
+	"gaal/internal/config"
+)
+
+// SourceWorkspace is the attribution string used for tools declared at the
+// top level of gaal.yaml.
+const SourceWorkspace = "workspace"
+
+// Entry pairs a declared tool with a human-readable attribution string
+// describing where the declaration came from ("workspace" or
+// "skill: <source>").
+type Entry struct {
+	Tool   config.ConfigTool
+	Source string
+}
+
+// Status is the result of a presence check for a single Entry.
+type Status struct {
+	Entry    Entry
+	Found    bool
+	Resolved string // absolute path from exec.LookPath when Found; empty otherwise
+}
+
+// Collect flattens top-level and per-skill tools into a deduplicated slice of
+// Entry, keyed on Tool.Name. Top-level declarations are collected first, so a
+// workspace-level entry (including its hint) wins attribution over any
+// per-skill mention of the same name. Per-skill entries appearing before a
+// top-level declaration of the same name are still shadowed by the top-level
+// one when ordering is preserved in input — the rule is simply first-seen
+// wins, and Collect walks top-level before skills.
+func Collect(cfg *config.Config) []Entry {
+	if cfg == nil {
+		return nil
+	}
+
+	out := make([]Entry, 0, len(cfg.Tools))
+	seen := make(map[string]struct{}, len(cfg.Tools))
+
+	add := func(tool config.ConfigTool, source string) {
+		if tool.Name == "" {
+			return
+		}
+		if _, dup := seen[tool.Name]; dup {
+			return
+		}
+		seen[tool.Name] = struct{}{}
+		out = append(out, Entry{Tool: tool, Source: source})
+	}
+
+	for _, tl := range cfg.Tools {
+		add(tl, SourceWorkspace)
+	}
+	for _, sk := range cfg.Skills {
+		source := fmt.Sprintf("skill: %s", sk.Source)
+		for _, tl := range sk.Tools {
+			add(tl, source)
+		}
+	}
+	return out
+}
+
+// Check runs exec.LookPath for each entry and returns one Status per input,
+// preserving order. It performs no network I/O and no concurrency — tool
+// counts are small in practice.
+func Check(entries []Entry) []Status {
+	out := make([]Status, len(entries))
+	for i, e := range entries {
+		resolved, err := exec.LookPath(e.Tool.Name)
+		out[i] = Status{Entry: e, Found: err == nil, Resolved: resolved}
+	}
+	return out
+}

--- a/internal/tools/check_test.go
+++ b/internal/tools/check_test.go
@@ -1,0 +1,165 @@
+package tools_test
+
+import (
+	"strings"
+	"testing"
+
+	"gaal/internal/config"
+	"gaal/internal/tools"
+)
+
+func TestCollect_EmptyConfig_ReturnsNil(t *testing.T) {
+	if got := tools.Collect(&config.Config{}); len(got) != 0 {
+		t.Errorf("want empty, got %+v", got)
+	}
+	if got := tools.Collect(nil); got != nil {
+		t.Errorf("want nil for nil config, got %+v", got)
+	}
+}
+
+func TestCollect_TopLevelOnly(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{
+			{Name: "gh", Hint: "brew install gh"},
+			{Name: "fnm"},
+		},
+	}
+	got := tools.Collect(cfg)
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d: %+v", len(got), got)
+	}
+	if got[0].Tool.Name != "gh" || got[0].Source != tools.SourceWorkspace {
+		t.Errorf("entry[0] = %+v", got[0])
+	}
+	if got[1].Source != tools.SourceWorkspace {
+		t.Errorf("entry[1] source = %q, want workspace", got[1].Source)
+	}
+}
+
+func TestCollect_PerSkillOnly(t *testing.T) {
+	cfg := &config.Config{
+		Skills: []config.ConfigSkill{
+			{Source: "owner/repo", Tools: []config.ConfigTool{{Name: "tree-sitter"}}},
+		},
+	}
+	got := tools.Collect(cfg)
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	if got[0].Tool.Name != "tree-sitter" {
+		t.Errorf("entry name = %q", got[0].Tool.Name)
+	}
+	if got[0].Source != "skill: owner/repo" {
+		t.Errorf("entry source = %q", got[0].Source)
+	}
+}
+
+func TestCollect_TopLevelWinsAttributionOnNameClash(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{
+			{Name: "gh", Hint: "from-workspace"},
+		},
+		Skills: []config.ConfigSkill{
+			{Source: "owner/repo", Tools: []config.ConfigTool{
+				{Name: "gh", Hint: "from-skill"}, // should be shadowed
+			}},
+		},
+	}
+	got := tools.Collect(cfg)
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry after dedup, got %d: %+v", len(got), got)
+	}
+	if got[0].Source != tools.SourceWorkspace {
+		t.Errorf("source = %q, want workspace (top-level wins)", got[0].Source)
+	}
+	if got[0].Tool.Hint != "from-workspace" {
+		t.Errorf("hint = %q, want from-workspace", got[0].Tool.Hint)
+	}
+}
+
+func TestCollect_PreservesOrder_TopLevelThenSkills(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{{Name: "gh"}, {Name: "fnm"}},
+		Skills: []config.ConfigSkill{
+			{Source: "a/b", Tools: []config.ConfigTool{{Name: "rtk"}}},
+			{Source: "c/d", Tools: []config.ConfigTool{{Name: "tree-sitter"}}},
+		},
+	}
+	got := tools.Collect(cfg)
+	wantNames := []string{"gh", "fnm", "rtk", "tree-sitter"}
+	if len(got) != len(wantNames) {
+		t.Fatalf("want %d entries, got %d", len(wantNames), len(got))
+	}
+	for i, n := range wantNames {
+		if got[i].Tool.Name != n {
+			t.Errorf("entry[%d] = %q, want %q", i, got[i].Tool.Name, n)
+		}
+	}
+}
+
+func TestCollect_SkipsEmptyName(t *testing.T) {
+	// Validation rejects empty names at parse time, but Collect should still
+	// be robust if given one directly.
+	cfg := &config.Config{Tools: []config.ConfigTool{{Name: ""}, {Name: "gh"}}}
+	got := tools.Collect(cfg)
+	if len(got) != 1 || got[0].Tool.Name != "gh" {
+		t.Errorf("got %+v, want only gh", got)
+	}
+}
+
+func TestCheck_PresentBinary(t *testing.T) {
+	// `go` is guaranteed to exist because the test suite runs under Go.
+	entries := []tools.Entry{{Tool: config.ConfigTool{Name: "go"}, Source: tools.SourceWorkspace}}
+	got := tools.Check(entries)
+	if len(got) != 1 {
+		t.Fatalf("want 1 status, got %d", len(got))
+	}
+	if !got[0].Found {
+		t.Errorf("expected `go` to be found on PATH")
+	}
+	if got[0].Resolved == "" {
+		t.Errorf("expected a non-empty resolved path")
+	}
+}
+
+func TestCheck_MissingBinary(t *testing.T) {
+	entries := []tools.Entry{
+		{Tool: config.ConfigTool{Name: "gaal-definitely-not-a-real-tool-xyz"}, Source: tools.SourceWorkspace},
+	}
+	got := tools.Check(entries)
+	if len(got) != 1 {
+		t.Fatalf("want 1 status, got %d", len(got))
+	}
+	if got[0].Found {
+		t.Errorf("expected missing binary, got found at %q", got[0].Resolved)
+	}
+	if got[0].Resolved != "" {
+		t.Errorf("expected empty resolved path, got %q", got[0].Resolved)
+	}
+}
+
+func TestCheck_PreservesOrder(t *testing.T) {
+	entries := []tools.Entry{
+		{Tool: config.ConfigTool{Name: "go"}},
+		{Tool: config.ConfigTool{Name: "gaal-missing-xyz"}},
+		{Tool: config.ConfigTool{Name: "go"}},
+	}
+	got := tools.Check(entries)
+	if len(got) != 3 {
+		t.Fatalf("want 3 statuses, got %d", len(got))
+	}
+	if !got[0].Found || got[1].Found || !got[2].Found {
+		t.Errorf("found flags = [%v %v %v], want [true false true]", got[0].Found, got[1].Found, got[2].Found)
+	}
+	// Sanity: names round-trip through the statuses.
+	wantNames := []string{"go", "gaal-missing-xyz", "go"}
+	for i, n := range wantNames {
+		if got[i].Entry.Tool.Name != n {
+			t.Errorf("status[%d] name = %q, want %q", i, got[i].Entry.Tool.Name, n)
+		}
+	}
+	// And the resolved path for `go` looks plausible.
+	if !strings.HasSuffix(got[0].Resolved, "go") && !strings.HasSuffix(got[0].Resolved, "go.exe") {
+		t.Errorf("resolved path %q does not look like a `go` binary", got[0].Resolved)
+	}
+}


### PR DESCRIPTION
Closes #49.

Adds a `tools:` block to `gaal.yaml` (both top-level and inside each
`skills:` entry) listing CLI executables the workspace expects to find
on `$PATH`. `gaal doctor` reports each one as ✓ (on PATH) or ⚠ (missing);
`gaal sync` prints a compact banner when any are missing but never blocks.

## Summary

- New `ConfigTool` type with bare-string shorthand (`- gh`) or full mapping (`{name, hint}`)
- Top-level `tools:` and per-skill `tools:` both supported; union deduplicated by name, top-level wins attribution on name clash
- Merge across global → user → workspace matches the existing MCP/skill upsert rules
- New `internal/tools` package: `Collect` + `Check` (wraps `exec.LookPath`)
- `gaal doctor` gains a Tools section; missing tools become warnings (exit code 1)
- `gaal sync` prints a one-shot stderr banner for missing tools, then proceeds
- `example.gaal.yaml` and `README.md` updated to document the feature

## Scope (explicit non-goals)

- No version checking — each tool's `--version` output is too varied to parse generically
- No installation — `doctor` only hints; users run the package manager themselves
- No reading tool requirements from inside skill repos — users declare tools in their own `gaal.yaml`

Design doc was posted on #49 ([comment](https://github.com/gmg-inc/gaal-lite/issues/49#issuecomment-4276377218)).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all 734 tests pass
- [x] Manual: `gaal doctor --offline` against `example.gaal.yaml` shows the new Tools section with mixed ✓/⚠ findings
- [x] Manual: `gaal sync --dry-run` with a missing tool prints the banner on stderr and still runs the dry-run plan