### PR TITLE
feat(mcp): add agents/global config fields, resolve target from registry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,8 @@
     "source": true,
     "history": true,
     "clear": true,
-    "gofmt": true
+    "gofmt": true,
+    "gh issue view": true
   },
   "makefile.configureOnOpen": false,
   "yaml.schemas": {

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,39 @@
+# Security & License Audit Commands
+
+Quick reference to reproduce the full dependency audit (CVE + licences + legal summary).
+
+## Prerequisites
+
+```sh
+# Install govulncheck (system)
+sudo apt install govulncheck
+# or
+sudo snap install govulncheck
+
+# Install go-licenses
+go install github.com/google/go-licenses@latest
+```
+
+## 1 — Active CVE scan (called code only)
+
+```sh
+govulncheck ./...
+```
+
+## 2 — Full CVE scan (including imported but not called)
+
+```sh
+govulncheck -show verbose ./...
+```
+
+## 3 — License report (all direct + indirect dependencies)
+
+```sh
+go-licenses report ./... 2>/dev/null | sort -t',' -k3 | column -t -s','
+```
+
+## 4 — One-liner: CVE + licences in a single pass
+
+```sh
+echo "=== CVE ===" && govulncheck ./... ; echo "" && echo "=== LICENSES ===" && go-licenses report ./... 2>/dev/null | sort -t',' -k3 | column -t -s','
+```

--- a/IDEA.md
+++ b/IDEA.md
@@ -1,0 +1,1 @@
+profil de depoyment pour un projet.. tpl:  react_app (Meta-package)

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,191 @@
+# La commande `gaal status` — Guide de lecture
+
+> **Pour qui ?** Ce guide s'adresse à quelqu'un qui n'a jamais utilisé `gaal`
+> et veut comprendre ce qu'affiche `gaal status` sans avoir à lire le code source.
+
+---
+
+## Principe général
+
+`gaal` lit un fichier de configuration (`gaal.yaml`) qui déclare trois types de ressources à gérer sur ta machine :
+
+| Type | Ce que c'est |
+|------|-------------|
+| **Repositories** | Des dépôts de code (git, svn, hg…) à cloner et maintenir à jour localement |
+| **Skills** | Des collections de fichiers `SKILL.md` à installer dans les répertoires de tes agents IA (GitHub Copilot, Claude, Cursor…) |
+| **MCP Configs** | Des entrées de serveur MCP (*Model Context Protocol*) à injecter dans les fichiers de configuration JSON de tes agents |
+
+La commande `gaal status` **ne fait rien** — elle se contente de **lire l'état actuel du disque** et de te dire si ce que tu as déclaré dans `gaal.yaml` correspond à ce qui est réellement installé.
+
+Pour synchroniser (installer / mettre à jour), tu utilises `gaal sync`.
+
+---
+
+## Structure de l'écran
+
+L'affichage est divisé en **quatre sections** présentées l'une après l'autre.
+
+---
+
+### Section 1 — Repositories
+
+```
+── Repositories  (N) ──
+┌──────────────┬──────┬────────────────┬──────────────────┐
+│ PATH         │ TYPE │ STATUS         │ VERSION / URL    │
+```
+
+| Colonne | Signification |
+|---------|--------------|
+| **PATH** | Chemin local où le dépôt est (ou devrait être) cloné, relatif au répertoire courant |
+| **TYPE** | Protocole utilisé : `git`, `hg`, `svn`, `bzr`, `tar`, `zip` |
+| **STATUS** | État du dépôt (voir tableau ci-dessous) |
+| **VERSION / URL** | Pour les dépôts clonés : version actuelle + version voulue. Pour les dépôts absents : URL source |
+
+**Valeurs possibles de STATUS :**
+
+| Icône | Label | Signification |
+|-------|-------|--------------|
+| ✓ | `synced` | Cloné et à la bonne version |
+| ⚠ | `dirty` | Cloné mais la version locale ne correspond pas à ce que demande la config |
+| ~ | `not cloned` | Pas encore téléchargé sur le disque — fait un `gaal sync` |
+| ? | `unmanaged` | Présent sur le disque mais non déclaré dans la config |
+| ✗ | `error` | Erreur lors de la vérification (permissions, réseau…) |
+
+---
+
+### Section 2 — Skills
+
+```
+── Skills  (N) ──
+┌──────────────────┬────────────┬───────────┬────────────┬──────────────┐
+│ SKILL            │ SOURCE     │ SCOPE     │ STATUS     │ INSTALLED IN │
+```
+
+C'est la section la plus importante si tu travailles avec des agents IA.
+
+#### Comprendre les concepts clés
+
+Un **skill** est un dossier contenant un fichier `SKILL.md` que les agents IA lisent pour obtenir des instructions spécialisées (ex. : "comment écrire du React performant"). `gaal` s'occupe de copier ces dossiers dans les bons répertoires de tes agents.
+
+Une **source** est le dépôt GitHub (ou chemin local) depuis lequel `gaal` télécharge les skills. Par exemple `vercel-labs/agent-skills` est un dépôt GitHub public.
+
+#### Colonnes
+
+| Colonne | Signification |
+|---------|--------------|
+| **SKILL** | Nom du skill (extrait du `SKILL.md`) |
+| **SOURCE** | D'où vient ce skill : dépôt GitHub (`owner/repo`) ou chemin local |
+| **SCOPE** | `global` = installé dans `~/.copilot/skills` (pour tous tes projets) · `workspace` = installé dans `.github/skills` (uniquement pour ce projet) |
+| **STATUS** | État de l'installation (voir tableau ci-dessous) |
+| **INSTALLED IN** | Dans quels agents le skill est actuellement présent sur le disque |
+
+**Valeurs possibles de STATUS :**
+
+| Icône | Label | Signification |
+|-------|-------|--------------|
+| ✓ | `synced` | Le skill est installé et ses fichiers correspondent exactement à la source |
+| ⚠ | `dirty` | Le skill est installé mais des fichiers ont été modifiés localement depuis la dernière sync |
+| ~ | `partial` | Déclaré dans la config mais pas encore installé — fait un `gaal sync` |
+| ? | `unmanaged` | Trouvé sur le disque dans un répertoire agent mais non déclaré dans la config |
+| ✗ | `error` | Erreur (source non cachée, agent inconnu…) |
+
+**Valeurs possibles de INSTALLED IN :**
+
+| Valeur | Signification |
+|--------|--------------|
+| `all` (vert) | Installé dans tous les agents ciblés par la config |
+| `none` (jaune) | Non encore installé dans aucun agent — `gaal sync` requis |
+| liste de noms | Installé uniquement dans ces agents (sous-ensemble des agents ciblés) |
+
+> **Astuce lecture :** une ligne `~ partial | none` signifie que le skill est déclaré dans
+> `gaal.yaml` mais que sa source n'a pas encore été téléchargée localement. Lance
+> `gaal sync` pour corriger ça.
+
+#### Exemple de lecture
+
+```
+│ react-best-practices │ vercel-labs/agent-skills │ workspace │ ✓ synced  │ all  │
+```
+→ Le skill `react-best-practices`, tiré du dépôt GitHub `vercel-labs/agent-skills`, est installé dans le répertoire `.github/skills` du projet et est synchronisé dans tous les agents ciblés.
+
+```
+│ canvas-design        │ anthropics/skills        │ global    │ ✓ synced  │ all  │
+```
+→ Ce skill est installé **globalement** (`~/.copilot/skills`) : il sera disponible dans tous tes projets, pas seulement celui-ci.
+
+```
+│ vercel-composition…  │ vercel-labs/agent-…      │ workspace │ ~ partial │ none │
+```
+→ Ce skill est dans ta config mais pas encore téléchargé. Lance `gaal sync`.
+
+---
+
+### Section 3 — MCP Configs
+
+```
+── MCP Configs  (N) ──
+┌────────────┬────────────┬───────────────────────────────────┐
+│ NAME       │ STATUS     │ TARGET                            │
+```
+
+| Colonne | Signification |
+|---------|--------------|
+| **NAME** | Nom de l'entrée MCP telle que déclarée dans `gaal.yaml` |
+| **STATUS** | État de la configuration (voir tableau ci-dessous) |
+| **TARGET** | Fichier JSON de configuration de l'agent où l'entrée doit être injectée |
+
+**Valeurs possibles de STATUS :**
+
+| Icône | Label | Signification |
+|-------|-------|--------------|
+| ✓ | `present` | L'entrée est présente dans le fichier cible et correspond à la config |
+| ⚠ | `dirty` | L'entrée existe mais a été modifiée localement depuis la dernière sync |
+| ~ | `absent` | L'entrée n'est pas dans le fichier cible — `gaal sync` requis |
+| ✗ | `error` | Impossible de lire/écrire le fichier cible |
+
+---
+
+### Section 4 — Supported Agents
+
+```
+── Supported Agents  (N) ──
+┌───────────────┬───────────┬────────────────────┬───────────────────┬───────────────────┐
+│ AGENT         │ INSTALLED │ PROJECT SKILLS DIR │ GLOBAL SKILLS DIR │ PROJECT MCP CONFIG│
+```
+
+Cette section est **informative uniquement** — elle te montre quels agents IA `gaal` connaît et lesquels sont détectés comme présents sur ta machine.
+
+| Colonne | Signification |
+|---------|--------------|
+| **AGENT** | Identifiant de l'agent (ex. `github-copilot`, `cursor`, `claude-code`) |
+| **INSTALLED** | `✓` si le répertoire de configuration de l'agent existe sur la machine · `—` si absent |
+| **PROJECT SKILLS DIR** | Répertoire (relatif au projet) où `gaal` installe les skills workspace pour cet agent |
+| **GLOBAL SKILLS DIR** | Répertoire absolu (`~/ …`) où `gaal` installe les skills globaux pour cet agent |
+| **PROJECT MCP CONFIG** | Fichier JSON de l'agent où les entrées MCP sont injectées |
+
+> `gaal` ne synchronise vers un agent que s'il est **installé** (`✓`). Les agents
+> marqués `—` sont ignorés lors du `gaal sync`.
+
+---
+
+## Statuts en un coup d'œil
+
+| Icône | Couleur | Signification rapide |
+|-------|---------|---------------------|
+| ✓ synced / present | vert | Tout est à jour |
+| ⚠ dirty | jaune | Modifié localement depuis la dernière sync |
+| ~ partial / not cloned / absent | jaune | Déclaré mais pas encore installé → `gaal sync` |
+| ? unmanaged | cyan | Présent sur le disque mais pas dans la config |
+| ✗ error | rouge | Problème à corriger (voir le message d'erreur) |
+
+---
+
+## Workflow typique
+
+```
+1. Tu édites gaal.yaml          → ajoute/modifie des ressources
+2. gaal status                  → vois ce qui est désynchronisé
+3. gaal sync                    → installe / met à jour tout
+4. gaal status                  → confirme que tout est ✓ synced
+```

--- a/example.gaal.yaml
+++ b/example.gaal.yaml
@@ -95,25 +95,29 @@ skills:
 #
 # source: URL to a remote JSON file containing an mcpServers document.
 # inline: define the server entry directly in this file.
-# target: path to the JSON config file to merge into.
-#         Common targets:
-#           ~/.config/claude/claude_desktop_config.json   (Claude Desktop)
-#           ~/.vscode/settings.json                       (VS Code)
+# agents: list of agent identifiers (or ["*"] to target all agents).
+#         The target JSON file is resolved automatically from the agent registry.
+# global: true  → write to the agent's global MCP config (global_mcp_config_file)
+#         false → write to the agent's project MCP config (project_mcp_config_file)
+#         (default: true, since most agents only have a global MCP config)
+#
+# Deprecated: target — specify the path explicitly. Prefer agents+global instead.
 # ─────────────────────────────────────────────────────────────────────────────
 mcps:
-  # Inline definition — filesystem MCP server.
+  # Inline server — installed into claude-code's global MCP config.
   - name: filesystem
-    target: ~/.config/claude/claude_desktop_config.json
+    agents: ["claude-code"]
+    global: true
     inline:
       command: uvx
       args:
         - mcp-server-filesystem
         - /home/user/projects
-      env: {}
 
-  # Inline definition — git MCP server.
+  # Inline server — installed into all agents that have a global MCP config.
   - name: git
-    target: ~/.config/claude/claude_desktop_config.json
+    agents: ["*"]
+    global: true
     inline:
       command: uvx
       args:
@@ -121,12 +125,15 @@ mcps:
         - --repository
         - /home/user/projects/gaal
 
-  # Remote source — download and merge an mcpServers document.
+  # Remote source — merged into claude-code and github-copilot's global configs.
   - name: github
     source: https://raw.githubusercontent.com/github/mcp-servers/main/config.json
-    target: ~/.config/claude/claude_desktop_config.json
+    agents:
+      - claude-code
+      - github-copilot
+    global: true
 
-  # VS Code MCP server configuration.
+  # Backward-compat: explicit target still works (deprecated, prefer agents+global).
   - name: sequential-thinking
     target: ~/.vscode/settings.json
     inline:

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -58,15 +58,15 @@ type ConfigTool struct {
 
 // ConfigMcp defines an MCP server configuration entry.
 type ConfigMcp struct {
-	Name   string         `yaml:"name"             json:"name"              jsonschema:"description=Unique name identifying this MCP server entry"                                       validate:"required"`
-	Source string         `yaml:"source,omitempty" json:"source,omitempty"  jsonschema:"description=URL to download a remote JSON server config (mutually exclusive with inline)"          validate:"required_without=Inline"`
+	Name   string `yaml:"name"             json:"name"              jsonschema:"description=Unique name identifying this MCP server entry"                                       validate:"required"`
+	Source string `yaml:"source,omitempty" json:"source,omitempty"  jsonschema:"description=URL to download a remote JSON server config (mutually exclusive with inline)"          validate:"required_without=Inline"`
 	// Target is deprecated: the path is now resolved automatically from the agent registry.
 	// Set agents instead. When both target and agents are set, target takes precedence
 	// and a deprecation warning is logged.
-	Target string         `yaml:"target,omitempty" json:"target,omitempty"  jsonschema:"description=Deprecated: use agents instead. Path to the JSON file to write or merge into"`
+	Target string `yaml:"target,omitempty" json:"target,omitempty"  jsonschema:"description=Deprecated: use agents instead. Path to the JSON file to write or merge into"`
 	// Agents lists the target agent identifiers.
 	// Use ["*"] to target all agents that have a non-empty MCP config for the requested scope.
-	Agents []string       `yaml:"agents,omitempty" json:"agents,omitempty"  jsonschema:"description=Target agent identifiers; use [\"*\"] to target all agents"`
+	Agents []string `yaml:"agents,omitempty" json:"agents,omitempty"  jsonschema:"description=Target agent identifiers; use [\"*\"] to target all agents"`
 	// Global controls which registry path is used:
 	//   false (default) -> project_mcp_config_file (workspace-scoped)
 	//   true            -> global_mcp_config_file   (user-global)

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -60,7 +60,17 @@ type ConfigTool struct {
 type ConfigMcp struct {
 	Name   string         `yaml:"name"             json:"name"              jsonschema:"description=Unique name identifying this MCP server entry"                                       validate:"required"`
 	Source string         `yaml:"source,omitempty" json:"source,omitempty"  jsonschema:"description=URL to download a remote JSON server config (mutually exclusive with inline)"          validate:"required_without=Inline"`
-	Target string         `yaml:"target"           json:"target"            jsonschema:"description=Absolute or ~-relative path to the JSON file to write or merge into"                   validate:"required"`
+	// Target is deprecated: the path is now resolved automatically from the agent registry.
+	// Set agents instead. When both target and agents are set, target takes precedence
+	// and a deprecation warning is logged.
+	Target string         `yaml:"target,omitempty" json:"target,omitempty"  jsonschema:"description=Deprecated: use agents instead. Path to the JSON file to write or merge into"`
+	// Agents lists the target agent identifiers.
+	// Use ["*"] to target all agents that have a non-empty MCP config for the requested scope.
+	Agents []string       `yaml:"agents,omitempty" json:"agents,omitempty"  jsonschema:"description=Target agent identifiers; use [\"*\"] to target all agents"`
+	// Global controls which registry path is used:
+	//   false (default) -> project_mcp_config_file (workspace-scoped)
+	//   true            -> global_mcp_config_file   (user-global)
+	Global bool           `yaml:"global,omitempty" json:"global,omitempty"  jsonschema:"description=When true the MCP is configured in the agent's global config file instead of the project-scoped one"`
 	Merge  *bool          `yaml:"merge,omitempty"  json:"merge,omitempty"   jsonschema:"description=Merge server entry into existing file rather than overwriting it (default: true when omitted)"`
 	Inline *ConfigMcpItem `yaml:"inline,omitempty" json:"inline,omitempty"  jsonschema:"description=Inline server definition (mutually exclusive with source)"                          validate:"omitempty"`
 }

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -235,15 +235,32 @@ mcps:
 	}
 }
 
-func TestLoad_ValidationError_MCPNoTarget(t *testing.T) {
+func TestLoad_MCP_WithoutTarget_IsValid(t *testing.T) {
+	// target is now optional — agents+global replace it.
 	p := writeYAML(t, `
 mcps:
   - name: myserver
     source: https://example.com/mcp.json
+    agents: ["claude-code"]
+    global: true
 `)
 	_, err := Load(p)
-	if err == nil {
-		t.Fatal("expected validation error for mcp without target")
+	if err != nil {
+		t.Fatalf("expected no validation error for mcp without explicit target: %v", err)
+	}
+}
+
+func TestLoad_MCP_WithExplicitTarget_IsValid(t *testing.T) {
+	// Backward-compat: explicit target is still accepted.
+	p := writeYAML(t, `
+mcps:
+  - name: myserver
+    source: https://example.com/mcp.json
+    target: /tmp/mcp.json
+`)
+	_, err := Load(p)
+	if err != nil {
+		t.Fatalf("expected no validation error for mcp with explicit target: %v", err)
 	}
 }
 

--- a/internal/core/agent/agents.yaml
+++ b/internal/core/agent/agents.yaml
@@ -4,7 +4,8 @@
 # Fields (*_dir):
 #   project_skills_dir      – skills directory relative to the project root (must be relative, no "..")
 #   global_skills_dir       – skills directory under the user home directory (~/ prefix required)
-#   project_mcp_config_file – path to the agent's MCP server config file (~/ prefix, empty if unsupported)
+#   global_mcp_config_file  – user-global MCP server config file (~/ prefix, empty if unsupported)
+#   project_mcp_config_file – workspace-scoped MCP server config file (~/ prefix, empty if unsupported)
 #
 # Fields (*_search) — used by "gaal audit" for discovery only:
 #   project_skills_search   – project-relative dirs scanned at 1 level (empty = fallback to project_skills_dir)
@@ -42,7 +43,8 @@ agents:
     supports_generic_project: true
     project_skills_dir: ""
     global_skills_dir: ~/.config/agents/skills
-    project_mcp_config_file: ~/.config/amp/settings.json
+    global_mcp_config_file: ~/.config/amp/settings.json
+    project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search:
       - ~/.config/agents/skills
@@ -55,6 +57,7 @@ agents:
     supports_generic_project: true
     project_skills_dir: ""
     global_skills_dir: ~/.gemini/antigravity/skills
+    global_mcp_config_file: ""
     project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search:
@@ -66,7 +69,8 @@ agents:
   augment:
     project_skills_dir: .augment/skills
     global_skills_dir: ~/.augment/skills
-    project_mcp_config_file: ~/.augment/settings.json
+    global_mcp_config_file: ~/.augment/settings.json
+    project_mcp_config_file: ""
     project_skills_search:
       - .augment/skills
       - .agents/skills
@@ -81,7 +85,8 @@ agents:
   claude-code:
     project_skills_dir: .claude/skills
     global_skills_dir: ~/.claude/skills
-    project_mcp_config_file: ~/.config/claude/claude_desktop_config.json
+    global_mcp_config_file: ~/.config/claude/claude_desktop_config.json
+    project_mcp_config_file: ""
     project_skills_search:
       - .claude/skills
       - .agents/skills
@@ -98,7 +103,8 @@ agents:
     supports_generic_global: true
     project_skills_dir: ""
     global_skills_dir: ""
-    project_mcp_config_file: *vmc
+    global_mcp_config_file: *vmc
+    project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search: *cgs
     pm_skills_search: []
@@ -107,7 +113,8 @@ agents:
     supports_generic_project: true
     project_skills_dir: ""
     global_skills_dir: ~/.codex/skills
-    project_mcp_config_file: ~/.codex/mcp.json
+    global_mcp_config_file: ~/.codex/mcp.json
+    project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search:
       - ~/.codex/skills
@@ -118,7 +125,8 @@ agents:
   continue:
     project_skills_dir: .continue/skills
     global_skills_dir: ~/.continue/skills
-    project_mcp_config_file: ~/.continue/config.json
+    global_mcp_config_file: ~/.continue/config.json
+    project_mcp_config_file: ""
     project_skills_search:
       - .continue/skills
       - .agents/skills
@@ -134,7 +142,8 @@ agents:
     supports_generic_project: true
     project_skills_dir: ""
     global_skills_dir: ~/.cursor/skills
-    project_mcp_config_file: ~/.cursor/mcp.json
+    global_mcp_config_file: ~/.cursor/mcp.json
+    project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search:
       - ~/.cursor/skills
@@ -148,7 +157,8 @@ agents:
     supports_generic_project: true
     project_skills_dir: ""
     global_skills_dir: ~/.gemini/skills
-    project_mcp_config_file: ~/.gemini/settings.json
+    global_mcp_config_file: ~/.gemini/settings.json
+    project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search:
       - ~/.gemini/skills
@@ -165,6 +175,7 @@ agents:
     # supports_generic_global: true.
     project_skills_dir: *psd
     global_skills_dir: *gas
+    global_mcp_config_file: ""
     project_mcp_config_file: ""
     project_skills_search:
       - .agents/skills
@@ -176,7 +187,8 @@ agents:
     # https://code.visualstudio.com/docs/copilot/customization/agent-skills#_create-a-skill
     project_skills_dir: .github/skills
     global_skills_dir: ~/.copilot/skills
-    project_mcp_config_file: *vmc
+    global_mcp_config_file: *vmc
+    project_mcp_config_file: ""
     project_skills_search:
       - .github/skills
       - .agents/skills
@@ -191,7 +203,8 @@ agents:
   goose:
     project_skills_dir: .goose/skills
     global_skills_dir: ~/.config/goose/skills
-    project_mcp_config_file: ~/.config/goose/config.yaml
+    global_mcp_config_file: ~/.config/goose/config.yaml
+    project_mcp_config_file: ""
     project_skills_search:
       - .goose/skills
       - .agents/skills
@@ -205,7 +218,8 @@ agents:
   kilo:
     project_skills_dir: .kilocode/skills
     global_skills_dir: ~/.kilocode/skills
-    project_mcp_config_file: ~/.kilocode/mcp.json
+    global_mcp_config_file: ~/.kilocode/mcp.json
+    project_mcp_config_file: ""
     project_skills_search:
       - .kilocode/skills
       - .agents/skills
@@ -220,7 +234,8 @@ agents:
   kiro-cli:
     project_skills_dir: .kiro/skills
     global_skills_dir: ~/.kiro/skills
-    project_mcp_config_file: ~/.kiro/settings/mcp.json
+    global_mcp_config_file: ~/.kiro/settings/mcp.json
+    project_mcp_config_file: ""
     project_skills_search:
       - .kiro/skills
       - .agents/skills
@@ -236,7 +251,8 @@ agents:
     supports_generic_project: true
     project_skills_dir: ""
     global_skills_dir: ~/.config/opencode/skills
-    project_mcp_config_file: ~/.config/opencode/config.json
+    global_mcp_config_file: ~/.config/opencode/config.json
+    project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search:
       - ~/.config/opencode/skills
@@ -247,7 +263,8 @@ agents:
   openhands:
     project_skills_dir: .openhands/skills
     global_skills_dir: ~/.openhands/skills
-    project_mcp_config_file: ~/.openhands/config.json
+    global_mcp_config_file: ~/.openhands/config.json
+    project_mcp_config_file: ""
     project_skills_search:
       - .openhands/skills
       - .agents/skills
@@ -260,7 +277,8 @@ agents:
   roo:
     project_skills_dir: .roo/skills
     global_skills_dir: ~/.roo/skills
-    project_mcp_config_file: *vmc
+    global_mcp_config_file: *vmc
+    project_mcp_config_file: ""
     project_skills_search:
       - .roo/skills
       - .agents/skills
@@ -275,7 +293,8 @@ agents:
   trae:
     project_skills_dir: .trae/skills
     global_skills_dir: ~/.trae/skills
-    project_mcp_config_file: ~/.trae/mcp.json
+    global_mcp_config_file: ~/.trae/mcp.json
+    project_mcp_config_file: ""
     project_skills_search:
       - .trae/skills
       - .agents/skills
@@ -293,7 +312,8 @@ agents:
     supports_generic_global: true
     project_skills_dir: ""
     global_skills_dir: ""
-    project_mcp_config_file: ~/.warp/launch_configurations/mcp.json
+    global_mcp_config_file: ~/.warp/launch_configurations/mcp.json
+    project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search:
       - ~/.agents/skills
@@ -304,7 +324,8 @@ agents:
   windsurf:
     project_skills_dir: .windsurf/skills
     global_skills_dir: ~/.codeium/windsurf/skills
-    project_mcp_config_file: ~/.codeium/windsurf/mcp_settings.json
+    global_mcp_config_file: ~/.codeium/windsurf/mcp_settings.json
+    project_mcp_config_file: ""
     project_skills_search:
       - .windsurf/skills
       - .agents/skills
@@ -320,7 +341,8 @@ agents:
   zencoder:
     project_skills_dir: .zencoder/skills
     global_skills_dir: ~/.zencoder/skills
-    project_mcp_config_file: ~/.zencoder/mcp.json
+    global_mcp_config_file: ~/.zencoder/mcp.json
+    project_mcp_config_file: ""
     project_skills_search:
       - .zencoder/skills
       - .agents/skills

--- a/internal/core/agent/registry.go
+++ b/internal/core/agent/registry.go
@@ -21,14 +21,18 @@ import (
 // Fields ending in *Search are scanned by "gaal audit" (discovery only).
 type Info struct {
 	// ProjectSkillsDir is the skills directory relative to the project root.
-	// Managed by gaal sync.
+	// Managed by gaal sync when global: true.
 	ProjectSkillsDir string
 	// GlobalSkillsDir is the skills directory under the user home directory (~).
-	// Managed by gaal sync.
+	// Managed by gaal sync when global: true.
 	GlobalSkillsDir string
-	// ProjectMCPConfigFile is the path to the agent's MCP server configuration
-	// file, relative to the user home directory (~). Empty when unsupported.
-	// Managed by gaal sync.
+	// GlobalMCPConfigFile is the user-global MCP server configuration file
+	// (~/ prefix). This is the agent's main MCP config (e.g. claude_desktop_config.json).
+	// Managed by gaal sync when global: true.
+	GlobalMCPConfigFile string
+	// ProjectMCPConfigFile is the workspace-scoped MCP server configuration file
+	// (~/ prefix). Empty when the agent has no workspace-level MCP config.
+	// Managed by gaal sync when global: false.
 	ProjectMCPConfigFile string
 
 	// ProjectSkillsSearch is the list of project-relative directories to scan
@@ -62,6 +66,7 @@ type Info struct {
 type agentEntry struct {
 	ProjectSkillsDir       string   `yaml:"project_skills_dir"`
 	GlobalSkillsDir        string   `yaml:"global_skills_dir"`
+	GlobalMCPConfigFile    string   `yaml:"global_mcp_config_file"`
 	ProjectMCPConfigFile   string   `yaml:"project_mcp_config_file"`
 	ProjectSkillsSearch    []string `yaml:"project_skills_search"`
 	GlobalSkillsSearch     []string `yaml:"global_skills_search"`
@@ -127,6 +132,7 @@ func loadInto(data []byte, dst map[string]Info, allowOverride bool) error {
 		dst[name] = Info{
 			ProjectSkillsDir:       e.ProjectSkillsDir,
 			GlobalSkillsDir:        e.GlobalSkillsDir,
+			GlobalMCPConfigFile:    e.GlobalMCPConfigFile,
 			ProjectMCPConfigFile:   e.ProjectMCPConfigFile,
 			ProjectSkillsSearch:    e.ProjectSkillsSearch,
 			GlobalSkillsSearch:     e.GlobalSkillsSearch,
@@ -142,6 +148,7 @@ func loadInto(data []byte, dst map[string]Info, allowOverride bool) error {
 //   - project_skills_dir must be relative and contain no ".." segments
 //   - project_skills_search entries must be relative and contain no ".." segments
 //   - global_skills_dir must start with "~/" or "~\" (home-relative)
+//   - global_mcp_config_file must be empty OR start with "~/" or "~\"
 //   - project_mcp_config_file must be empty OR start with "~/" or "~\"
 //   - global_skills_search and pm_skills_search entries must start with "~/" or "~\"
 func validateEntry(name string, e agentEntry) error {
@@ -171,9 +178,14 @@ func validateEntry(name string, e agentEntry) error {
 	} else if !strings.HasPrefix(e.GlobalSkillsDir, "~/") && !strings.HasPrefix(e.GlobalSkillsDir, `~\`) {
 		return fmt.Errorf("agent %q: global_skills_dir must start with '~/', got %q", name, e.GlobalSkillsDir)
 	}
+	if e.GlobalMCPConfigFile != "" &&
+		!strings.HasPrefix(e.GlobalMCPConfigFile, "~/") &&
+		!strings.HasPrefix(e.GlobalMCPConfigFile, `~\`) {
+		return fmt.Errorf("agent %q: global_mcp_config_file must be empty or start with '~/', got %q", name, e.GlobalMCPConfigFile)
+	}
 	if e.ProjectMCPConfigFile != "" &&
 		!strings.HasPrefix(e.ProjectMCPConfigFile, "~/") &&
-		!strings.HasPrefix(e.ProjectMCPConfigFile, `~\`) {
+		!strings.HasPrefix(e.ProjectMCPConfigFile, `~\\`) {
 		return fmt.Errorf("agent %q: project_mcp_config_file must be empty or start with '~/', got %q", name, e.ProjectMCPConfigFile)
 	}
 	for _, d := range e.ProjectSkillsSearch {
@@ -289,9 +301,21 @@ func SkillDir(name string, global bool, home string) (string, bool) {
 	return info.ProjectSkillsDir, true
 }
 
-// ProjectMCPConfigPath returns the absolute path to the agent's MCP configuration
-// file (home expanded). Returns ("", false) when not known for this agent.
+// GlobalMCPConfigPath returns the absolute path to the agent's user-global MCP
+// configuration file (home expanded). Returns ("", false) when not supported.
+func GlobalMCPConfigPath(name, home string) (string, bool) {
+	slog.Debug("resolving global mcp config path", "agent", name)
+	info, ok := registry[name]
+	if !ok || info.GlobalMCPConfigFile == "" {
+		return "", false
+	}
+	return ExpandHome(info.GlobalMCPConfigFile, home), true
+}
+
+// ProjectMCPConfigPath returns the absolute path to the agent's workspace-scoped
+// MCP configuration file (home expanded). Returns ("", false) when not supported.
 func ProjectMCPConfigPath(name, home string) (string, bool) {
+	slog.Debug("resolving project mcp config path", "agent", name)
 	info, ok := registry[name]
 	if !ok || info.ProjectMCPConfigFile == "" {
 		return "", false

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -49,8 +49,8 @@ func TestLookup_Known(t *testing.T) {
 	if info.GlobalSkillsDir == "" {
 		t.Error("expected non-empty GlobalSkillsDir")
 	}
-	if info.ProjectMCPConfigFile == "" {
-		t.Error("expected non-empty ProjectMCPConfigFile for claude-code")
+	if info.GlobalMCPConfigFile == "" {
+		t.Error("expected non-empty GlobalMCPConfigFile for claude-code")
 	}
 }
 
@@ -102,9 +102,9 @@ func TestSkillDir_Unknown(t *testing.T) {
 
 func TestMCPConfigPath_Known(t *testing.T) {
 	home := "/home/testuser"
-	path, ok := agent.ProjectMCPConfigPath("claude-code", home)
+	path, ok := agent.GlobalMCPConfigPath("claude-code", home)
 	if !ok {
-		t.Fatal("expected ProjectMCPConfigPath to return ok=true for claude-code")
+		t.Fatal("expected GlobalMCPConfigPath to return ok=true for claude-code")
 	}
 	if strings.HasPrefix(path, "~") {
 		t.Errorf("expected ~ to be expanded, got %q", path)
@@ -122,10 +122,10 @@ func TestMCPConfigPath_Unknown(t *testing.T) {
 }
 
 func TestMCPConfigPath_EmptyWhenNotSet(t *testing.T) {
-	// antigravity has an empty project_mcp_config_file.
-	_, ok := agent.ProjectMCPConfigPath("antigravity", "/home/user")
+	// antigravity has an empty global_mcp_config_file.
+	_, ok := agent.GlobalMCPConfigPath("antigravity", "/home/user")
 	if ok {
-		t.Error("expected ok=false for agent with empty ProjectMCPConfigFile")
+		t.Error("expected ok=false for agent with empty GlobalMCPConfigFile")
 	}
 }
 
@@ -198,7 +198,7 @@ func TestList_InfoMatchesLookup(t *testing.T) {
 		}
 		if e.Info.ProjectSkillsDir != info.ProjectSkillsDir ||
 			e.Info.GlobalSkillsDir != info.GlobalSkillsDir ||
-			e.Info.ProjectMCPConfigFile != info.ProjectMCPConfigFile {
+			e.Info.GlobalMCPConfigFile != info.GlobalMCPConfigFile {
 			t.Errorf("List() entry %q Info mismatch: got %+v, want %+v", e.Name, e.Info, info)
 		}
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -110,7 +110,7 @@ func NewWithOptions(cfg *config.Config, opts Options) *Engine {
 		cfg:       cfg,
 		repos:     repo.NewManager(cfg.Repositories, stateDir),
 		skills:    skill.NewManager(cfg.Skills, cacheDir, home, workDir, stateDir, opts.Force),
-		mcps:      mcp.NewManager(cfg.MCPs, stateDir),
+		mcps:      mcp.NewManager(cfg.MCPs, home, stateDir),
 		home:      home,
 		workDir:   workDir,
 		cacheRoot: cacheRoot,

--- a/internal/engine/ops/agents.go
+++ b/internal/engine/ops/agents.go
@@ -48,7 +48,7 @@ func ListAgents(home, workDir string) ([]render.AgentEntry, error) {
 			Source:                  source,
 			ProjectSkillsDir:        projectDir,
 			GlobalSkillsDir:         globalDir,
-			ProjectMCPConfigFile:    a.Info.ProjectMCPConfigFile,
+			ProjectMCPConfigFile:    a.Info.GlobalMCPConfigFile,
 			ProjectSkillsViaGeneric: a.Info.SupportsGenericProject,
 			GlobalSkillsViaGeneric:  a.Info.SupportsGenericGlobal,
 		})
@@ -96,7 +96,7 @@ func AgentDetail(home, workDir, name string) (*render.AgentDetail, error) {
 
 	paths := collectAgentPaths(match.Name, home, workDir)
 
-	mcpCfg, mcpOk := agent.ProjectMCPConfigPath(match.Name, home)
+	mcpCfg, mcpOk := agent.GlobalMCPConfigPath(match.Name, home)
 	var mcpExists bool
 	if mcpOk {
 		_, err := os.Stat(mcpCfg)
@@ -108,7 +108,7 @@ func AgentDetail(home, workDir, name string) (*render.AgentDetail, error) {
 		Installed:  installed,
 		Source:     source,
 		Paths:      paths,
-		MCPSupport: match.Info.ProjectMCPConfigFile != "",
+		MCPSupport: match.Info.GlobalMCPConfigFile != "",
 		MCPConfig:  mcpCfg,
 		MCPExists:  mcpExists,
 	}, nil

--- a/internal/engine/ops/init_build.go
+++ b/internal/engine/ops/init_build.go
@@ -154,7 +154,7 @@ func collectInitMCPs(ctx context.Context, home string) ([]initMCPEntry, error) {
 	var entries []initMCPEntry
 
 	for _, a := range agent.List() {
-		cfgFile, ok := agent.ProjectMCPConfigPath(a.Name, home)
+		cfgFile, ok := agent.GlobalMCPConfigPath(a.Name, home)
 		if !ok {
 			continue
 		}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 
 	"gaal/internal/config"
+	"gaal/internal/core/agent"
 	"gaal/internal/discover"
 )
 
@@ -41,17 +42,68 @@ type Status struct {
 // Manager handles MCP server configuration files.
 type Manager struct {
 	mcps     []config.ConfigMcp
+	home     string // user home directory for ~/ expansion and agent path resolution
 	stateDir string // gaal state root for snapshot writing
 }
 
 // NewManager creates a new MCP Manager.
-func NewManager(mcps []config.ConfigMcp, stateDir string) *Manager {
-	return &Manager{mcps: mcps, stateDir: stateDir}
+func NewManager(mcps []config.ConfigMcp, home, stateDir string) *Manager {
+	slog.Debug("creating mcp manager", "entries", len(mcps), "home", home)
+	return &Manager{mcps: mcps, home: home, stateDir: stateDir}
+}
+
+// resolvedMCPs expands each ConfigMcp into one or more concrete entries with
+// Target resolved from the agent registry. Entries with an explicit Target
+// are kept as-is (backward compat, deprecated). Entries without Target use the
+// Agents + Global fields to fan out one entry per agent.
+func (m *Manager) resolvedMCPs() []config.ConfigMcp {
+	slog.Debug("resolving mcp targets", "count", len(m.mcps))
+	var out []config.ConfigMcp
+	for _, mc := range m.mcps {
+		if mc.Target != "" {
+			slog.Warn("mcp: 'target' field is deprecated; use 'agents' and 'global' instead",
+				"name", mc.Name, "target", mc.Target)
+			out = append(out, mc)
+			continue
+		}
+
+		if len(mc.Agents) == 0 {
+			slog.Warn("mcp: no target and no agents configured, entry skipped", "name", mc.Name)
+			continue
+		}
+
+		agentNames := mc.Agents
+		if len(agentNames) == 1 && agentNames[0] == "*" {
+			agentNames = agent.Names()
+		}
+
+		for _, agentName := range agentNames {
+			var (
+				target string
+				ok     bool
+			)
+			if mc.Global {
+				target, ok = agent.GlobalMCPConfigPath(agentName, m.home)
+			} else {
+				target, ok = agent.ProjectMCPConfigPath(agentName, m.home)
+			}
+			if !ok || target == "" {
+				slog.Debug("mcp: agent has no mcp config for this scope, skipping",
+					"name", mc.Name, "agent", agentName, "global", mc.Global)
+				continue
+			}
+			resolved := mc
+			resolved.Target = target
+			slog.Debug("mcp: resolved target", "name", mc.Name, "agent", agentName, "target", target, "global", mc.Global)
+			out = append(out, resolved)
+		}
+	}
+	return out
 }
 
 // Sync applies every MCP configuration entry.
 func (m *Manager) Sync(ctx context.Context) error {
-	for _, mc := range m.mcps {
+	for _, mc := range m.resolvedMCPs() {
 		if err := m.syncOne(ctx, mc); err != nil {
 			return fmt.Errorf("mcp %q: %w", mc.Name, err)
 		}
@@ -220,7 +272,7 @@ func (m *Manager) Prune(ctx context.Context) error {
 
 	// Build expected name set per target path.
 	keepPerTarget := make(map[string]map[string]struct{})
-	for _, mc := range m.mcps {
+	for _, mc := range m.resolvedMCPs() {
 		if keepPerTarget[mc.Target] == nil {
 			keepPerTarget[mc.Target] = make(map[string]struct{})
 		}
@@ -296,10 +348,11 @@ func (m *Manager) Prune(ctx context.Context) error {
 
 // Status returns the presence state of every MCP entry.
 func (m *Manager) Status(_ context.Context) []Status {
-	slog.Debug("checking mcp status", "count", len(m.mcps))
-	statuses := make([]Status, 0, len(m.mcps))
+	resolved := m.resolvedMCPs()
+	slog.Debug("checking mcp status", "count", len(resolved))
+	statuses := make([]Status, 0, len(resolved))
 
-	for _, mc := range m.mcps {
+	for _, mc := range resolved {
 		st := Status{Name: mc.Name, Target: mc.Target}
 
 		data, err := os.ReadFile(mc.Target)

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -769,110 +769,110 @@ func TestMCPPrune_MissingFileIsNoOp(t *testing.T) {
 // ── resolvedMCPs tests ──────────────────────────────────────────────────────
 
 func TestResolvedMCPs_ExplicitTarget_DeprecatedPath(t *testing.T) {
-target := filepath.Join(t.TempDir(), "mcp.json")
-mcps := []config.ConfigMcp{
-{Name: "srv", Target: target, Inline: &config.ConfigMcpItem{Command: "node"}},
-}
-m := NewManager(mcps, "/home/testuser", "")
-resolved := m.resolvedMCPs()
-if len(resolved) != 1 {
-t.Fatalf("expected 1 resolved entry, got %d", len(resolved))
-}
-if resolved[0].Target != target {
-t.Errorf("expected target %q, got %q", target, resolved[0].Target)
-}
+	target := filepath.Join(t.TempDir(), "mcp.json")
+	mcps := []config.ConfigMcp{
+		{Name: "srv", Target: target, Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	m := NewManager(mcps, "/home/testuser", "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry, got %d", len(resolved))
+	}
+	if resolved[0].Target != target {
+		t.Errorf("expected target %q, got %q", target, resolved[0].Target)
+	}
 }
 
 func TestResolvedMCPs_NoTargetNoAgents_Skipped(t *testing.T) {
-mcps := []config.ConfigMcp{
-{Name: "srv", Source: "https://example.com/mcp.json"},
-}
-m := NewManager(mcps, "/home/testuser", "")
-resolved := m.resolvedMCPs()
-if len(resolved) != 0 {
-t.Errorf("expected 0 resolved entries for entry with no target and no agents, got %d", len(resolved))
-}
+	mcps := []config.ConfigMcp{
+		{Name: "srv", Source: "https://example.com/mcp.json"},
+	}
+	m := NewManager(mcps, "/home/testuser", "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 0 {
+		t.Errorf("expected 0 resolved entries for entry with no target and no agents, got %d", len(resolved))
+	}
 }
 
 func TestResolvedMCPs_AgentWithGlobalTrue_ResolvesTarget(t *testing.T) {
-// claude-code has a non-empty global_mcp_config_file.
-home := "/home/testuser"
-mcps := []config.ConfigMcp{
-{
-Name:   "srv",
-Global: true,
-Agents: []string{"claude-code"},
-Inline: &config.ConfigMcpItem{Command: "node"},
-},
-}
-m := NewManager(mcps, home, "")
-resolved := m.resolvedMCPs()
-if len(resolved) != 1 {
-t.Fatalf("expected 1 resolved entry for claude-code global, got %d", len(resolved))
-}
-if resolved[0].Target == "" {
-t.Error("expected non-empty resolved target for claude-code global")
-}
+	// claude-code has a non-empty global_mcp_config_file.
+	home := "/home/testuser"
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: true,
+			Agents: []string{"claude-code"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, home, "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry for claude-code global, got %d", len(resolved))
+	}
+	if resolved[0].Target == "" {
+		t.Error("expected non-empty resolved target for claude-code global")
+	}
 }
 
 func TestResolvedMCPs_AgentWithGlobalFalse_SkipsWhenNoProjectMCP(t *testing.T) {
-// claude-code has an empty project_mcp_config_file → should be skipped.
-home := "/home/testuser"
-mcps := []config.ConfigMcp{
-{
-Name:   "srv",
-Global: false,
-Agents: []string{"claude-code"},
-Inline: &config.ConfigMcpItem{Command: "node"},
-},
-}
-m := NewManager(mcps, home, "")
-resolved := m.resolvedMCPs()
-if len(resolved) != 0 {
-t.Errorf("expected 0 resolved entries for claude-code project scope (empty), got %d", len(resolved))
-}
+	// claude-code has an empty project_mcp_config_file → should be skipped.
+	home := "/home/testuser"
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: false,
+			Agents: []string{"claude-code"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, home, "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 0 {
+		t.Errorf("expected 0 resolved entries for claude-code project scope (empty), got %d", len(resolved))
+	}
 }
 
 func TestResolvedMCPs_UnknownAgent_Skipped(t *testing.T) {
-mcps := []config.ConfigMcp{
-{
-Name:   "srv",
-Global: true,
-Agents: []string{"no-such-agent-xyz"},
-Inline: &config.ConfigMcpItem{Command: "node"},
-},
-}
-m := NewManager(mcps, "/home/testuser", "")
-resolved := m.resolvedMCPs()
-if len(resolved) != 0 {
-t.Errorf("expected 0 resolved entries for unknown agent, got %d", len(resolved))
-}
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: true,
+			Agents: []string{"no-such-agent-xyz"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, "/home/testuser", "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 0 {
+		t.Errorf("expected 0 resolved entries for unknown agent, got %d", len(resolved))
+	}
 }
 
 func TestResolvedMCPs_MultipleAgents_FansOut(t *testing.T) {
-// Both claude-code and github-copilot have non-empty global_mcp_config_file.
-home := "/home/testuser"
-mcps := []config.ConfigMcp{
-{
-Name:   "srv",
-Global: true,
-Agents: []string{"claude-code", "github-copilot"},
-Inline: &config.ConfigMcpItem{Command: "node"},
-},
-}
-m := NewManager(mcps, home, "")
-resolved := m.resolvedMCPs()
-if len(resolved) != 2 {
-t.Fatalf("expected 2 resolved entries (one per agent), got %d", len(resolved))
-}
-targets := map[string]bool{}
-for _, r := range resolved {
-if r.Target == "" {
-t.Error("expected non-empty target")
-}
-targets[r.Target] = true
-}
-if len(targets) != 2 {
-t.Errorf("expected 2 distinct targets, got %d: %v", len(targets), targets)
-}
+	// Both claude-code and github-copilot have non-empty global_mcp_config_file.
+	home := "/home/testuser"
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: true,
+			Agents: []string{"claude-code", "github-copilot"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, home, "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2 resolved entries (one per agent), got %d", len(resolved))
+	}
+	targets := map[string]bool{}
+	for _, r := range resolved {
+		if r.Target == "" {
+			t.Error("expected non-empty target")
+		}
+		targets[r.Target] = true
+	}
+	if len(targets) != 2 {
+		t.Errorf("expected 2 distinct targets, got %d: %v", len(targets), targets)
+	}
 }

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -164,7 +164,7 @@ func TestManager_Sync_Inline(t *testing.T) {
 			},
 		},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestManager_Sync_NoSourceOrInline(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "bad", Target: filepath.Join(t.TempDir(), "mcp.json")},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	err := m.Sync(context.Background())
 	if err == nil {
 		t.Fatal("expected error when no source or inline provided")
@@ -188,7 +188,7 @@ func TestManager_Status_Missing(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "srv", Target: "/no/such/file.json"},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -204,7 +204,7 @@ func TestManager_Status_Present(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "my-srv", Target: target},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -227,7 +227,7 @@ func TestManager_Sync_WithSource(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "my-srv", Source: srv.URL, Target: target},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync with source URL: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestManager_Sync_SkipsUninstalledAgentTarget(t *testing.T) {
 			Inline: &config.ConfigMcpItem{Command: "node"},
 		},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestManager_Status_InvalidJSON(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "srv", Target: target},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -404,7 +404,7 @@ func TestManager_Status_DirtyInline(t *testing.T) {
 			Inline: &config.ConfigMcpItem{Command: "new-cmd"},
 		},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -428,7 +428,7 @@ func TestManager_Status_CleanInline(t *testing.T) {
 			Inline: &config.ConfigMcpItem{Command: "node", Args: []string{"server.js"}},
 		},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -446,7 +446,7 @@ func TestManager_Status_SourceNoInline_NoDirtyCheck(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "srv", Target: target, Source: "https://example.com/mcp.json"},
 	}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -687,7 +687,7 @@ func TestManager_Status_ReadError(t *testing.T) {
 	t.Cleanup(func() { os.Chmod(tmp.Name(), 0o644) })
 
 	mcps := []config.ConfigMcp{{Name: "srv", Target: tmp.Name()}}
-	m := NewManager(mcps, "")
+	m := NewManager(mcps, "", "")
 	statuses := m.Status(context.Background())
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
@@ -719,7 +719,7 @@ func TestMCPPrune_RemovesOrphanEntry(t *testing.T) {
 	cfg := []config.ConfigMcp{
 		{Name: "kept", Target: target, Inline: &config.ConfigMcpItem{Command: "node"}},
 	}
-	m := NewManager(cfg, "")
+	m := NewManager(cfg, "", "")
 	if err := m.Prune(context.Background()); err != nil {
 		t.Fatalf("Prune returned error: %v", err)
 	}
@@ -745,7 +745,7 @@ func TestMCPPrune_NoOpWhenAllManaged(t *testing.T) {
 	cfg := []config.ConfigMcp{
 		{Name: "myserver", Target: target, Inline: &config.ConfigMcpItem{Command: "node"}},
 	}
-	m := NewManager(cfg, "")
+	m := NewManager(cfg, "", "")
 	if err := m.Prune(context.Background()); err != nil {
 		t.Fatalf("Prune returned error: %v", err)
 	}
@@ -760,8 +760,119 @@ func TestMCPPrune_MissingFileIsNoOp(t *testing.T) {
 	cfg := []config.ConfigMcp{
 		{Name: "x", Target: target, Inline: &config.ConfigMcpItem{Command: "node"}},
 	}
-	m := NewManager(cfg, "")
+	m := NewManager(cfg, "", "")
 	if err := m.Prune(context.Background()); err != nil {
 		t.Fatalf("Prune returned error: %v", err)
 	}
+}
+
+// ── resolvedMCPs tests ──────────────────────────────────────────────────────
+
+func TestResolvedMCPs_ExplicitTarget_DeprecatedPath(t *testing.T) {
+target := filepath.Join(t.TempDir(), "mcp.json")
+mcps := []config.ConfigMcp{
+{Name: "srv", Target: target, Inline: &config.ConfigMcpItem{Command: "node"}},
+}
+m := NewManager(mcps, "/home/testuser", "")
+resolved := m.resolvedMCPs()
+if len(resolved) != 1 {
+t.Fatalf("expected 1 resolved entry, got %d", len(resolved))
+}
+if resolved[0].Target != target {
+t.Errorf("expected target %q, got %q", target, resolved[0].Target)
+}
+}
+
+func TestResolvedMCPs_NoTargetNoAgents_Skipped(t *testing.T) {
+mcps := []config.ConfigMcp{
+{Name: "srv", Source: "https://example.com/mcp.json"},
+}
+m := NewManager(mcps, "/home/testuser", "")
+resolved := m.resolvedMCPs()
+if len(resolved) != 0 {
+t.Errorf("expected 0 resolved entries for entry with no target and no agents, got %d", len(resolved))
+}
+}
+
+func TestResolvedMCPs_AgentWithGlobalTrue_ResolvesTarget(t *testing.T) {
+// claude-code has a non-empty global_mcp_config_file.
+home := "/home/testuser"
+mcps := []config.ConfigMcp{
+{
+Name:   "srv",
+Global: true,
+Agents: []string{"claude-code"},
+Inline: &config.ConfigMcpItem{Command: "node"},
+},
+}
+m := NewManager(mcps, home, "")
+resolved := m.resolvedMCPs()
+if len(resolved) != 1 {
+t.Fatalf("expected 1 resolved entry for claude-code global, got %d", len(resolved))
+}
+if resolved[0].Target == "" {
+t.Error("expected non-empty resolved target for claude-code global")
+}
+}
+
+func TestResolvedMCPs_AgentWithGlobalFalse_SkipsWhenNoProjectMCP(t *testing.T) {
+// claude-code has an empty project_mcp_config_file → should be skipped.
+home := "/home/testuser"
+mcps := []config.ConfigMcp{
+{
+Name:   "srv",
+Global: false,
+Agents: []string{"claude-code"},
+Inline: &config.ConfigMcpItem{Command: "node"},
+},
+}
+m := NewManager(mcps, home, "")
+resolved := m.resolvedMCPs()
+if len(resolved) != 0 {
+t.Errorf("expected 0 resolved entries for claude-code project scope (empty), got %d", len(resolved))
+}
+}
+
+func TestResolvedMCPs_UnknownAgent_Skipped(t *testing.T) {
+mcps := []config.ConfigMcp{
+{
+Name:   "srv",
+Global: true,
+Agents: []string{"no-such-agent-xyz"},
+Inline: &config.ConfigMcpItem{Command: "node"},
+},
+}
+m := NewManager(mcps, "/home/testuser", "")
+resolved := m.resolvedMCPs()
+if len(resolved) != 0 {
+t.Errorf("expected 0 resolved entries for unknown agent, got %d", len(resolved))
+}
+}
+
+func TestResolvedMCPs_MultipleAgents_FansOut(t *testing.T) {
+// Both claude-code and github-copilot have non-empty global_mcp_config_file.
+home := "/home/testuser"
+mcps := []config.ConfigMcp{
+{
+Name:   "srv",
+Global: true,
+Agents: []string{"claude-code", "github-copilot"},
+Inline: &config.ConfigMcpItem{Command: "node"},
+},
+}
+m := NewManager(mcps, home, "")
+resolved := m.resolvedMCPs()
+if len(resolved) != 2 {
+t.Fatalf("expected 2 resolved entries (one per agent), got %d", len(resolved))
+}
+targets := map[string]bool{}
+for _, r := range resolved {
+if r.Target == "" {
+t.Error("expected non-empty target")
+}
+targets[r.Target] = true
+}
+if len(targets) != 2 {
+t.Errorf("expected 2 distinct targets, got %d: %v", len(targets), targets)
+}
 }


### PR DESCRIPTION
## Summary

Replace the mandatory `target` field on `ConfigMcp` with automatic resolution from the agent registry, mirroring the `ConfigSkill` pattern (`agents` + `global`).

### Key changes

- **`agents.yaml`**: rename `project_mcp_config_file` → `global_mcp_config_file` (the existing values were always user-global paths); add new `project_mcp_config_file` field (workspace-scoped, empty for now on all agents).
- **`registry.go`**: add `GlobalMCPConfigFile` to `Info` and `agentEntry`; new `GlobalMCPConfigPath()` function; update `validateEntry` to check both fields.
- **`config/manager.go`**: `ConfigMcp` gains `Agents []string` and `Global bool`; `Target` becomes optional/deprecated (kept for backward compat with a `slog.Warn`).
- **`mcp/manager.go`**: `Manager` gains `home`; `resolvedMCPs()` fans out each entry by agent, routing `Global=true` → `GlobalMCPConfigPath` and `Global=false` → `ProjectMCPConfigPath`; `Sync`, `Status`, `Prune` all route through `resolvedMCPs()`.
- **`engine.go`**: pass `home` to `mcp.NewManager`.
- **`ops/agents.go`**, **`ops/init_build.go`**: use `GlobalMCPConfigPath` for display/discovery.
- **`skill/agents.go`**: expose `GlobalMCPConfigPath` wrapper.
- **`example.gaal.yaml`**: updated MCP section to new `agents` + `global` format.

### New config format

```yaml
mcps:
  # New format — target resolved automatically from agent registry
  - name: filesystem
    agents: ["claude-code"]
    global: true          # → uses global_mcp_config_file from registry
    inline:
      command: uvx
      args: [mcp-server-filesystem, /home/user/projects]

  # All agents that have a global MCP config
  - name: git
    agents: ["*"]
    global: true
    inline:
      command: uvx
      args: [mcp-server-git, --repository, /home/user/projects]

  # Backward-compat: explicit target still works (deprecated)
  - name: legacy
    target: ~/.vscode/settings.json
    inline:
      command: npx
      args: [-y, "@mcp/server"]
```

## Type of Change
- [x] feat — new feature

## Related Issues
Closes #58

## Checklist
- [x] `make lint` passes — `gofmt` formatting + `go vet` clean
- [x] `make build` passes on Linux and macOS
- [x] `make test` passes — unit tests with race detector
- [x] Every new function has at least one `slog.Debug` / `slog.DebugContext` call
- [x] No secrets or credentials are exposed in logs or config snippets
- [x] Backward compatibility preserved — explicit `target` still accepted with deprecation warning