### PR TITLE
fix(render): shorten local skill source paths in sync/status output

### DIFF
--- a/internal/engine/render/plan_table.go
+++ b/internal/engine/render/plan_table.go
@@ -128,7 +128,7 @@ func (pr *planTableRenderer) skillTable(w io.Writer, tr *tableRenderer, entries 
 			detail = e.Error
 		}
 		data = append(data, []string{
-			trunc(e.Source, vw),
+			trunc(displaySource(e.Source), vw),
 			trunc(e.Agent, vw),
 			actionCell(e.Action, e.Error),
 			trunc(detail, vw),

--- a/internal/engine/render/plan_text.go
+++ b/internal/engine/render/plan_text.go
@@ -69,7 +69,7 @@ func collectPlanItems(r *PlanReport) []planTextItem {
 	for _, e := range r.Skills {
 		items = append(items, planTextItem{
 			marker: markerFor(e.Action),
-			name:   e.Source,
+			name:   displaySource(e.Source),
 			detail: skillPlanDetail(e),
 		})
 	}

--- a/internal/engine/render/table.go
+++ b/internal/engine/render/table.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -47,6 +48,35 @@ func statusCell(code StatusCode, errMsg string) string {
 	default:
 		return label
 	}
+}
+
+// displaySource shortens a skill source for terminal rendering. Remote
+// sources (URLs and GitHub owner/repo shorthand) are returned unchanged;
+// local paths are reduced to their last segment so deeply-nested plugin
+// cache directories stay readable in the Skills table — e.g.
+// "/Users/.../skills/claude-md-improver" becomes "claude-md-improver".
+// The data model keeps the full source; this helper is display-only.
+func displaySource(s string) string {
+	switch {
+	case strings.HasPrefix(s, "http://"),
+		strings.HasPrefix(s, "https://"),
+		strings.HasPrefix(s, "git@"),
+		strings.HasPrefix(s, "ssh://"):
+		return s
+	case !strings.ContainsAny(s, `/\`):
+		return s
+	case strings.HasPrefix(s, "./"), strings.HasPrefix(s, `.\`),
+		strings.HasPrefix(s, "../"), strings.HasPrefix(s, `..\`),
+		strings.HasPrefix(s, "~/"), strings.HasPrefix(s, `~\`),
+		strings.HasPrefix(s, "/"), filepath.IsAbs(s):
+		return filepath.Base(s)
+	}
+	// Two-segment strings without a leading path marker are treated as
+	// GitHub owner/repo shorthand and left as-is.
+	if strings.Count(s, "/") == 1 {
+		return s
+	}
+	return filepath.Base(s)
 }
 
 // trunc truncates s to max visible runes, appending "…" when shortened.
@@ -417,9 +447,13 @@ func (tr *tableRenderer) skillTable(w io.Writer, entries []SkillEntry, termW int
 		if name == "" {
 			name = "—"
 		}
+		displaySources := make([]string, len(s.Sources))
+		for i, src := range s.Sources {
+			displaySources[i] = displaySource(src)
+		}
 		data = append(data, []string{
 			trunc(name, vw),
-			trunc(strings.Join(s.Sources, ", "), vw),
+			trunc(strings.Join(displaySources, ", "), vw),
 			scope,
 			statusCell(s.Status, s.Error),
 			trunc(installedIn, vw),

--- a/internal/engine/render/table_test.go
+++ b/internal/engine/render/table_test.go
@@ -234,6 +234,37 @@ func TestAggregateSkillsByName_MultipleSourcesMerged(t *testing.T) {
 	}
 }
 
+func TestDisplaySource(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		// Remote sources pass through unchanged.
+		{"https://github.com/owner/repo", "https://github.com/owner/repo"},
+		{"http://example.com/foo", "http://example.com/foo"},
+		{"git@github.com:owner/repo.git", "git@github.com:owner/repo.git"},
+		{"ssh://git@host/path", "ssh://git@host/path"},
+		// GitHub owner/repo shorthand stays intact.
+		{"owner/repo", "owner/repo"},
+		{"anthropics/skills", "anthropics/skills"},
+		// Bare names (no slash) are unchanged.
+		{"skills", "skills"},
+		{"", ""},
+		// Absolute and home-relative local paths reduce to the last segment.
+		{"/Users/nls/.claude/plugins/cache/claude-plugins-official/claude-md-management/1.0.0/skills/claude-md-improver", "claude-md-improver"},
+		{"/abs/path/to/skill", "skill"},
+		{"~/skills/my-skill", "my-skill"},
+		{"./local/path/skill", "skill"},
+		{"../other/skill-dir", "skill-dir"},
+		// Three-plus-segment non-prefixed paths are also reduced.
+		{"a/b/c", "c"},
+	}
+	for _, tc := range tests {
+		if got := displaySource(tc.in); got != tc.want {
+			t.Errorf("displaySource(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestAggregateSkillsByName_ErrorPropagates(t *testing.T) {
 	in := []SkillEntry{
 		{Source: "owner/repo", Agent: "cursor", Status: StatusOK, Installed: []string{"broken"}},


### PR DESCRIPTION
On complex setups (Claude Code plugins, vendored skills, etc.) skill sources are often deeply-nested local paths like:

    /Users/nls/.claude/plugins/cache/claude-plugins-official/claude-md-management/1.0.0/skills/claude-md-improver

Rendering those in full made the \`SOURCE\` column in \`gaal sync --dry-run\` and \`gaal status\` unreadable and bloated the output.

## Summary

- Added \`displaySource\` helper in \`internal/engine/render\`: absolute / home-relative / dot-relative paths are reduced to their last segment (\`filepath.Base\`); URLs and \`owner/repo\` shorthand pass through unchanged
- Applied it in the status skill table, the plan skill table, and the plan text renderer
- Data model (\`SkillEntry.Source\`, \`PlanSkillEntry.Source\`) is unchanged — this is purely a rendering change, so JSON output is unaffected

## Test plan

- [x] \`go test ./...\` — all 735 tests pass (includes new \`TestDisplaySource\` table-driven cases)
- [x] \`go vet ./...\` clean