### PR TITLE
chore(repo): migrate all references from gmg-inc/gaal-lite to getgaal/gaal

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Question / Discussion
-    url: https://github.com/gmg-inc/gaal-lite/discussions
+    url: https://github.com/getgaal/gaal/discussions
     about: Ask questions and discuss ideas in GitHub Discussions rather than opening an issue.

--- a/.github/agents/create-issue.md
+++ b/.github/agents/create-issue.md
@@ -16,7 +16,7 @@ tools:
 # CreateIssue — GitHub Issue Creation Agent
 
 You are an agent that helps create well-structured GitHub issues for the **gaal** project
-(`gmg-inc/gaal-lite`). You enforce the official issue templates and create issues via `gh`.
+(`getgaal/gaal`). You enforce the official issue templates and create issues via `gh`.
 
 ## Workflow
 
@@ -97,7 +97,7 @@ Run the following command (adapt title, label, and body):
 
 ```bash
 gh issue create \
-  --repo gmg-inc/gaal-lite \
+  --repo getgaal/gaal \
   --title "<title>" \
   --label "<label>" \
   --body "<body>"

--- a/.github/agents/doc-writer.md
+++ b/.github/agents/doc-writer.md
@@ -34,7 +34,7 @@ If no user-facing behaviour changed, output: `No documentation update required.`
 ## Documentation principles
 
 - **Do NOT duplicate code** — reference source files with line numbers instead:
-  `[Description](https://github.com/gmg-inc/gaal-lite/blob/main/path/to/file.go#L10-L20)`
+  `[Description](https://github.com/getgaal/gaal/blob/main/path/to/file.go#L10-L20)`
 - **Keep it DRY** — link to the source of truth, do not maintain parallel definitions
 - **Structure per file** (where applicable): Overview → Installation → Usage → API Reference → Configuration
 - **English only** — all documentation content

--- a/.github/agents/pr-workflow.md
+++ b/.github/agents/pr-workflow.md
@@ -202,7 +202,7 @@ git push -u origin <branch-name>
 
 ```bash
 gh pr create \
-  --repo gmg-inc/gaal-lite \
+  --repo getgaal/gaal \
   --base main \
   --head <branch-name> \
   --title "<Conventional Commits title>" \
@@ -237,7 +237,7 @@ Report the PR URL to the user.
 🤖 Poll the PR state periodically or when the user asks for an update:
 
 ```bash
-gh pr view <PR-number> --repo gmg-inc/gaal-lite --json state,reviews,comments
+gh pr view <PR-number> --repo getgaal/gaal --json state,reviews,comments
 ```
 
 #### If the PR is merged → CLEANUP & SYNC

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ See [`docs/architecture.md`](docs/architecture.md) for a full description of the
 ### Quick install (macOS / Linux)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/getgaal/gaal/main/scripts/install.sh | sh
 ```
 
 Installs the latest release binary to `~/.local/bin/gaal`. Pin a specific
@@ -387,13 +387,13 @@ version with `VERSION=v0.1.2`, or pick a different directory with
 `INSTALL_DIR=/usr/local/bin`.
 
 Pass `GAAL_INSTALL_DEBUG=1` for verbose output, or run
-`curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | sh -s -- --help`
+`curl -fsSL https://raw.githubusercontent.com/getgaal/gaal/main/scripts/install.sh | sh -s -- --help`
 to see all options.
 
 ### With Go
 
 ```bash
-go install github.com/gmg-inc/gaal@latest
+go install github.com/getgaal/gaal@latest
 ```
 
 ### From source
@@ -401,7 +401,7 @@ go install github.com/gmg-inc/gaal@latest
 **Prerequisites:** Go 1.26+
 
 ```bash
-git clone https://github.com/gmg-inc/gaal.git
+git clone https://github.com/getgaal/gaal.git
 cd gaal
 make build
 ```

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -6,23 +6,23 @@
 
 ## 1. Install
 
-Download the binary for your platform from the [latest release](https://github.com/gmg-inc/gaal/releases/latest):
+Download the binary for your platform from the [latest release](https://github.com/getgaal/gaal/releases/latest):
 
 ```bash
 # Linux (amd64)
-curl -Lo gaal https://github.com/gmg-inc/gaal/releases/latest/download/gaal-linux-amd64
+curl -Lo gaal https://github.com/getgaal/gaal/releases/latest/download/gaal-linux-amd64
 chmod +x gaal && sudo mv gaal /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -Lo gaal https://github.com/gmg-inc/gaal/releases/latest/download/gaal-darwin-arm64
+curl -Lo gaal https://github.com/getgaal/gaal/releases/latest/download/gaal-darwin-arm64
 chmod +x gaal && sudo mv gaal /usr/local/bin/
 
 # macOS (Intel)
-curl -Lo gaal https://github.com/gmg-inc/gaal/releases/latest/download/gaal-darwin-amd64
+curl -Lo gaal https://github.com/getgaal/gaal/releases/latest/download/gaal-darwin-amd64
 chmod +x gaal && sudo mv gaal /usr/local/bin/
 
 # Windows (amd64) — PowerShell
-Invoke-WebRequest -Uri https://github.com/gmg-inc/gaal/releases/latest/download/gaal-windows-amd64.exe -OutFile gaal.exe
+Invoke-WebRequest -Uri https://github.com/getgaal/gaal/releases/latest/download/gaal-windows-amd64.exe -OutFile gaal.exe
 ```
 
 Verify the installation:

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -130,7 +130,7 @@ skills:
 }
 
 func TestLoad_SkillAgents_NestedListIsFlattened(t *testing.T) {
-	// Regression for https://github.com/gmg-inc/gaal/issues/13
+	// Regression for https://github.com/getgaal/gaal/issues/13
 	// A list-of-lists is a common hand-written mistake (mentally copying the
 	// canonical `agents: ["*"]` example under a list bullet).
 	p := writeYAML(t, `

--- a/internal/installscript/install_test.go
+++ b/internal/installscript/install_test.go
@@ -57,7 +57,7 @@ func fakeReleaseServer(t *testing.T, version, goos, goarch string, binary []byte
 	sumsContent := fmt.Sprintf("%s  %s\n", sha256hex(binary), binName)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/gmg-inc/gaal/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/getgaal/gaal/releases/latest", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"tag_name":%q}`, version)
 	})
@@ -161,7 +161,7 @@ func TestInstallChecksumMismatch(t *testing.T) {
 	sumsContent := fmt.Sprintf("%s  %s\n", sha256hex(realBinary), binName)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/gmg-inc/gaal/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/getgaal/gaal/releases/latest", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `{"tag_name":%q}`, version)
 	})
 	mux.HandleFunc(fmt.Sprintf("/releases/download/%s/%s", version, binName), func(w http.ResponseWriter, r *http.Request) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,7 +6,7 @@
 # to $INSTALL_DIR (default $HOME/.local/bin).
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/getgaal/gaal/main/scripts/install.sh | sh
 #   curl -fsSL ... | VERSION=v0.1.2 sh
 #   curl -fsSL ... | INSTALL_DIR=/usr/local/bin sh
 #
@@ -31,7 +31,7 @@ if [ "${GAAL_INSTALL_DEBUG:-}" = "1" ]; then
 fi
 
 # --- constants ---------------------------------------------------------------
-REPO="gmg-inc/gaal"
+REPO="getgaal/gaal"
 BIN_NAME="gaal"
 DEFAULT_INSTALL_DIR="$HOME/.local/bin"
 
@@ -46,8 +46,8 @@ usage() {
 gaal installer
 
 Usage:
-  curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | sh
-  curl -fsSL https://raw.githubusercontent.com/gmg-inc/gaal/main/scripts/install.sh | VERSION=v0.1.2 sh
+  curl -fsSL https://raw.githubusercontent.com/getgaal/gaal/main/scripts/install.sh | sh
+  curl -fsSL https://raw.githubusercontent.com/getgaal/gaal/main/scripts/install.sh | VERSION=v0.1.2 sh
 
 Environment:
   VERSION              Release tag to install (default: latest from GitHub Releases)
@@ -64,7 +64,7 @@ Examples:
   # System-wide install (will prompt for sudo on install)
   curl -fsSL <URL> | INSTALL_DIR=/usr/local/bin sh
 
-Report issues: https://github.com/gmg-inc/gaal/issues
+Report issues: https://github.com/getgaal/gaal/issues
 EOF
 }
 


### PR DESCRIPTION
## Summary

Following the repository transfer from `gmg-inc/gaal-lite` to `getgaal/gaal`, this PR updates all hardcoded references across the codebase.

## Type of Change
- [x] Chore (non-breaking change that doesn't affect functionality)

## Changes

| File | Change |
|------|--------|
| `README.md` | Install/clone/`go install` URLs |
| `scripts/install.sh` | `REPO` constant and all usage URLs |
| `docs/quick_start.md` | Binary download links for all platforms |
| `.github/ISSUE_TEMPLATE/config.yml` | Discussions link |
| `.github/agents/create-issue.md` | `--repo` flag in `gh issue create` |
| `.github/agents/pr-workflow.md` | `--repo` flags in `gh pr` commands |
| `.github/agents/doc-writer.md` | Source code link example |
| `internal/config/manager_test.go` | Regression comment URL |
| `internal/installscript/install_test.go` | Fake GitHub API handler paths |

## Checklist
- [x] `make build` passes
- [x] `make test` passes — all packages green
- [x] No secrets or credentials exposed
- [x] No functional code changed — documentation and config only