### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug Report
+about: Report a reproducible bug or unexpected behaviour in gaal
+title: "[Bug] "
+labels: ["bug"]
+assignees: []
+---
+
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1. Run `gaal ...`
+2. With config / flags `...`
+3. See error
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. Paste any error output verbatim. -->
+
+## Environment
+
+| Field        | Value |
+|--------------|-------|
+| gaal version | `gaal --version` |
+| OS / Arch    | e.g. macOS 15 arm64 / Ubuntu 24.04 x86_64 |
+| Go version   | `go version` |
+
+## Logs / Config Snippet
+
+<!-- Run with --verbose and paste the relevant output.
+     Redact any secrets or personal paths before posting. -->
+
+```
+<paste here>
+```
+
+## Additional Context
+
+<!-- Any other context, screenshots, or links that might help. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/gmg-inc/gaal-lite/discussions
+    about: Ask questions and discuss ideas in GitHub Discussions rather than opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Propose a new feature or enhancement for gaal
+title: "[Feature] "
+labels: ["enhancement"]
+assignees: []
+---
+
+## Problem Statement
+
+<!-- Describe the problem you are trying to solve.
+     e.g. "I often need to … but currently gaal doesn't support …" -->
+
+## Proposed Solution
+
+<!-- Describe the solution you'd like, including proposed CLI flags, config keys,
+     or behavioural changes. Code snippets and example gaal.yaml excerpts are welcome. -->
+
+## Alternatives Considered
+
+<!-- Have you tried workarounds? Are there other approaches you evaluated? -->
+
+## Additional Context
+
+<!-- Anything else that could help — links to related issues, prior art in other tools, etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What does this PR do? Why? Keep it to 2-3 sentences. -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (no functional change)
+- [ ] Documentation
+- [ ] Chore / dependency update
+
+## Related Issues
+
+<!-- Link every issue this PR closes or relates to. -->
+
+Closes #
+
+## Checklist
+
+<!-- CI runs: lint → build → test-ci → coverage-ci.
+     Tick every box that applies before requesting review. -->
+
+- [ ] `make lint` passes — `gofmt` formatting + `go vet` clean
+- [ ] `make build` passes on Linux and macOS
+- [ ] `make test-ci` passes — unit tests with race detector
+- [ ] `make coverage-ci` run (if this PR adds or changes covered code)
+- [ ] Every new function has at least one `slog.Debug` / `slog.DebugContext` call
+- [ ] Documentation updated if user-facing behaviour changed
+- [ ] No secrets or credentials are exposed in logs or config snippets


### PR DESCRIPTION
## Summary

Add structured GitHub templates to standardise contributions: two issue templates (bug report and feature request) and one pull request template aligned with the CI pipeline.

## Type of Change

- [x] Chore / dependency update

## Related Issues

N/A

## Checklist

- [x] `make lint` passes — `gofmt` formatting + `go vet` clean
- [x] `make build` passes on Linux and macOS
- [x] `make test-ci` passes — unit tests with race detector
- [x] No secrets or credentials are exposed in logs or config snippets

---

### Files added

| File | Purpose |
|------|---------|
| `.github/ISSUE_TEMPLATE/bug_report.md` | Bug report template (auto-label: `bug`) |
| `.github/ISSUE_TEMPLATE/feature_request.md` | Feature request template (auto-label: `enhancement`) |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues, links to GitHub Discussions |
| `.github/pull_request_template.md` | PR template with CI-aligned checklist |