### PR TITLE
refactor: rename references from gaal-lite to gaal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Code owners for gaal-lite.
+# Code owners for gaal.
 #
 # Changes to files matching a pattern below require review from at least
 # one of the listed owners. See:

--- a/README.md
+++ b/README.md
@@ -331,8 +331,9 @@ Use `gaal agents` to list all registered agents (built-in + custom) and verify y
 
 ## Graduation path to gaal Community
 
-When your team outgrows single-user Lite (shared configs, drift detection,
-approval workflows), gaal Community Edition picks up where Lite leaves off.
+When your team outgrows single-user gaal (shared configs, drift detection,
+approval workflows), gaal Community Edition picks up where the standalone
+CLI leaves off.
 
 The migration command validates your current configuration and confirms it is
 ready to push to a Community instance:
@@ -367,7 +368,7 @@ See [`docs/architecture.md`](docs/architecture.md) for a full description of the
 ### Quick install (macOS / Linux)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | sh
 ```
 
 Installs the latest release binary to `~/.local/bin/gaal`. Pin a specific
@@ -375,13 +376,13 @@ version with `VERSION=v0.1.2`, or pick a different directory with
 `INSTALL_DIR=/usr/local/bin`.
 
 Pass `GAAL_INSTALL_DEBUG=1` for verbose output, or run
-`curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | sh -s -- --help`
+`curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | sh -s -- --help`
 to see all options.
 
 ### With Go
 
 ```bash
-go install github.com/gmg-inc/gaal-lite@latest
+go install github.com/gmg-inc/gaal@latest
 ```
 
 ### From source
@@ -389,8 +390,8 @@ go install github.com/gmg-inc/gaal-lite@latest
 **Prerequisites:** Go 1.26+
 
 ```bash
-git clone https://github.com/gmg-inc/gaal-lite.git
-cd gaal-lite
+git clone https://github.com/gmg-inc/gaal.git
+cd gaal
 make build
 ```
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -17,8 +17,8 @@ var (
 
 var migrateCmd = &cobra.Command{
 	Use:   "migrate --to community <url>",
-	Short: "Migrate this Lite configuration to a gaal Community Edition instance",
-	Long: `Migrate this Lite configuration to a gaal Community Edition instance.
+	Short: "Migrate this configuration to a gaal Community Edition instance",
+	Long: `Migrate this configuration to a gaal Community Edition instance.
 
 Reads the local gaal configuration, validates it, and pushes it to the
 specified Community URL as versioned configs.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -6,23 +6,23 @@
 
 ## 1. Install
 
-Download the binary for your platform from the [latest release](https://github.com/gmg-inc/gaal-lite/releases/latest):
+Download the binary for your platform from the [latest release](https://github.com/gmg-inc/gaal/releases/latest):
 
 ```bash
 # Linux (amd64)
-curl -Lo gaal https://github.com/gmg-inc/gaal-lite/releases/latest/download/gaal-linux-amd64
+curl -Lo gaal https://github.com/gmg-inc/gaal/releases/latest/download/gaal-linux-amd64
 chmod +x gaal && sudo mv gaal /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -Lo gaal https://github.com/gmg-inc/gaal-lite/releases/latest/download/gaal-darwin-arm64
+curl -Lo gaal https://github.com/gmg-inc/gaal/releases/latest/download/gaal-darwin-arm64
 chmod +x gaal && sudo mv gaal /usr/local/bin/
 
 # macOS (Intel)
-curl -Lo gaal https://github.com/gmg-inc/gaal-lite/releases/latest/download/gaal-darwin-amd64
+curl -Lo gaal https://github.com/gmg-inc/gaal/releases/latest/download/gaal-darwin-amd64
 chmod +x gaal && sudo mv gaal /usr/local/bin/
 
 # Windows (amd64) — PowerShell
-Invoke-WebRequest -Uri https://github.com/gmg-inc/gaal-lite/releases/latest/download/gaal-windows-amd64.exe -OutFile gaal.exe
+Invoke-WebRequest -Uri https://github.com/gmg-inc/gaal/releases/latest/download/gaal-windows-amd64.exe -OutFile gaal.exe
 ```
 
 Verify the installation:

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -130,7 +130,7 @@ skills:
 }
 
 func TestLoad_SkillAgents_NestedListIsFlattened(t *testing.T) {
-	// Regression for https://github.com/gmg-inc/gaal-lite/issues/13
+	// Regression for https://github.com/gmg-inc/gaal/issues/13
 	// A list-of-lists is a common hand-written mistake (mentally copying the
 	// canonical `agents: ["*"]` example under a list bullet).
 	p := writeYAML(t, `

--- a/internal/installscript/install_test.go
+++ b/internal/installscript/install_test.go
@@ -57,7 +57,7 @@ func fakeReleaseServer(t *testing.T, version, goos, goarch string, binary []byte
 	sumsContent := fmt.Sprintf("%s  %s\n", sha256hex(binary), binName)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/gmg-inc/gaal-lite/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/gmg-inc/gaal/releases/latest", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"tag_name":%q}`, version)
 	})
@@ -161,7 +161,7 @@ func TestInstallChecksumMismatch(t *testing.T) {
 	sumsContent := fmt.Sprintf("%s  %s\n", sha256hex(realBinary), binName)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/gmg-inc/gaal-lite/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/gmg-inc/gaal/releases/latest", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `{"tag_name":%q}`, version)
 	})
 	mux.HandleFunc(fmt.Sprintf("/releases/download/%s/%s", version, binName), func(w http.ResponseWriter, r *http.Request) {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -12,7 +12,7 @@ import (
 var plausibleEndpoint = "https://usage.getgaal.com/api/event"
 
 const (
-	plausibleDomain = "gaal-lite"
+	plausibleDomain = "gaal"
 	sendTimeout     = 5 * time.Second
 )
 

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -25,12 +25,12 @@ func TestSendPageview(t *testing.T) {
 
 	c := &client{
 		endpoint:  srv.URL,
-		userAgent: "gaal-lite/test",
+		userAgent: "gaal/test",
 	}
 
 	p := plausiblePayload{
 		Name:   "pageview",
-		URL:    "app://gaal-lite/cmd/install",
+		URL:    "app://gaal/cmd/install",
 		Domain: plausibleDomain,
 		Props:  map[string]string{"version": "1.2.3"},
 	}
@@ -40,8 +40,8 @@ func TestSendPageview(t *testing.T) {
 	}
 
 	// Verify User-Agent header
-	if got := capturedReq.Header.Get("User-Agent"); got != "gaal-lite/test" {
-		t.Errorf("User-Agent = %q, want %q", got, "gaal-lite/test")
+	if got := capturedReq.Header.Get("User-Agent"); got != "gaal/test" {
+		t.Errorf("User-Agent = %q, want %q", got, "gaal/test")
 	}
 
 	// Verify Content-Type header
@@ -58,8 +58,8 @@ func TestSendPageview(t *testing.T) {
 	if got.Name != "pageview" {
 		t.Errorf("Name = %q, want %q", got.Name, "pageview")
 	}
-	if got.URL != "app://gaal-lite/cmd/install" {
-		t.Errorf("URL = %q, want %q", got.URL, "app://gaal-lite/cmd/install")
+	if got.URL != "app://gaal/cmd/install" {
+		t.Errorf("URL = %q, want %q", got.URL, "app://gaal/cmd/install")
 	}
 	if got.Domain != plausibleDomain {
 		t.Errorf("Domain = %q, want %q", got.Domain, plausibleDomain)
@@ -84,12 +84,12 @@ func TestSendCustomEvent(t *testing.T) {
 
 	c := &client{
 		endpoint:  srv.URL,
-		userAgent: "gaal-lite/test",
+		userAgent: "gaal/test",
 	}
 
 	p := plausiblePayload{
 		Name:   "Install",
-		URL:    "app://gaal-lite/cmd/install",
+		URL:    "app://gaal/cmd/install",
 		Domain: plausibleDomain,
 	}
 
@@ -115,12 +115,12 @@ func TestSendHandlesServerError(t *testing.T) {
 
 	c := &client{
 		endpoint:  srv.URL,
-		userAgent: "gaal-lite/test",
+		userAgent: "gaal/test",
 	}
 
 	p := plausiblePayload{
 		Name:   "pageview",
-		URL:    "app://gaal-lite/cmd/install",
+		URL:    "app://gaal/cmd/install",
 		Domain: plausibleDomain,
 	}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -122,7 +122,7 @@ func Track(command string) {
 		return
 	}
 	props := copyProps(baseProps)
-	url := "app://gaal-lite/cmd/" + command
+	url := "app://gaal/cmd/" + command
 	slog.Debug("telemetry", "event", "pageview", "url", url, "props", props)
 	pending.Add(1)
 	go func() {
@@ -149,7 +149,7 @@ func TrackCustom(name string, extra map[string]string) {
 	for k, v := range extra {
 		props[k] = v
 	}
-	url := "app://gaal-lite/custom/" + name
+	url := "app://gaal/custom/" + name
 	slog.Debug("telemetry", "event", name, "url", url, "props", props)
 	pending.Add(1)
 	go func() {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -61,8 +61,8 @@ func TestTrackSendsPageviewWhenEnabled(t *testing.T) {
 	if p.Name != "pageview" {
 		t.Errorf("Name = %q, want %q", p.Name, "pageview")
 	}
-	if p.URL != "app://gaal-lite/cmd/install" {
-		t.Errorf("URL = %q, want %q", p.URL, "app://gaal-lite/cmd/install")
+	if p.URL != "app://gaal/cmd/install" {
+		t.Errorf("URL = %q, want %q", p.URL, "app://gaal/cmd/install")
 	}
 	if p.Domain != plausibleDomain {
 		t.Errorf("Domain = %q, want %q", p.Domain, plausibleDomain)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
-# gaal-lite installer.
+# gaal installer.
 #
 # Downloads the latest release of gaal from GitHub Releases, verifies its
 # SHA-256 checksum against the release's SHA256SUMS file, and installs it
 # to $INSTALL_DIR (default $HOME/.local/bin).
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | sh
 #   curl -fsSL ... | VERSION=v0.1.2 sh
 #   curl -fsSL ... | INSTALL_DIR=/usr/local/bin sh
 #
@@ -31,7 +31,7 @@ if [ "${GAAL_INSTALL_DEBUG:-}" = "1" ]; then
 fi
 
 # --- constants ---------------------------------------------------------------
-REPO="gmg-inc/gaal-lite"
+REPO="gmg-inc/gaal"
 BIN_NAME="gaal"
 DEFAULT_INSTALL_DIR="$HOME/.local/bin"
 
@@ -43,11 +43,11 @@ die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
 # --- arg parsing -------------------------------------------------------------
 usage() {
   cat <<'EOF'
-gaal-lite installer
+gaal installer
 
 Usage:
-  curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | sh
-  curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal-lite/main/scripts/install.sh | VERSION=v0.1.2 sh
+  curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | sh
+  curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | VERSION=v0.1.2 sh
 
 Environment:
   VERSION              Release tag to install (default: latest from GitHub Releases)
@@ -64,7 +64,7 @@ Examples:
   # System-wide install (will prompt for sudo on install)
   curl -fsSL <URL> | INSTALL_DIR=/usr/local/bin sh
 
-Report issues: https://github.com/gmg-inc/gaal-lite/issues
+Report issues: https://github.com/gmg-inc/gaal/issues
 EOF
 }
 


### PR DESCRIPTION
## Summary

Rebrand cleanup — remove every `gaal-lite` / "Lite" reference so the product is consistently named `gaal`:

- **Install script** ([scripts/install.sh](scripts/install.sh)): banner, repo slug, help text, issues link.
- **Docs & README**: download URLs, clone target, "single-user Lite" / "Lite leaves off" prose rewritten to reflect the single brand.
- **CODEOWNERS**: header comment.
- **`gaal migrate`**: short and long help strings drop "Lite".
- **Telemetry** ([internal/telemetry](internal/telemetry)): `plausibleDomain` and the `app://.../cmd/*` / `app://.../custom/*` event URLs change from `gaal-lite` to `gaal`. Matching tests updated.
- **Test fixtures**: installscript test URLs, `manager_test.go` regression link, telemetry User-Agent placeholders.

Only `LiteIDE` in `.gitignore` is left intact — that is the name of an unrelated Go IDE in a stock gitignore comment.

## ⚠️ Operational note

The telemetry change alters the `domain` and `url` fields that the Plausible backend receives. Before (or right after) merging, either:

- Create a new Plausible site named `gaal` (recommended), or
- Add `gaal` as an alias on the existing `gaal-lite` Plausible site

…otherwise usage and install events from updated clients will be dropped.

GitHub's automatic redirect will keep `gmg-inc/gaal-lite` URLs working until the repo is renamed; the install-script change just points new invocations at the canonical URL.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 711 passed
- [x] `bash scripts/install.sh --help` renders cleanly with the new branding
- [ ] Verify the Plausible site is ready (see above) before relying on telemetry from released binaries