### PR TITLE
refactor(platform): export UserConfigDir and centralise XDG/darwin logic

### DIFF
--- a/internal/config/platform/manager.go
+++ b/internal/config/platform/manager.go
@@ -46,6 +46,15 @@ func UserConfigFilePath() string {
 	return userConfigFilePath()
 }
 
+// UserConfigDir is the exported accessor for the per-user config directory.
+// It delegates to the OS-specific userConfigDir() and is the single source of
+// truth for any code that needs to resolve the user config directory without
+// also appending the config filename (e.g. registry.go).
+func UserConfigDir() (string, error) {
+	slog.Debug("resolving user config directory")
+	return userConfigDir()
+}
+
 // userConfigFilePath returns the per-user config path for the current OS.
 // It respects XDG_CONFIG_HOME on Linux and macOS when set, otherwise ~/.config
 // on macOS (see userConfigDir), and %AppData% on Windows.

--- a/internal/config/platform/manager_test.go
+++ b/internal/config/platform/manager_test.go
@@ -184,3 +184,112 @@ func TestUserConfigFilePath_DarwinExported_NoXDG(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// UserConfigDir (exported)
+// ---------------------------------------------------------------------------
+
+func TestUserConfigDir_ReturnsNonEmpty(t *testing.T) {
+	got, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir returned error: %v", err)
+	}
+	if got == "" {
+		t.Fatal("UserConfigDir returned empty string")
+	}
+}
+
+func TestUserConfigDir_MatchesUserConfigFilePath(t *testing.T) {
+	dir, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir returned error: %v", err)
+	}
+	filePath := UserConfigFilePath()
+	// The file path must be dir/gaal/config.yaml
+	want := filepath.Join(dir, "gaal", "config.yaml")
+	if filePath != want {
+		t.Errorf("UserConfigFilePath=%q, want %q (derived from UserConfigDir=%q)", filePath, want, dir)
+	}
+}
+
+func TestUserConfigDir_LinuxUsesXDGConfigHome(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only test")
+	}
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	got, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir returned error: %v", err)
+	}
+	if got != xdg {
+		t.Errorf("got %q, want %q", got, xdg)
+	}
+}
+
+func TestUserConfigDir_LinuxDefaultsToConfigDir(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	got, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir returned error: %v", err)
+	}
+	want := filepath.Join(home, ".config")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestUserConfigDir_DarwinUsesXDGConfigHome(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only test")
+	}
+	xdg := filepath.Join(t.TempDir(), "xdg-config")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	got, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir returned error: %v", err)
+	}
+	if got != xdg {
+		t.Errorf("got %q, want %q", got, xdg)
+	}
+}
+
+func TestUserConfigDir_DarwinNoXDGFallsBackToHome(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	got, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir returned error: %v", err)
+	}
+	want := filepath.Join(home, ".config")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestUserConfigDir_WindowsUsesAppData(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only test")
+	}
+	got, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir returned error: %v", err)
+	}
+	appData := os.Getenv("APPDATA")
+	if appData != "" && !strings.HasPrefix(got, appData) {
+		t.Errorf("got %q, expected path under APPDATA=%q", got, appData)
+	}
+}

--- a/internal/core/agent/registry.go
+++ b/internal/core/agent/registry.go
@@ -7,9 +7,10 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
+
+	"gaal/internal/config/platform"
 
 	"gopkg.in/yaml.v3"
 )
@@ -215,21 +216,10 @@ func isAbsPath(p string) bool {
 }
 
 // userAgentsPath returns the path to the optional user agents config file.
-// On macOS it intentionally diverges from os.UserConfigDir() and prefers
-// XDG_CONFIG_HOME when it is set, otherwise ~/.config/gaal/agents.yaml.
+// Platform-specific XDG/darwin logic is centralised in platform.UserConfigDir.
 func userAgentsPath() (string, bool) {
 	slog.Debug("resolving user agents path")
-	if runtime.GOOS == "darwin" {
-		if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
-			return filepath.Join(xdg, "gaal", "agents.yaml"), true
-		}
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", false
-		}
-		return filepath.Join(home, ".config", "gaal", "agents.yaml"), true
-	}
-	dir, err := os.UserConfigDir()
+	dir, err := platform.UserConfigDir()
 	if err != nil {
 		return "", false
 	}


### PR DESCRIPTION
## Summary

Eliminate the duplicated XDG/darwin platform resolution in `internal/core/agent/registry.go` by exporting `UserConfigDir()` from `internal/config/platform` and delegating to it.

**Before:** `userAgentsPath()` re-implemented the full darwin/XDG_CONFIG_HOME switch (identical to `platform/darwin.go` and `platform/unix.go`), creating a silent divergence risk.

**After:** `userAgentsPath()` calls `platform.UserConfigDir()` — a single source of truth for all platform-specific config directory resolution.

Changes:
- `internal/config/platform/manager.go`: add exported `UserConfigDir() (string, error)`
- `internal/core/agent/registry.go`: simplify `userAgentsPath()`, remove `"runtime"` import
- `internal/config/platform/manager_test.go`: add 7 tests covering Linux XDG, Linux fallback, darwin XDG, darwin fallback, Windows, non-empty guarantee, and consistency with `UserConfigFilePath`

## Type of Change
- [ ] Bug fix
- [x] Refactoring (no behaviour change)
- [ ] New feature
- [ ] Documentation update

## Related Issues
Closes #59

## Checklist
- [x] `make lint` passes — `gofmt` formatting + `go vet` clean
- [x] `make build` passes on Linux and macOS
- [x] `make test` passes — unit tests with race detector
- [x] Every new function has at least one `slog.Debug` / `slog.DebugContext` call
- [x] Documentation updated if user-facing behaviour changed
- [x] No secrets or credentials are exposed in logs or config snippets