### PR TITLE
feat(cli): add text output format and make it the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | **Repositories** | Clone or update multi-protocol repos (git, hg, svn, bzr, tar, zip) from a single YAML file |
 | **Skills** | Download and install `SKILL.md` collections into your local AI agent directories (Claude, Copilot, Cursor, …) |
 | **MCPs** | Upsert MCP server entries into agent JSON config files without overwriting your existing configuration |
+| **Tools** | Check that required CLI binaries (e.g. `gh`, `fnm`) are on PATH and surface install hints when they are missing |
 
 ---
 
@@ -82,7 +83,17 @@ mcps:
     inline:
       command: uvx
       args: [mcp-server-filesystem, /home/user/projects]
+
+tools:
+  - gh                       # bare string — required on PATH, no install hint
+  - name: rtk                # full form with an install hint
+    hint: "cargo install rtk"
 ```
+
+The `tools:` block can also appear inside an individual `skills:` entry to
+document tools required by that specific skill. `gaal doctor` reports each
+tool as `✓` (on PATH) or `⚠` (missing); `gaal sync` prints a one-line
+banner per missing tool but never blocks.
 
 Then run:
 

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -71,15 +71,87 @@ func runAgentList(eng *engine.Engine, w io.Writer, format engine.OutputFormat) e
 		entries = filtered
 	}
 
-	if format == engine.FormatJSON {
+	switch format {
+	case engine.FormatJSON:
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(struct {
 			Agents []render.AgentEntry `json:"agents"`
 		}{entries})
+	case engine.FormatTable:
+		return renderAgentsTable(w, entries)
+	default:
+		return renderAgentsText(w, entries)
+	}
+}
+
+// renderAgentsText prints the agent list as space-aligned columns matching
+// the sample in docs/content/cli/agents.mdx.
+func renderAgentsText(w io.Writer, entries []render.AgentEntry) error {
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "no agents found")
+		return nil
 	}
 
-	return renderAgentsTable(w, entries)
+	headers := []string{"NAME", "INSTALLED", "PROJECT_SKILLS", "GLOBAL_SKILLS", "MCP_CONFIG"}
+	rows := make([][]string, 0, len(entries))
+	for _, e := range entries {
+		installed := "no"
+		if e.Installed {
+			installed = "yes"
+		}
+		mcpCfg := e.ProjectMCPConfigFile
+		if mcpCfg == "" {
+			mcpCfg = "—"
+		}
+		rows = append(rows, []string{
+			e.Name,
+			installed,
+			dashIfEmpty(e.ProjectSkillsDir),
+			dashIfEmpty(e.GlobalSkillsDir),
+			mcpCfg,
+		})
+	}
+
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if len(cell) > widths[i] {
+				widths[i] = len(cell)
+			}
+		}
+	}
+
+	printRow := func(cells []string) {
+		var b strings.Builder
+		for i, c := range cells {
+			if i > 0 {
+				b.WriteString("  ")
+			}
+			if i == len(cells)-1 {
+				b.WriteString(c)
+			} else {
+				b.WriteString(c)
+				b.WriteString(strings.Repeat(" ", widths[i]-len(c)))
+			}
+		}
+		fmt.Fprintln(w, b.String())
+	}
+	printRow(headers)
+	for _, row := range rows {
+		printRow(row)
+	}
+	return nil
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
 }
 
 func renderAgentsTable(w io.Writer, entries []render.AgentEntry) error {
@@ -118,15 +190,100 @@ func runAgentDetail(eng *engine.Engine, w io.Writer, name string, format engine.
 		return err
 	}
 
-	if format == engine.FormatJSON {
+	switch format {
+	case engine.FormatJSON:
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(struct {
 			Agent *render.AgentDetail `json:"agent"`
 		}{detail})
+	case engine.FormatTable:
+		return renderAgentDetailCard(w, detail)
+	default:
+		return renderAgentDetailText(w, detail)
+	}
+}
+
+// renderAgentDetailText prints the agent detail as a plain indented block
+// matching docs/content/cli/agents.mdx (detailed view).
+func renderAgentDetailText(w io.Writer, d *render.AgentDetail) error {
+	label := "not installed"
+	if d.Installed {
+		label = "installed"
+	}
+	fmt.Fprintf(w, "%s (%s)\n", d.Name, label)
+
+	source := d.Source
+	if source == "" {
+		source = "built-in"
+	}
+	if source == "builtin" {
+		source = "built-in"
+	}
+	fmt.Fprintf(w, "  %-16s %s\n", "source:", source)
+
+	byLabel := map[string][]render.AgentPath{}
+	labelOrder := []string{}
+	for _, p := range d.Paths {
+		if _, ok := byLabel[p.Label]; !ok {
+			labelOrder = append(labelOrder, p.Label)
+		}
+		byLabel[p.Label] = append(byLabel[p.Label], p)
 	}
 
-	return renderAgentDetailCard(w, detail)
+	if paths := byLabel["project"]; len(paths) > 0 {
+		fmt.Fprintf(w, "  %-16s %s\n", "project skills:", paths[0].Path)
+	}
+	if paths := byLabel["global"]; len(paths) > 0 {
+		fmt.Fprintf(w, "  %-16s %s\n", "global skills:", paths[0].Path)
+	}
+
+	if d.MCPSupport {
+		marker := "(not found)"
+		if d.MCPExists {
+			marker = "(exists)"
+		}
+		fmt.Fprintf(w, "  %-16s %s %s\n", "mcp config:", d.MCPConfig, marker)
+	}
+
+	writeExtraPaths := func(label string, paths []render.AgentPath) {
+		if len(paths) <= 1 {
+			return
+		}
+		extras := make([]string, 0, len(paths)-1)
+		for _, p := range paths[1:] {
+			extras = append(extras, p.Path)
+		}
+		fmt.Fprintf(w, "  audit search (%s):\n    %s\n", label, strings.Join(extras, ", "))
+	}
+	writeExtraPaths("project", byLabel["project"])
+	writeExtraPaths("global", byLabel["global"])
+
+	if pm := byLabel["package-manager"]; len(pm) > 0 {
+		paths := make([]string, 0, len(pm))
+		for _, p := range pm {
+			paths = append(paths, p.Path)
+		}
+		fmt.Fprintf(w, "  package-manager search:\n    %s\n", strings.Join(paths, ", "))
+	}
+	// Keep label order deterministic even when an unexpected label appears.
+	for _, name := range labelOrder {
+		switch name {
+		case "project", "global", "package-manager":
+			continue
+		}
+		paths := byLabel[name]
+		list := make([]string, 0, len(paths))
+		for _, p := range paths {
+			list = append(list, p.Path)
+		}
+		fmt.Fprintf(w, "  %s:\n    %s\n", name, strings.Join(list, ", "))
+	}
+
+	for _, warn := range d.Warnings {
+		fmt.Fprintf(w, "  warning: %s\n", warn)
+	}
+	return nil
 }
 
 func renderAgentDetailCard(w io.Writer, d *render.AgentDetail) error {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -80,9 +80,10 @@ func renderDoctorTable(report *ops.DoctorReport) {
 		"telemetry": "Telemetry",
 		"skills":    "Skills",
 		"mcps":      "MCP",
+		"tools":     "Tools",
 		"agents":    "Agents",
 	}
-	sections := []string{"config", "telemetry", "skills", "mcps", "agents"}
+	sections := []string{"config", "telemetry", "skills", "mcps", "tools", "agents"}
 	for _, section := range sections {
 		var sectionFindings []ops.Finding
 		for _, f := range report.Findings {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -60,10 +60,14 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	eng := engine.NewWithOptions(cfg.Config, engineOpts)
 	report := eng.Doctor(ops.DoctorOptions{Offline: doctorOffline, Levels: cfg.Levels})
 
-	if outputFormat == "json" {
+	switch outputFormat {
+	case "json":
 		return renderDoctorJSON(report, !doctorNoUpsell)
+	case "table":
+		renderDoctorTable(report)
+	default:
+		renderDoctorText(report)
 	}
-	renderDoctorTable(report)
 	if !doctorNoUpsell {
 		renderCommunityBlock()
 	}
@@ -72,6 +76,66 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		os.Exit(report.ExitCode)
 	}
 	return nil
+}
+
+// renderDoctorText emits the section-per-line layout shown in docs/content/cli/doctor.mdx.
+func renderDoctorText(report *ops.DoctorReport) {
+	sections := []struct {
+		id, label string
+	}{
+		{"config", "config"},
+		{"telemetry", "telemetry"},
+		{"skills", "sources"},
+		{"mcps", "mcps"},
+		{"tools", "tools"},
+		{"agents", "agents"},
+	}
+
+	for _, s := range sections {
+		var findings []ops.Finding
+		for _, f := range report.Findings {
+			if f.Section == s.id {
+				findings = append(findings, f)
+			}
+		}
+		if len(findings) == 0 {
+			continue
+		}
+		fmt.Printf("%s:\n", s.label)
+		for _, f := range findings {
+			var icon string
+			switch f.Severity {
+			case ops.SeverityInfo:
+				icon = "✓"
+			case ops.SeverityWarning:
+				icon = "!"
+			case ops.SeverityError:
+				icon = "✗"
+			}
+			fmt.Printf("  %s %s\n", icon, f.Message)
+		}
+	}
+
+	// Summary line, e.g. "3 agents installed, 0 misconfigured".
+	// `checkAgents` emits one info finding worded "N agent(s) detected" —
+	// parse the count from it, and count error findings as misconfigured.
+	installed, misconfigured := 0, 0
+	for _, f := range report.Findings {
+		if f.Section != "agents" {
+			continue
+		}
+		switch f.Severity {
+		case ops.SeverityInfo:
+			var n int
+			if _, err := fmt.Sscanf(f.Message, "%d ", &n); err == nil {
+				installed = n
+			}
+		case ops.SeverityError:
+			misconfigured++
+		}
+	}
+	fmt.Println()
+	fmt.Printf("%d agents installed, %d misconfigured\n", installed, misconfigured)
 }
 
 func renderDoctorTable(report *ops.DoctorReport) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,11 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 		if cmd.HasParent() && cmd.Parent().Name() == "completion" {
 			return nil
 		}
+		switch outputFormat {
+		case "text", "table", "json":
+		default:
+			return fmt.Errorf("invalid --output value %q (want: text, table, json)", outputFormat)
+		}
 		if !noBanner && outputFormat != "json" {
 			printBanner()
 		}
@@ -119,7 +124,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noBanner, "no-banner", false, "suppress the ASCII-art banner")
 	rootCmd.PersistentFlags().StringVar(&sandboxDir, "sandbox", "", "redirect all writes to this directory (safe for tests)")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "write structured JSON logs to this file (in addition to console)")
-	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "output format: table, json")
+	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "text", "output format: text, table, json")
 }
 
 // applyOptions builds engine.Options, applying sandbox mode when requested.

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"gaal/internal/config"
 	"gaal/internal/engine"
 	"gaal/internal/telemetry"
+	"gaal/internal/tools"
 )
 
 var (
@@ -54,6 +56,8 @@ func runSync(_ *cobra.Command, _ []string) error {
 	}
 
 	cfg := resolvedCfg
+
+	warnMissingTools(cfg.Config)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -101,4 +105,38 @@ func runSync(_ *cobra.Command, _ []string) error {
 	telemetry.Track("sync")
 	telemetry.TrackFirstSync(0)
 	return nil
+}
+
+// warnMissingTools prints a compact stderr banner listing required tools that
+// are missing from PATH. Sync never blocks on missing tools — full attribution
+// and exit-code semantics live in `gaal doctor`. The per-line rule: show the
+// install hint when set, otherwise show "(required by <source>)".
+func warnMissingTools(cfg *config.Config) {
+	statuses := tools.Check(tools.Collect(cfg))
+	missing := statuses[:0]
+	for _, st := range statuses {
+		if !st.Found {
+			missing = append(missing, st)
+		}
+	}
+	if len(missing) == 0 {
+		return
+	}
+
+	maxName := 0
+	for _, st := range missing {
+		if n := len(st.Entry.Tool.Name); n > maxName {
+			maxName = n
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "⚠ Required tools missing from PATH:")
+	for _, st := range missing {
+		detail := fmt.Sprintf("(required by %s)", st.Entry.Source)
+		if st.Entry.Tool.Hint != "" {
+			detail = st.Entry.Tool.Hint
+		}
+		fmt.Fprintf(os.Stderr, "    %-*s  — %s\n", maxName, st.Entry.Tool.Name, detail)
+	}
+	fmt.Fprintln(os.Stderr, "  Run `gaal doctor` for details.")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,12 +22,14 @@ var versionCmd = &cobra.Command{
 	Annotations: map[string]string{"config": "optional"},
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if outputFormat == "json" {
-			return json.NewEncoder(os.Stdout).Encode(struct {
-				Version   string `json:"version"`
-				BuildTime string `json:"build_time"`
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(struct {
+				Version string `json:"version"`
+				Built   string `json:"built"`
 			}{Version, BuildTime})
 		}
-		fmt.Printf("gaal %s (built: %s)\n", Version, BuildTime)
+		fmt.Printf("gaal %s\nbuilt %s\n", Version, BuildTime)
 		return nil
 	},
 }

--- a/example.gaal.yaml
+++ b/example.gaal.yaml
@@ -74,12 +74,18 @@ skills:
       - github-copilot
     global: true
 
-  # Install from a local directory.
+  # Install from a local directory. Per-skill `tools:` lists CLI binaries
+  # that this skill expects to find on PATH; gaal doctor warns when any
+  # are missing.
   - source: ./company-skills
     agents:
       - claude-code
       - cursor
     global: false
+    tools:
+      - tree-sitter
+      - name: rg
+        hint: "brew install ripgrep"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # mcps
@@ -128,3 +134,31 @@ mcps:
       args:
         - -y
         - "@modelcontextprotocol/server-sequential-thinking"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# tools
+#
+# CLI executables your workspace expects to find on PATH. gaal does not
+# install tools — it checks for their presence and surfaces an optional hint
+# when any are missing.
+#
+# Two shapes are accepted in a tools list:
+#   - bare string:  `- gh`
+#   - full mapping: `- {name: gh, hint: "brew install gh"}`
+#
+# Tool entries can also live inside an individual `skills:` entry above to
+# document tools required by that specific skill. Top-level entries always
+# win attribution if the same name appears in both places.
+#
+# Behaviour:
+#   - `gaal doctor` reports each tool as ✓ (on PATH) or ⚠ (missing); any
+#     missing tool raises doctor's exit code to 1.
+#   - `gaal sync` prints a one-line banner per missing tool to stderr but
+#     never blocks. Use `gaal doctor` to gate CI.
+# ─────────────────────────────────────────────────────────────────────────────
+tools:
+  - gh                       # GitHub CLI — bare string, no hint
+  - name: rtk                # Token-killer proxy
+    hint: "cargo install rtk"
+  - name: fnm                # Fast Node manager
+    hint: "https://github.com/Schniz/fnm#installation"

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -24,6 +24,7 @@ type Config struct {
 	Repositories map[string]ConfigRepo `yaml:"repositories" json:"repositories,omitempty" jsonschema:"description=Map of workspace-relative paths to repository entries" validate:"dive"`
 	Skills       []ConfigSkill         `yaml:"skills"       json:"skills,omitempty"       jsonschema:"description=Skill sources to install into agent skill directories"   validate:"dive"`
 	MCPs         []ConfigMcp           `yaml:"mcps"         json:"mcps,omitempty"         jsonschema:"description=MCP server configuration entries to merge"             validate:"dive"`
+	Tools        []ConfigTool          `yaml:"tools,omitempty" json:"tools,omitempty"    jsonschema:"description=CLI tools expected to be on PATH; gaal doctor/sync report any missing ones" validate:"dive"`
 	Telemetry    *bool                 `yaml:"telemetry,omitempty" json:"telemetry,omitempty" jsonschema:"description=Opt-in anonymous usage telemetry (true/false)" gaal:"maxscope=user"`
 
 	// SourcePath is populated at runtime by Load and never written to disk.
@@ -40,10 +41,19 @@ type ConfigRepo struct {
 
 // ConfigSkill defines a skill source to install.
 type ConfigSkill struct {
-	Source string   `yaml:"source"           json:"source"           jsonschema:"description=Skill source: GitHub shorthand (owner/repo), HTTPS URL, or local path" validate:"required"`
-	Agents []string `yaml:"agents,omitempty" json:"agents,omitempty" jsonschema:"description=Target agent identifiers; use [\"*\"] to target all detected agents"`
-	Global bool     `yaml:"global,omitempty" json:"global,omitempty" jsonschema:"description=When true the skill is installed globally under ~/.<agent>/skills/ instead of the project directory"`
-	Select []string `yaml:"select,omitempty" json:"select,omitempty" jsonschema:"description=Specific skill names to include; empty list installs all skills from the source"`
+	Source string       `yaml:"source"           json:"source"           jsonschema:"description=Skill source: GitHub shorthand (owner/repo), HTTPS URL, or local path" validate:"required"`
+	Agents []string     `yaml:"agents,omitempty" json:"agents,omitempty" jsonschema:"description=Target agent identifiers; use [\"*\"] to target all detected agents"`
+	Global bool         `yaml:"global,omitempty" json:"global,omitempty" jsonschema:"description=When true the skill is installed globally under ~/.<agent>/skills/ instead of the project directory"`
+	Select []string     `yaml:"select,omitempty" json:"select,omitempty" jsonschema:"description=Specific skill names to include; empty list installs all skills from the source"`
+	Tools  []ConfigTool `yaml:"tools,omitempty"  json:"tools,omitempty"  jsonschema:"description=CLI tools required by this skill; gaal doctor reports any missing ones"                             validate:"dive"`
+}
+
+// ConfigTool declares a CLI executable that is expected to be present on PATH.
+// gaal does not install tools; it only checks for their presence and, when a
+// tool is missing, surfaces the optional Hint to help the user install it.
+type ConfigTool struct {
+	Name string `yaml:"name"           json:"name"           jsonschema:"description=Executable name to look up on PATH (e.g. gh, fnm, rtk)" validate:"required"`
+	Hint string `yaml:"hint,omitempty" json:"hint,omitempty" jsonschema:"description=Free-form install hint shown when the tool is missing"`
 }
 
 // ConfigMcp defines an MCP server configuration entry.
@@ -305,10 +315,11 @@ func (c *Config) validate() error {
 // []string so downstream code does not need to care.
 func (s *ConfigSkill) UnmarshalYAML(node *yaml.Node) error {
 	type rawSkill struct {
-		Source string    `yaml:"source"`
-		Agents yaml.Node `yaml:"agents,omitempty"`
-		Global bool      `yaml:"global,omitempty"`
-		Select []string  `yaml:"select,omitempty"`
+		Source string       `yaml:"source"`
+		Agents yaml.Node    `yaml:"agents,omitempty"`
+		Global bool         `yaml:"global,omitempty"`
+		Select []string     `yaml:"select,omitempty"`
+		Tools  []ConfigTool `yaml:"tools,omitempty"`
 	}
 	var raw rawSkill
 	if err := node.Decode(&raw); err != nil {
@@ -318,6 +329,7 @@ func (s *ConfigSkill) UnmarshalYAML(node *yaml.Node) error {
 	s.Source = raw.Source
 	s.Global = raw.Global
 	s.Select = raw.Select
+	s.Tools = raw.Tools
 
 	agents, err := decodeAgents(&raw.Agents)
 	if err != nil {
@@ -368,4 +380,34 @@ func (mc ConfigMcp) MergeEnabled() bool {
 		return true
 	}
 	return *mc.Merge
+}
+
+// ── ConfigTool methods ────────────────────────────────────────────────────────
+
+// UnmarshalYAML accepts tool entries in two shapes:
+//   - scalar:  tools: [gh, fnm]
+//   - mapping: tools: [{name: gh, hint: "brew install gh"}]
+//
+// Bare strings are the common case for tools without install hints; the mapping
+// form is used when a hint is provided.
+func (t *ConfigTool) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		t.Name = node.Value
+		return nil
+	case yaml.MappingNode:
+		type rawTool struct {
+			Name string `yaml:"name"`
+			Hint string `yaml:"hint,omitempty"`
+		}
+		var raw rawTool
+		if err := node.Decode(&raw); err != nil {
+			return err
+		}
+		t.Name = raw.Name
+		t.Hint = raw.Hint
+		return nil
+	default:
+		return fmt.Errorf("line %d: expected a tool name string or a {name, hint} mapping", node.Line)
+	}
 }

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -289,13 +289,23 @@ func (c *Config) mergeFrom(src *Config, scope ConfigScope) {
 			c.MCPs = append(c.MCPs, mc)
 		}
 	}
+
+	for _, tl := range src.Tools {
+		if i := indexOf(c.Tools, func(t ConfigTool) bool { return t.Name == tl.Name }); i >= 0 {
+			c.Tools[i] = tl // higher-priority src wins
+		} else {
+			c.Tools = append(c.Tools, tl)
+		}
+	}
 }
 
 // deduplicate removes duplicate entries within this Config, keeping the first
-// occurrence. Skills are keyed by Source; MCPs are keyed by Name.
+// occurrence. Skills are keyed by Source; MCPs are keyed by Name; Tools are
+// keyed by Name.
 func (c *Config) deduplicate() {
 	c.Skills = deduplicate(c.Skills, func(s ConfigSkill) string { return s.Source })
 	c.MCPs = deduplicate(c.MCPs, func(m ConfigMcp) string { return m.Name })
+	c.Tools = deduplicate(c.Tools, func(t ConfigTool) string { return t.Name })
 }
 
 func (c *Config) validate() error {

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -981,5 +981,138 @@ func repoKeys(cfg *Config) []string {
 	return keys
 }
 
+// ---------------------------------------------------------------------------
+// Tools — top-level and per-skill
+// ---------------------------------------------------------------------------
+
+func TestLoad_Tools_TopLevel_Shorthand(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - gh
+  - fnm
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Tools) != 2 {
+		t.Fatalf("want 2 tools, got %d", len(cfg.Tools))
+	}
+	if cfg.Tools[0].Name != "gh" || cfg.Tools[0].Hint != "" {
+		t.Errorf("tool[0] = %+v, want {gh, \"\"}", cfg.Tools[0])
+	}
+	if cfg.Tools[1].Name != "fnm" {
+		t.Errorf("tool[1] name = %q, want %q", cfg.Tools[1].Name, "fnm")
+	}
+}
+
+func TestLoad_Tools_TopLevel_FullMap(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - name: gh
+    hint: "brew install gh"
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Tools) != 1 {
+		t.Fatalf("want 1 tool, got %d", len(cfg.Tools))
+	}
+	if cfg.Tools[0].Name != "gh" || cfg.Tools[0].Hint != "brew install gh" {
+		t.Errorf("tool = %+v", cfg.Tools[0])
+	}
+}
+
+func TestLoad_Tools_TopLevel_MixedShorthandAndMap(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - gh
+  - name: rtk
+    hint: "cargo install rtk"
+  - fnm
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Tools) != 3 {
+		t.Fatalf("want 3 tools, got %d", len(cfg.Tools))
+	}
+	names := []string{cfg.Tools[0].Name, cfg.Tools[1].Name, cfg.Tools[2].Name}
+	wantNames := []string{"gh", "rtk", "fnm"}
+	for i, n := range wantNames {
+		if names[i] != n {
+			t.Errorf("tool[%d] name = %q, want %q", i, names[i], n)
+		}
+	}
+	if cfg.Tools[1].Hint != "cargo install rtk" {
+		t.Errorf("tool[1] hint = %q, want %q", cfg.Tools[1].Hint, "cargo install rtk")
+	}
+}
+
+func TestLoad_Tools_PerSkill_Shorthand(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    tools:
+      - gh
+      - tree-sitter
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Skills) != 1 {
+		t.Fatalf("want 1 skill, got %d", len(cfg.Skills))
+	}
+	if got := len(cfg.Skills[0].Tools); got != 2 {
+		t.Fatalf("want 2 skill tools, got %d", got)
+	}
+	if cfg.Skills[0].Tools[0].Name != "gh" {
+		t.Errorf("skill tool[0] = %q", cfg.Skills[0].Tools[0].Name)
+	}
+}
+
+func TestLoad_Tools_PerSkill_FullMap(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    tools:
+      - name: tree-sitter
+        hint: "brew install tree-sitter"
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	tools := cfg.Skills[0].Tools
+	if len(tools) != 1 || tools[0].Name != "tree-sitter" || tools[0].Hint != "brew install tree-sitter" {
+		t.Errorf("skill tool = %+v", tools)
+	}
+}
+
+func TestLoad_Tools_MissingName_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - hint: "nameless"
+`)
+	if _, err := Load(p); err == nil {
+		t.Fatal("expected validation error for tool without name")
+	}
+}
+
+func TestLoad_Tools_InvalidNodeKind_Rejected(t *testing.T) {
+	// A list-of-list is a sequence under a sequence; each sub-item is rejected
+	// by ConfigTool.UnmarshalYAML because it is neither scalar nor mapping.
+	p := writeYAML(t, `
+tools:
+  - [gh]
+`)
+	if _, err := Load(p); err == nil {
+		t.Fatal("expected error for non-scalar/non-mapping tool entry")
+	}
+}
+
 // Ensure fmt is used (suppress unused import).
 var _ = fmt.Sprintf

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -868,6 +868,78 @@ func TestMergeFrom_MCPsDeduplicated(t *testing.T) {
 	}
 }
 
+func TestMergeFrom_ToolsUpsertByName(t *testing.T) {
+	lower := &Config{Tools: []ConfigTool{
+		{Name: "gh", Hint: "user-hint"},
+		{Name: "fnm"},
+	}}
+	higher := &Config{Tools: []ConfigTool{
+		{Name: "gh", Hint: "workspace-hint"}, // same name → replaces
+		{Name: "rtk", Hint: "cargo install rtk"},
+	}}
+
+	merged := &Config{}
+	merged.mergeFrom(lower, ScopeUser)
+	merged.mergeFrom(higher, ScopeWorkspace)
+
+	if len(merged.Tools) != 3 {
+		t.Fatalf("want 3 tools, got %d: %+v", len(merged.Tools), merged.Tools)
+	}
+	// gh should carry the higher-priority hint.
+	var ghHint string
+	for _, tl := range merged.Tools {
+		if tl.Name == "gh" {
+			ghHint = tl.Hint
+		}
+	}
+	if ghHint != "workspace-hint" {
+		t.Errorf("gh hint = %q, want workspace-hint", ghHint)
+	}
+}
+
+func TestLoad_ToolsDeduplicatedWithinFile(t *testing.T) {
+	p := writeYAML(t, `
+tools:
+  - name: gh
+    hint: first
+  - name: gh
+    hint: second
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Tools) != 1 {
+		t.Fatalf("want 1 tool after dedup, got %d", len(cfg.Tools))
+	}
+	if cfg.Tools[0].Hint != "first" {
+		t.Errorf("kept hint = %q, want first (first-occurrence wins)", cfg.Tools[0].Hint)
+	}
+}
+
+func TestMergeFrom_SkillLevelToolsCarriedThrough(t *testing.T) {
+	// When a higher-priority level replaces a skill entry by Source, the
+	// replacement's nested Tools come along with it (no special-case needed
+	// — skill upsert already replaces the whole entry).
+	lower := &Config{Skills: []ConfigSkill{
+		{Source: "owner/repo", Tools: []ConfigTool{{Name: "old"}}},
+	}}
+	higher := &Config{Skills: []ConfigSkill{
+		{Source: "owner/repo", Tools: []ConfigTool{{Name: "new1"}, {Name: "new2"}}},
+	}}
+	merged := &Config{}
+	merged.mergeFrom(lower, ScopeUser)
+	merged.mergeFrom(higher, ScopeWorkspace)
+
+	if len(merged.Skills) != 1 {
+		t.Fatalf("want 1 skill, got %d", len(merged.Skills))
+	}
+	got := merged.Skills[0].Tools
+	if len(got) != 2 || got[0].Name != "new1" || got[1].Name != "new2" {
+		t.Errorf("skill tools = %+v, want [new1, new2]", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // LoadChain + ConfigLevels
 // ---------------------------------------------------------------------------

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -36,6 +36,7 @@ type (
 
 // Re-exported constants from the render sub-package.
 const (
+	FormatText  OutputFormat = render.FormatText
 	FormatTable OutputFormat = render.FormatTable
 	FormatJSON  OutputFormat = render.FormatJSON
 

--- a/internal/engine/ops/doctor.go
+++ b/internal/engine/ops/doctor.go
@@ -14,6 +14,7 @@ import (
 	"gaal/internal/core/agent"
 	"gaal/internal/skill"
 	"gaal/internal/telemetry"
+	"gaal/internal/tools"
 )
 
 // Severity indicates the importance level of a doctor finding.
@@ -66,6 +67,7 @@ func RunDoctor(cfg *config.Config, opts DoctorOptions) *DoctorReport {
 	findings = append(findings, checkTelemetry(cfg)...)
 	findings = append(findings, checkSkillSources(cfg, opts.Offline)...)
 	findings = append(findings, checkMCPTargets(cfg)...)
+	findings = append(findings, checkTools(cfg)...)
 	findings = append(findings, checkAgents()...)
 
 	exitCode := 0
@@ -357,4 +359,39 @@ func countInstalledAgents() int {
 		}
 	}
 	return count
+}
+
+// checkTools reports, for each tool declared at the top level or under a
+// skill, whether it is available on PATH. Missing tools produce warnings
+// (doctor exit code becomes 1); present tools produce info findings.
+// Returns nil when no tools are declared anywhere so the Tools section
+// stays hidden for configs that don't use the feature.
+func checkTools(cfg *config.Config) []Finding {
+	entries := tools.Collect(cfg)
+	if len(entries) == 0 {
+		return nil
+	}
+
+	findings := make([]Finding, 0, len(entries))
+	for _, st := range tools.Check(entries) {
+		if st.Found {
+			findings = append(findings, Finding{
+				Section:  "tools",
+				Severity: SeverityInfo,
+				Message:  fmt.Sprintf("%s (on PATH: %s)", st.Entry.Tool.Name, st.Resolved),
+			})
+			continue
+		}
+		msg := fmt.Sprintf("%s — missing from PATH (required by: %s", st.Entry.Tool.Name, st.Entry.Source)
+		if st.Entry.Tool.Hint != "" {
+			msg += fmt.Sprintf("; hint: %s", st.Entry.Tool.Hint)
+		}
+		msg += ")"
+		findings = append(findings, Finding{
+			Section:  "tools",
+			Severity: SeverityWarning,
+			Message:  msg,
+		})
+	}
+	return findings
 }

--- a/internal/engine/ops/doctor_test.go
+++ b/internal/engine/ops/doctor_test.go
@@ -459,3 +459,91 @@ func TestDoctorSkillSources_DuplicateSource(t *testing.T) {
 		t.Errorf("expected warning for duplicate skill source; findings: %+v", report.Findings)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tools section
+// ---------------------------------------------------------------------------
+
+func toolsFindings(findings []Finding) []Finding {
+	var out []Finding
+	for _, f := range findings {
+		if f.Section == "tools" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func TestDoctorTools_NoToolsDeclared_NoSection(t *testing.T) {
+	cfg := &config.Config{}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+	if got := toolsFindings(report.Findings); len(got) != 0 {
+		t.Errorf("expected no tools findings, got %+v", got)
+	}
+}
+
+func TestDoctorTools_Missing_WarnsWithHint(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{
+			{Name: "gaal-definitely-missing-xyz", Hint: "cargo install gaal-ghost"},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+	got := toolsFindings(report.Findings)
+	if len(got) != 1 {
+		t.Fatalf("want 1 tools finding, got %d: %+v", len(got), got)
+	}
+	if got[0].Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", got[0].Severity)
+	}
+	if !strings.Contains(got[0].Message, "missing from PATH") {
+		t.Errorf("message missing 'missing from PATH': %q", got[0].Message)
+	}
+	if !strings.Contains(got[0].Message, "required by: workspace") {
+		t.Errorf("message missing attribution: %q", got[0].Message)
+	}
+	if !strings.Contains(got[0].Message, "cargo install gaal-ghost") {
+		t.Errorf("message missing hint: %q", got[0].Message)
+	}
+	if report.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1 (warning)", report.ExitCode)
+	}
+}
+
+func TestDoctorTools_PresentAndMissing(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{
+			{Name: "go"},                          // guaranteed present
+			{Name: "gaal-definitely-missing-xyz"}, // guaranteed missing
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+	got := toolsFindings(report.Findings)
+	if len(got) != 2 {
+		t.Fatalf("want 2 tools findings, got %d: %+v", len(got), got)
+	}
+	if got[0].Severity != SeverityInfo || !strings.Contains(got[0].Message, "on PATH:") {
+		t.Errorf("first finding = %+v, want info with 'on PATH:'", got[0])
+	}
+	if got[1].Severity != SeverityWarning {
+		t.Errorf("second severity = %q, want warning", got[1].Severity)
+	}
+}
+
+func TestDoctorTools_PerSkillAttribution(t *testing.T) {
+	cfg := &config.Config{
+		Skills: []config.ConfigSkill{
+			{Source: "owner/repo", Tools: []config.ConfigTool{
+				{Name: "gaal-definitely-missing-xyz"},
+			}},
+		},
+	}
+	report := RunDoctor(cfg, DoctorOptions{Offline: true})
+	got := toolsFindings(report.Findings)
+	if len(got) != 1 {
+		t.Fatalf("want 1 tools finding, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Message, "required by: skill: owner/repo") {
+		t.Errorf("message lacks skill attribution: %q", got[0].Message)
+	}
+}

--- a/internal/engine/ops/info.go
+++ b/internal/engine/ops/info.go
@@ -35,19 +35,34 @@ func Info(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps 
 
 	w := os.Stdout
 
-	if format == render.FormatJSON {
+	switch format {
+	case render.FormatJSON:
 		return renderInfoJSON(w, pkg, filter, report)
+	case render.FormatTable:
+		switch pkg {
+		case "repo":
+			return renderRepoInfo(w, cfg.Repositories, report.Repositories, filter)
+		case "skill":
+			return renderSkillInfo(w, cfg.Skills, report.Skills, filter)
+		case "mcp":
+			return renderMCPInfo(w, cfg.MCPs, report.MCPs, filter)
+		case "agent":
+			return renderAgentInfo(w, report.Agents, filter)
+		default:
+			return fmt.Errorf("unknown package type %q (want: repo, skill, mcp, agent)", pkg)
+		}
 	}
 
+	// Default: text format.
 	switch pkg {
 	case "repo":
-		return renderRepoInfo(w, cfg.Repositories, report.Repositories, filter)
+		return renderRepoInfoText(w, cfg.Repositories, report.Repositories, filter)
 	case "skill":
-		return renderSkillInfo(w, cfg.Skills, report.Skills, filter)
+		return renderSkillInfoText(w, cfg.Skills, report.Skills, filter, home, workDir)
 	case "mcp":
-		return renderMCPInfo(w, cfg.MCPs, report.MCPs, filter)
+		return renderMCPInfoText(w, cfg.MCPs, report.MCPs, filter)
 	case "agent":
-		return renderAgentInfo(w, report.Agents, filter)
+		return renderAgentInfoText(w, report.Agents, filter)
 	default:
 		return fmt.Errorf("unknown package type %q (want: repo, skill, mcp, agent)", pkg)
 	}

--- a/internal/engine/ops/info_text.go
+++ b/internal/engine/ops/info_text.go
@@ -1,0 +1,314 @@
+package ops
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gaal/internal/config"
+	"gaal/internal/core/agent"
+	"gaal/internal/engine/render"
+)
+
+// ── Text renderers ───────────────────────────────────────────────────────────
+//
+// The functions below produce a compact line-based layout matching the
+// samples in docs/content/cli/info.mdx. Each entry is one card of the form:
+//
+//	<type>: <name>
+//	  key:       value
+//	  key:       value
+//
+// Empty fields are omitted, and filtering is handled by the caller.
+
+const infoTextKeyWidth = 13
+
+// infoTextKV formats a single key/value line with a fixed-width key column.
+func infoTextKV(key, value string) string {
+	pad := infoTextKeyWidth - len(key)
+	if pad < 1 {
+		pad = 1
+	}
+	return fmt.Sprintf("  %s:%s%s", key, strings.Repeat(" ", pad), value)
+}
+
+func renderRepoInfoText(w io.Writer, cfgRepos map[string]config.ConfigRepo, entries []render.RepoEntry, filter string) error {
+	filtered := make([]render.RepoEntry, 0, len(entries))
+	for _, e := range entries {
+		if matchFilter(e.Path, filter) {
+			filtered = append(filtered, e)
+		}
+	}
+	if len(filtered) == 0 {
+		if filter != "" {
+			fmt.Fprintf(w, "no repository matches %q\n", filter)
+			return nil
+		}
+		fmt.Fprintln(w, "no repositories configured")
+		return nil
+	}
+	sort.Slice(filtered, func(i, j int) bool { return filtered[i].Path < filtered[j].Path })
+
+	for i, e := range filtered {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "repo: %s\n", e.Path)
+		fmt.Fprintln(w, infoTextKV("type", e.Type))
+		if e.URL != "" {
+			fmt.Fprintln(w, infoTextKV("url", e.URL))
+		}
+		cfg := cfgRepos[e.Path]
+		version := orDefault(cfg.Version, "default (HEAD)")
+		if e.Current != "" {
+			version = fmt.Sprintf("%s  →  current: %s", version, e.Current)
+		}
+		fmt.Fprintln(w, infoTextKV("version", version))
+		fmt.Fprintln(w, infoTextKV("status", repoStatusLabel(e)))
+		if e.Error != "" {
+			fmt.Fprintln(w, infoTextKV("error", e.Error))
+		}
+	}
+	return nil
+}
+
+func repoStatusLabel(e render.RepoEntry) string {
+	switch e.Status {
+	case render.StatusOK:
+		return "clean"
+	case render.StatusDirty:
+		return "dirty (local changes)"
+	case render.StatusNotCloned:
+		return "not cloned"
+	case render.StatusError:
+		return "error"
+	case render.StatusUnmanaged:
+		return "unmanaged"
+	default:
+		return string(e.Status)
+	}
+}
+
+func renderSkillInfoText(w io.Writer, cfgSkills []config.ConfigSkill, entries []render.SkillEntry, filter string, home, workDir string) error {
+	filtered := make([]config.ConfigSkill, 0, len(cfgSkills))
+	for _, sc := range cfgSkills {
+		if matchFilter(sc.Source, filter) {
+			filtered = append(filtered, sc)
+		}
+	}
+	if len(filtered) == 0 {
+		if filter != "" {
+			fmt.Fprintf(w, "no skill matches %q\n", filter)
+			return nil
+		}
+		fmt.Fprintln(w, "no skills configured")
+		return nil
+	}
+
+	bySource := make(map[string][]render.SkillEntry, len(entries))
+	for _, e := range entries {
+		bySource[e.Source] = append(bySource[e.Source], e)
+	}
+
+	for i, sc := range filtered {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "skill: %s\n", sc.Source)
+
+		selection := "all"
+		if len(sc.Select) > 0 {
+			selection = "select [" + strings.Join(sc.Select, ", ") + "]"
+		}
+		fmt.Fprintln(w, infoTextKV("selection", selection))
+
+		scope := "project"
+		if sc.Global {
+			scope = "global"
+		}
+		fmt.Fprintln(w, infoTextKV("scope", scope))
+
+		agents := "all detected"
+		if len(sc.Agents) > 0 && !(len(sc.Agents) == 1 && sc.Agents[0] == "*") {
+			agents = strings.Join(sc.Agents, ", ")
+		}
+		fmt.Fprintln(w, infoTextKV("agents", agents))
+
+		skillEntries := bySource[sc.Source]
+		if len(skillEntries) > 0 {
+			fmt.Fprintln(w, "  installed at:")
+			for _, e := range skillEntries {
+				dir, ok := skillInstallDir(e.Agent, e.Global, home, workDir)
+				if !ok {
+					continue
+				}
+				for _, name := range e.Installed {
+					path := filepath.Join(dir, name) + string(filepath.Separator)
+					fmt.Fprintf(w, "    %s   (%s)\n", path, skillStateDesc(e, name))
+				}
+				for _, name := range e.Missing {
+					path := filepath.Join(dir, name) + string(filepath.Separator)
+					fmt.Fprintf(w, "    %s   (missing)\n", path)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// skillInstallDir resolves the directory gaal writes to for the given agent
+// and scope, falling back to workDir-relative when the computed path is not
+// absolute. Returns false when the agent has no registered skills dir.
+func skillInstallDir(agentName string, global bool, home, workDir string) (string, bool) {
+	dir, ok := agent.SkillDir(agentName, global, home)
+	if !ok {
+		return "", false
+	}
+	if !global && !filepath.IsAbs(dir) {
+		dir = filepath.Join(workDir, dir)
+	}
+	return filepath.Clean(dir), true
+}
+
+func skillStateDesc(e render.SkillEntry, name string) string {
+	for _, m := range e.Modified {
+		if m == name {
+			return "modified"
+		}
+	}
+	if e.Error != "" {
+		return "error: " + e.Error
+	}
+	return "fresh"
+}
+
+func renderMCPInfoText(w io.Writer, cfgMCPs []config.ConfigMcp, entries []render.MCPEntry, filter string) error {
+	filtered := make([]config.ConfigMcp, 0, len(cfgMCPs))
+	for _, mc := range cfgMCPs {
+		if matchFilter(mc.Name, filter) {
+			filtered = append(filtered, mc)
+		}
+	}
+	if len(filtered) == 0 {
+		if filter != "" {
+			fmt.Fprintf(w, "no MCP matches %q\n", filter)
+			return nil
+		}
+		fmt.Fprintln(w, "no MCP configs configured")
+		return nil
+	}
+
+	byName := make(map[string]render.MCPEntry, len(entries))
+	for _, e := range entries {
+		byName[e.Name] = e
+	}
+
+	for i, mc := range filtered {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		e := byName[mc.Name]
+		fmt.Fprintf(w, "mcp: %s\n", mc.Name)
+		fmt.Fprintln(w, infoTextKV("target", mc.Target))
+		if mc.Source != "" {
+			fmt.Fprintln(w, infoTextKV("source", mc.Source))
+		}
+		merge := "false"
+		if mc.MergeEnabled() {
+			merge = "true"
+		}
+		fmt.Fprintln(w, infoTextKV("merge", merge))
+
+		if mc.Inline != nil {
+			fmt.Fprintln(w, "  inline:")
+			fmt.Fprintf(w, "    command: %s\n", mc.Inline.Command)
+			if len(mc.Inline.Args) > 0 {
+				fmt.Fprintf(w, "    args:    [%s]\n", strings.Join(mc.Inline.Args, ", "))
+			}
+			if len(mc.Inline.Env) > 0 {
+				envPairs := make([]string, 0, len(mc.Inline.Env))
+				for k, v := range mc.Inline.Env {
+					envPairs = append(envPairs, k+"="+v)
+				}
+				sort.Strings(envPairs)
+				fmt.Fprintf(w, "    env:     %s\n", strings.Join(envPairs, ", "))
+			}
+		}
+
+		fmt.Fprintln(w, infoTextKV("state", mcpStateLabel(e)))
+		if e.Error != "" {
+			fmt.Fprintln(w, infoTextKV("error", e.Error))
+		}
+	}
+	return nil
+}
+
+func mcpStateLabel(e render.MCPEntry) string {
+	switch e.Status {
+	case render.StatusPresent:
+		return "upserted, hash matches config"
+	case render.StatusDirty:
+		return "upserted with local changes"
+	case render.StatusAbsent:
+		return "absent (would be created on next sync)"
+	case render.StatusError:
+		return "error"
+	case render.StatusUnmanaged:
+		return "unmanaged"
+	default:
+		return string(e.Status)
+	}
+}
+
+func renderAgentInfoText(w io.Writer, entries []render.AgentEntry, filter string) error {
+	filtered := make([]render.AgentEntry, 0, len(entries))
+	for _, e := range entries {
+		if matchFilter(e.Name, filter) {
+			filtered = append(filtered, e)
+		}
+	}
+	if len(filtered) == 0 {
+		if filter != "" {
+			fmt.Fprintf(w, "no agent matches %q\n", filter)
+			return nil
+		}
+		fmt.Fprintln(w, "no agents registered")
+		return nil
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		if filtered[i].Installed != filtered[j].Installed {
+			return filtered[i].Installed
+		}
+		return filtered[i].Name < filtered[j].Name
+	})
+
+	for i, e := range filtered {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		label := "not installed"
+		if e.Installed {
+			label = "installed"
+		}
+		fmt.Fprintf(w, "agent: %s (%s)\n", e.Name, label)
+
+		source := e.Source
+		if source == "" {
+			source = "builtin"
+		}
+		fmt.Fprintln(w, infoTextKV("source", source))
+
+		if e.ProjectSkillsDir != "" {
+			fmt.Fprintln(w, infoTextKV("project", e.ProjectSkillsDir))
+		}
+		if e.GlobalSkillsDir != "" {
+			fmt.Fprintln(w, infoTextKV("global", e.GlobalSkillsDir))
+		}
+		if e.ProjectMCPConfigFile != "" {
+			fmt.Fprintln(w, infoTextKV("mcp config", e.ProjectMCPConfigFile))
+		}
+	}
+	return nil
+}

--- a/internal/engine/render/audit.go
+++ b/internal/engine/render/audit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/pterm/pterm"
@@ -17,10 +18,14 @@ type AuditRenderer interface {
 
 // NewAuditRenderer returns the appropriate AuditRenderer for the given format.
 func NewAuditRenderer(format OutputFormat) AuditRenderer {
-	if format == FormatJSON {
+	switch format {
+	case FormatJSON:
 		return &auditJSONRenderer{}
+	case FormatTable:
+		return &auditTableRenderer{}
+	default:
+		return &auditTextRenderer{}
 	}
-	return &auditTableRenderer{}
 }
 
 // ── JSON renderer ────────────────────────────────────────────────────────────
@@ -32,6 +37,104 @@ func (j *auditJSONRenderer) Render(w io.Writer, r *AuditReport) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(r)
+}
+
+// ── Text renderer ───────────────────────────────────────────────────────────
+//
+// Matches the sample in cli/audit.mdx:
+//
+//	discovered:
+//	  skills (project)
+//	    .claude/skills/code-review     (claude-code)
+//	  mcps
+//	    ~/.config/claude/claude_desktop_config.json
+//	      filesystem, git, github
+
+type auditTextRenderer struct{}
+
+func (tr *auditTextRenderer) Render(w io.Writer, r *AuditReport) error {
+	slog.Debug("rendering audit text output")
+
+	fmt.Fprintln(w, "discovered:")
+	tr.skillGroups(w, r.Skills, r.Home)
+	tr.mcpGroups(w, r.MCPs, r.Home)
+	return nil
+}
+
+func (tr *auditTextRenderer) skillGroups(w io.Writer, skills []AuditSkillEntry, home string) {
+	groups := map[string][]AuditSkillEntry{}
+	for _, s := range skills {
+		groups[s.Source] = append(groups[s.Source], s)
+	}
+
+	// Fixed order for stable output; labels mirror the docs example wording.
+	order := []struct {
+		key, label string
+	}{
+		{"project", "skills (project)"},
+		{"global", "skills (global)"},
+		{"package-manager", "skills (package manager)"},
+	}
+	for _, g := range order {
+		entries := groups[g.key]
+		if len(entries) == 0 {
+			continue
+		}
+		sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+
+		pathWidth := 0
+		for _, e := range entries {
+			if n := len(shortenHome(e.Path, home)); n > pathWidth {
+				pathWidth = n
+			}
+		}
+
+		fmt.Fprintf(w, "  %s\n", g.label)
+		for _, e := range entries {
+			path := shortenHome(e.Path, home)
+			fmt.Fprintf(w, "    %s  (%s)\n", padText(path, pathWidth), e.Agent)
+		}
+	}
+}
+
+func (tr *auditTextRenderer) mcpGroups(w io.Writer, mcps []AuditMCPEntry, home string) {
+	if len(mcps) == 0 {
+		return
+	}
+
+	// Collapse entries by config file so the same file (reachable via several
+	// agents) renders once with the combined server list.
+	type fileGroup struct {
+		path    string
+		servers map[string]struct{}
+	}
+	byFile := map[string]*fileGroup{}
+	order := []string{}
+	for _, e := range mcps {
+		g, ok := byFile[e.ConfigFile]
+		if !ok {
+			g = &fileGroup{path: e.ConfigFile, servers: map[string]struct{}{}}
+			byFile[e.ConfigFile] = g
+			order = append(order, e.ConfigFile)
+		}
+		for _, s := range e.Servers {
+			g.servers[s] = struct{}{}
+		}
+	}
+
+	fmt.Fprintln(w, "  mcps")
+	for _, path := range order {
+		g := byFile[path]
+		servers := make([]string, 0, len(g.servers))
+		for s := range g.servers {
+			servers = append(servers, s)
+		}
+		sort.Strings(servers)
+		fmt.Fprintf(w, "    %s\n", shortenHome(g.path, home))
+		if len(servers) > 0 {
+			fmt.Fprintf(w, "      %s\n", strings.Join(servers, ", "))
+		}
+	}
 }
 
 // ── Table renderer ───────────────────────────────────────────────────────────

--- a/internal/engine/render/plan_text.go
+++ b/internal/engine/render/plan_text.go
@@ -1,0 +1,155 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+)
+
+// planTextRenderer implements PlanRenderer producing a compact, line-per-item
+// layout matching cli/sync.mdx:
+//
+//	✓ src/example          cloned
+//	✓ code-review          installed in claude-code, cursor
+//	✓ filesystem           upserted in claude_desktop_config.json
+//	sync complete in 1.2s
+//
+// For dry-run mode the trailing summary line is replaced with a status hint.
+type planTextRenderer struct{}
+
+func (pr *planTextRenderer) Render(w io.Writer, r *PlanReport) error {
+	slog.Debug("rendering plan text output")
+
+	items := collectPlanItems(r)
+	nameWidth := 0
+	for _, it := range items {
+		if n := len(it.name); n > nameWidth {
+			nameWidth = n
+		}
+	}
+
+	for _, it := range items {
+		fmt.Fprintf(w, "%s %s  %s\n", it.marker, padText(it.name, nameWidth), it.detail)
+	}
+
+	if len(items) == 0 {
+		fmt.Fprintln(w, "nothing to do")
+		return nil
+	}
+
+	switch {
+	case r.HasErrors:
+		fmt.Fprintln(w, "plan completed with errors")
+	case r.HasChanges:
+		fmt.Fprintln(w, "changes pending — run `gaal sync` to apply")
+	default:
+		fmt.Fprintln(w, "everything up to date")
+	}
+	return nil
+}
+
+type planTextItem struct {
+	marker string
+	name   string
+	detail string
+}
+
+func collectPlanItems(r *PlanReport) []planTextItem {
+	items := make([]planTextItem, 0,
+		len(r.Repositories)+len(r.Skills)+len(r.MCPs))
+
+	for _, e := range r.Repositories {
+		items = append(items, planTextItem{
+			marker: markerFor(e.Action),
+			name:   e.Path,
+			detail: repoPlanDetail(e),
+		})
+	}
+	for _, e := range r.Skills {
+		items = append(items, planTextItem{
+			marker: markerFor(e.Action),
+			name:   e.Source,
+			detail: skillPlanDetail(e),
+		})
+	}
+	for _, e := range r.MCPs {
+		items = append(items, planTextItem{
+			marker: markerFor(e.Action),
+			name:   e.Name,
+			detail: mcpPlanDetail(e),
+		})
+	}
+	return items
+}
+
+func markerFor(a PlanAction) string {
+	switch a {
+	case PlanNoOp:
+		return "✓"
+	case PlanClone, PlanCreate:
+		return "+"
+	case PlanUpdate:
+		return "~"
+	case PlanError:
+		return "✗"
+	default:
+		return "·"
+	}
+}
+
+func repoPlanDetail(e PlanRepoEntry) string {
+	switch e.Action {
+	case PlanNoOp:
+		if e.Current != "" {
+			return "up to date (" + e.Current + ")"
+		}
+		return "up to date"
+	case PlanClone:
+		if e.URL != "" {
+			return "would clone " + e.URL
+		}
+		return "would clone"
+	case PlanUpdate:
+		return "would update " + e.Current + " → " + e.Want
+	case PlanError:
+		return "error: " + e.Error
+	default:
+		return string(e.Action)
+	}
+}
+
+func skillPlanDetail(e PlanSkillEntry) string {
+	switch e.Action {
+	case PlanNoOp:
+		return "installed in " + e.Agent
+	case PlanCreate:
+		names := append([]string{}, e.Install...)
+		names = append(names, e.Update...)
+		if len(names) == 0 {
+			return "would install in " + e.Agent
+		}
+		return "would install " + strings.Join(names, ", ") + " in " + e.Agent
+	case PlanUpdate:
+		return "would update " + strings.Join(e.Update, ", ") + " in " + e.Agent
+	case PlanError:
+		return "error: " + e.Error
+	default:
+		return string(e.Action)
+	}
+}
+
+func mcpPlanDetail(e PlanMCPEntry) string {
+	switch e.Action {
+	case PlanNoOp:
+		return "upserted in " + e.Target
+	case PlanCreate:
+		return "would upsert in " + e.Target
+	case PlanUpdate:
+		return "would update in " + e.Target
+	case PlanError:
+		return "error: " + e.Error
+	default:
+		return string(e.Action)
+	}
+}

--- a/internal/engine/render/renderer.go
+++ b/internal/engine/render/renderer.go
@@ -10,6 +10,7 @@ import (
 type OutputFormat string
 
 const (
+	FormatText  OutputFormat = "text"
 	FormatTable OutputFormat = "table"
 	FormatJSON  OutputFormat = "json"
 )
@@ -23,12 +24,14 @@ type Renderer interface {
 func NewRenderer(f OutputFormat) (Renderer, error) {
 	slog.Debug("creating renderer", "format", f)
 	switch f {
+	case FormatText, "":
+		return &textRenderer{}, nil
 	case FormatTable:
 		return &tableRenderer{}, nil
 	case FormatJSON:
 		return &jsonRenderer{}, nil
 	default:
-		return nil, fmt.Errorf("unknown output format %q (want: table, json)", f)
+		return nil, fmt.Errorf("unknown output format %q (want: text, table, json)", f)
 	}
 }
 
@@ -41,11 +44,13 @@ type PlanRenderer interface {
 func NewPlanRenderer(f OutputFormat) (PlanRenderer, error) {
 	slog.Debug("creating plan renderer", "format", f)
 	switch f {
+	case FormatText, "":
+		return &planTextRenderer{}, nil
 	case FormatTable:
 		return &planTableRenderer{}, nil
 	case FormatJSON:
 		return &planJSONRenderer{}, nil
 	default:
-		return nil, fmt.Errorf("unknown output format %q (want: table, json)", f)
+		return nil, fmt.Errorf("unknown output format %q (want: text, table, json)", f)
 	}
 }

--- a/internal/engine/render/text.go
+++ b/internal/engine/render/text.go
@@ -1,0 +1,209 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"sort"
+	"strings"
+)
+
+// textRenderer implements Renderer producing a compact, pipe-friendly text
+// layout that matches the samples shown in the docs (cli/status.mdx):
+//
+//	repositories
+//	  src/gaal               git · main · clean
+//
+// Sections are lowercased and indented with two spaces. Empty sections are
+// omitted entirely so scripts can rely on presence-as-signal.
+type textRenderer struct{}
+
+func (tr *textRenderer) Render(w io.Writer, r *StatusReport) error {
+	slog.Debug("rendering text output")
+
+	wroteAny := false
+	write := func(f func() bool) {
+		if f() {
+			wroteAny = true
+		}
+	}
+
+	write(func() bool { return tr.repoSection(w, r.Repositories) })
+	write(func() bool { return tr.skillSection(w, r.Skills) })
+	write(func() bool { return tr.mcpSection(w, r.MCPs) })
+	write(func() bool { return tr.agentSection(w, r.Agents) })
+
+	if !wroteAny {
+		fmt.Fprintln(w, "no managed resources")
+	}
+	return nil
+}
+
+func (tr *textRenderer) repoSection(w io.Writer, entries []RepoEntry) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	fmt.Fprintln(w, "repositories")
+	nameWidth := maxWidth(entries, func(i int) string { return entries[i].Path })
+	for _, e := range entries {
+		fmt.Fprintf(w, "  %s  %s\n", padText(e.Path, nameWidth), repoTextInfo(e))
+	}
+	fmt.Fprintln(w)
+	return true
+}
+
+func repoTextInfo(e RepoEntry) string {
+	parts := []string{}
+	if e.Type != "" {
+		parts = append(parts, e.Type)
+	}
+	switch e.Status {
+	case StatusOK:
+		if e.Current != "" {
+			parts = append(parts, e.Current)
+		} else if e.Want != "" {
+			parts = append(parts, e.Want)
+		}
+		parts = append(parts, "clean")
+	case StatusDirty:
+		if e.Current != "" {
+			parts = append(parts, e.Current)
+		}
+		parts = append(parts, "dirty")
+	case StatusNotCloned:
+		parts = append(parts, "not cloned")
+		if e.URL != "" {
+			parts = append(parts, e.URL)
+		}
+	case StatusUnmanaged:
+		parts = append(parts, "unmanaged")
+	case StatusError:
+		if e.Error != "" {
+			parts = append(parts, "error: "+e.Error)
+		} else {
+			parts = append(parts, "error")
+		}
+	default:
+		parts = append(parts, string(e.Status))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func (tr *textRenderer) skillSection(w io.Writer, entries []SkillEntry) bool {
+	aggregated := aggregateSkillsByName(entries)
+	if len(aggregated) == 0 {
+		return false
+	}
+	fmt.Fprintln(w, "skills")
+
+	nameWidth := 0
+	for _, s := range aggregated {
+		if n := len(displayName(s.Name)); n > nameWidth {
+			nameWidth = n
+		}
+	}
+
+	for _, s := range aggregated {
+		name := displayName(s.Name)
+		agents := "none"
+		if len(s.Agents) > 0 {
+			agents = strings.Join(s.Agents, ", ")
+		}
+		scope := "workspace"
+		if s.Global {
+			scope = "global"
+		}
+		if s.Status == StatusError && s.Error != "" {
+			fmt.Fprintf(w, "  %s  error: %s\n", padText(name, nameWidth), s.Error)
+			continue
+		}
+		fmt.Fprintf(w, "  %s  %s (%s)\n", padText(name, nameWidth), agents, scope)
+	}
+	fmt.Fprintln(w)
+	return true
+}
+
+func displayName(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+func (tr *textRenderer) mcpSection(w io.Writer, entries []MCPEntry) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	fmt.Fprintln(w, "mcps")
+
+	nameWidth := maxWidth(entries, func(i int) string { return entries[i].Name })
+	for _, e := range entries {
+		suffix := ""
+		switch e.Status {
+		case StatusDirty:
+			suffix = " (dirty)"
+		case StatusAbsent:
+			suffix = " (absent)"
+		case StatusError:
+			if e.Error != "" {
+				suffix = " (error: " + e.Error + ")"
+			} else {
+				suffix = " (error)"
+			}
+		case StatusUnmanaged:
+			suffix = " (unmanaged)"
+		}
+		fmt.Fprintf(w, "  %s  %s%s\n", padText(e.Name, nameWidth), e.Target, suffix)
+	}
+	fmt.Fprintln(w)
+	return true
+}
+
+func (tr *textRenderer) agentSection(w io.Writer, entries []AgentEntry) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	installed := make([]string, 0, len(entries))
+	other := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.Installed {
+			installed = append(installed, e.Name)
+		} else {
+			other = append(other, e.Name)
+		}
+	}
+	sort.Strings(installed)
+	sort.Strings(other)
+
+	fmt.Fprintln(w, "agents")
+	if len(installed) > 0 {
+		fmt.Fprintf(w, "  installed:     %s\n", strings.Join(installed, ", "))
+	}
+	if len(other) > 0 {
+		fmt.Fprintf(w, "  not installed: %s\n", strings.Join(other, ", "))
+	}
+	fmt.Fprintln(w)
+	return true
+}
+
+// maxWidth returns the longest visible length of the string returned by f for
+// indices [0, len(slice)). It is a small helper to line up two-column text
+// output without pulling in pterm's tabular layout.
+func maxWidth[T any](slice []T, f func(i int) string) int {
+	max := 0
+	for i := range slice {
+		if n := len(f(i)); n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+// padText right-pads s with spaces to width. It assumes no embedded ANSI codes
+// (text renderers intentionally skip colouring).
+func padText(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}

--- a/internal/tools/check.go
+++ b/internal/tools/check.go
@@ -1,0 +1,81 @@
+// Package tools checks whether CLI executables declared in gaal.yaml are
+// present on the user's PATH. It is intentionally scope-limited to detection:
+// installation, version parsing, and per-OS install hints are out of scope
+// for now (see issue #49 discussion).
+package tools
+
+import (
+	"fmt"
+	"os/exec"
+
+	"gaal/internal/config"
+)
+
+// SourceWorkspace is the attribution string used for tools declared at the
+// top level of gaal.yaml.
+const SourceWorkspace = "workspace"
+
+// Entry pairs a declared tool with a human-readable attribution string
+// describing where the declaration came from ("workspace" or
+// "skill: <source>").
+type Entry struct {
+	Tool   config.ConfigTool
+	Source string
+}
+
+// Status is the result of a presence check for a single Entry.
+type Status struct {
+	Entry    Entry
+	Found    bool
+	Resolved string // absolute path from exec.LookPath when Found; empty otherwise
+}
+
+// Collect flattens top-level and per-skill tools into a deduplicated slice of
+// Entry, keyed on Tool.Name. Top-level declarations are collected first, so a
+// workspace-level entry (including its hint) wins attribution over any
+// per-skill mention of the same name. Per-skill entries appearing before a
+// top-level declaration of the same name are still shadowed by the top-level
+// one when ordering is preserved in input — the rule is simply first-seen
+// wins, and Collect walks top-level before skills.
+func Collect(cfg *config.Config) []Entry {
+	if cfg == nil {
+		return nil
+	}
+
+	out := make([]Entry, 0, len(cfg.Tools))
+	seen := make(map[string]struct{}, len(cfg.Tools))
+
+	add := func(tool config.ConfigTool, source string) {
+		if tool.Name == "" {
+			return
+		}
+		if _, dup := seen[tool.Name]; dup {
+			return
+		}
+		seen[tool.Name] = struct{}{}
+		out = append(out, Entry{Tool: tool, Source: source})
+	}
+
+	for _, tl := range cfg.Tools {
+		add(tl, SourceWorkspace)
+	}
+	for _, sk := range cfg.Skills {
+		source := fmt.Sprintf("skill: %s", sk.Source)
+		for _, tl := range sk.Tools {
+			add(tl, source)
+		}
+	}
+	return out
+}
+
+// Check runs exec.LookPath for each entry and returns one Status per input,
+// preserving order. It performs no network I/O and no concurrency — tool
+// counts are small in practice.
+func Check(entries []Entry) []Status {
+	out := make([]Status, len(entries))
+	for i, e := range entries {
+		resolved, err := exec.LookPath(e.Tool.Name)
+		out[i] = Status{Entry: e, Found: err == nil, Resolved: resolved}
+	}
+	return out
+}

--- a/internal/tools/check_test.go
+++ b/internal/tools/check_test.go
@@ -1,0 +1,165 @@
+package tools_test
+
+import (
+	"strings"
+	"testing"
+
+	"gaal/internal/config"
+	"gaal/internal/tools"
+)
+
+func TestCollect_EmptyConfig_ReturnsNil(t *testing.T) {
+	if got := tools.Collect(&config.Config{}); len(got) != 0 {
+		t.Errorf("want empty, got %+v", got)
+	}
+	if got := tools.Collect(nil); got != nil {
+		t.Errorf("want nil for nil config, got %+v", got)
+	}
+}
+
+func TestCollect_TopLevelOnly(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{
+			{Name: "gh", Hint: "brew install gh"},
+			{Name: "fnm"},
+		},
+	}
+	got := tools.Collect(cfg)
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d: %+v", len(got), got)
+	}
+	if got[0].Tool.Name != "gh" || got[0].Source != tools.SourceWorkspace {
+		t.Errorf("entry[0] = %+v", got[0])
+	}
+	if got[1].Source != tools.SourceWorkspace {
+		t.Errorf("entry[1] source = %q, want workspace", got[1].Source)
+	}
+}
+
+func TestCollect_PerSkillOnly(t *testing.T) {
+	cfg := &config.Config{
+		Skills: []config.ConfigSkill{
+			{Source: "owner/repo", Tools: []config.ConfigTool{{Name: "tree-sitter"}}},
+		},
+	}
+	got := tools.Collect(cfg)
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	if got[0].Tool.Name != "tree-sitter" {
+		t.Errorf("entry name = %q", got[0].Tool.Name)
+	}
+	if got[0].Source != "skill: owner/repo" {
+		t.Errorf("entry source = %q", got[0].Source)
+	}
+}
+
+func TestCollect_TopLevelWinsAttributionOnNameClash(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{
+			{Name: "gh", Hint: "from-workspace"},
+		},
+		Skills: []config.ConfigSkill{
+			{Source: "owner/repo", Tools: []config.ConfigTool{
+				{Name: "gh", Hint: "from-skill"}, // should be shadowed
+			}},
+		},
+	}
+	got := tools.Collect(cfg)
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry after dedup, got %d: %+v", len(got), got)
+	}
+	if got[0].Source != tools.SourceWorkspace {
+		t.Errorf("source = %q, want workspace (top-level wins)", got[0].Source)
+	}
+	if got[0].Tool.Hint != "from-workspace" {
+		t.Errorf("hint = %q, want from-workspace", got[0].Tool.Hint)
+	}
+}
+
+func TestCollect_PreservesOrder_TopLevelThenSkills(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ConfigTool{{Name: "gh"}, {Name: "fnm"}},
+		Skills: []config.ConfigSkill{
+			{Source: "a/b", Tools: []config.ConfigTool{{Name: "rtk"}}},
+			{Source: "c/d", Tools: []config.ConfigTool{{Name: "tree-sitter"}}},
+		},
+	}
+	got := tools.Collect(cfg)
+	wantNames := []string{"gh", "fnm", "rtk", "tree-sitter"}
+	if len(got) != len(wantNames) {
+		t.Fatalf("want %d entries, got %d", len(wantNames), len(got))
+	}
+	for i, n := range wantNames {
+		if got[i].Tool.Name != n {
+			t.Errorf("entry[%d] = %q, want %q", i, got[i].Tool.Name, n)
+		}
+	}
+}
+
+func TestCollect_SkipsEmptyName(t *testing.T) {
+	// Validation rejects empty names at parse time, but Collect should still
+	// be robust if given one directly.
+	cfg := &config.Config{Tools: []config.ConfigTool{{Name: ""}, {Name: "gh"}}}
+	got := tools.Collect(cfg)
+	if len(got) != 1 || got[0].Tool.Name != "gh" {
+		t.Errorf("got %+v, want only gh", got)
+	}
+}
+
+func TestCheck_PresentBinary(t *testing.T) {
+	// `go` is guaranteed to exist because the test suite runs under Go.
+	entries := []tools.Entry{{Tool: config.ConfigTool{Name: "go"}, Source: tools.SourceWorkspace}}
+	got := tools.Check(entries)
+	if len(got) != 1 {
+		t.Fatalf("want 1 status, got %d", len(got))
+	}
+	if !got[0].Found {
+		t.Errorf("expected `go` to be found on PATH")
+	}
+	if got[0].Resolved == "" {
+		t.Errorf("expected a non-empty resolved path")
+	}
+}
+
+func TestCheck_MissingBinary(t *testing.T) {
+	entries := []tools.Entry{
+		{Tool: config.ConfigTool{Name: "gaal-definitely-not-a-real-tool-xyz"}, Source: tools.SourceWorkspace},
+	}
+	got := tools.Check(entries)
+	if len(got) != 1 {
+		t.Fatalf("want 1 status, got %d", len(got))
+	}
+	if got[0].Found {
+		t.Errorf("expected missing binary, got found at %q", got[0].Resolved)
+	}
+	if got[0].Resolved != "" {
+		t.Errorf("expected empty resolved path, got %q", got[0].Resolved)
+	}
+}
+
+func TestCheck_PreservesOrder(t *testing.T) {
+	entries := []tools.Entry{
+		{Tool: config.ConfigTool{Name: "go"}},
+		{Tool: config.ConfigTool{Name: "gaal-missing-xyz"}},
+		{Tool: config.ConfigTool{Name: "go"}},
+	}
+	got := tools.Check(entries)
+	if len(got) != 3 {
+		t.Fatalf("want 3 statuses, got %d", len(got))
+	}
+	if !got[0].Found || got[1].Found || !got[2].Found {
+		t.Errorf("found flags = [%v %v %v], want [true false true]", got[0].Found, got[1].Found, got[2].Found)
+	}
+	// Sanity: names round-trip through the statuses.
+	wantNames := []string{"go", "gaal-missing-xyz", "go"}
+	for i, n := range wantNames {
+		if got[i].Entry.Tool.Name != n {
+			t.Errorf("status[%d] name = %q, want %q", i, got[i].Entry.Tool.Name, n)
+		}
+	}
+	// And the resolved path for `go` looks plausible.
+	if !strings.HasSuffix(got[0].Resolved, "go") && !strings.HasSuffix(got[0].Resolved, "go.exe") {
+		t.Errorf("resolved path %q does not look like a `go` binary", got[0].Resolved)
+	}
+}


### PR DESCRIPTION
## Summary

- New `text` output format: compact, pipe-friendly line-based layouts for `status`, `info`, `agents`, `audit`, `doctor`, `sync --dry-run`, `version`, matching the samples in the docs.
- `text` replaces `table` as the default for `-o`. `-o table` still renders the boxed pterm layout and `-o json` still emits structured data.
- Invalid `-o` values are now rejected up front rather than falling back silently.

Paired with [docs PR](https://github.com/getgaal/docs).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (734 passed)
- [x] Manual: `gaal status`, `gaal info agent`, `gaal agents`, `gaal audit`, `gaal doctor --offline`, `gaal version` — output matches docs samples.
- [x] Manual: `-o table` and `-o json` still produce the previous formats.
- [x] Manual: `-o bogus` is rejected with a helpful error.