### PR TITLE
feat(sync): align output with docs; nested dry-run plan

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -13,6 +13,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/engine"
+	"gaal/internal/engine/render"
 	"gaal/internal/telemetry"
 	"gaal/internal/tools"
 )
@@ -90,18 +91,34 @@ func runSync(_ *cobra.Command, _ []string) error {
 		return eng.RunService(ctx, interval)
 	}
 
-	slog.Info("one-shot sync", "config", cfgFile)
+	slog.Debug("one-shot sync", "config", cfgFile)
+	plan, err := eng.Plan(ctx)
+	if err != nil {
+		telemetry.TrackError("sync", err)
+		return err
+	}
+
+	start := time.Now()
 	if err := eng.RunOnce(ctx); err != nil {
 		telemetry.TrackError("sync", err)
 		return err
 	}
 	if prune {
-		slog.Info("pruning orphan resources")
+		slog.Debug("pruning orphan resources")
 		if err := eng.Prune(ctx); err != nil {
 			telemetry.TrackError("sync-prune", err)
 			return err
 		}
 	}
+
+	duration := time.Since(start)
+	status, err := eng.Collect(ctx)
+	if err != nil {
+		slog.Debug("post-sync status collection failed; skipping summary", "err", err)
+	} else if rerr := render.RenderSyncSummary(os.Stdout, plan, status, duration); rerr != nil {
+		slog.Debug("rendering sync summary failed", "err", rerr)
+	}
+
 	telemetry.Track("sync")
 	telemetry.TrackFirstSync(0)
 	return nil

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -120,26 +120,26 @@ func NewWithOptions(cfg *config.Config, opts Options) *Engine {
 
 // RunOnce performs a single synchronisation pass.
 func (e *Engine) RunOnce(ctx context.Context) error {
-	slog.Info("sync started")
+	slog.Debug("sync started")
 
 	var errs []error
 
 	if len(e.cfg.Repositories) > 0 {
-		slog.Info("syncing repositories", "count", len(e.cfg.Repositories))
+		slog.Debug("syncing repositories", "count", len(e.cfg.Repositories))
 		if err := e.repos.Sync(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("repositories: %w", err))
 		}
 	}
 
 	if len(e.cfg.Skills) > 0 {
-		slog.Info("syncing skills", "count", len(e.cfg.Skills))
+		slog.Debug("syncing skills", "count", len(e.cfg.Skills))
 		if err := e.skills.Sync(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("skills: %w", err))
 		}
 	}
 
 	if len(e.cfg.MCPs) > 0 {
-		slog.Info("syncing MCP configs", "count", len(e.cfg.MCPs))
+		slog.Debug("syncing MCP configs", "count", len(e.cfg.MCPs))
 		if err := e.mcps.Sync(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("mcps: %w", err))
 		}
@@ -150,7 +150,7 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 		return fmt.Errorf("sync errors: %v", errs)
 	}
 
-	slog.Info("sync completed successfully")
+	slog.Debug("sync completed successfully")
 	return nil
 }
 
@@ -209,6 +209,14 @@ func (e *Engine) Collect(ctx context.Context) (*render.StatusReport, error) {
 // exit code logic.
 func (e *Engine) DryRun(ctx context.Context, format OutputFormat) (*render.PlanReport, error) {
 	return ops.RenderPlan(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir, format)
+}
+
+// Plan computes the sync plan without rendering it. It is the same planner
+// used by DryRun; the cmd layer calls this before RunOnce so the sync
+// summary can report past-tense verbs ("cloned", "installed", "upserted")
+// for each managed resource.
+func (e *Engine) Plan(ctx context.Context) (*render.PlanReport, error) {
+	return ops.SyncPlan(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir)
 }
 
 // Status collects the current resource state and renders it to os.Stdout.

--- a/internal/engine/ops/plan.go
+++ b/internal/engine/ops/plan.go
@@ -124,6 +124,7 @@ func planSkills(entries []render.SkillEntry) []render.PlanSkillEntry {
 			p.Update = e.Modified
 		default:
 			p.Action = render.PlanNoOp
+			p.NoOp = append([]string(nil), e.Installed...)
 		}
 		out = append(out, p)
 	}

--- a/internal/engine/render/display.go
+++ b/internal/engine/render/display.go
@@ -1,0 +1,76 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// displaySkillName reduces a skill source (typically from ConfigSkill.Source)
+// to a short, human-friendly label for the sync summary and plan output.
+// Remote URLs and GitHub owner/repo shorthand pass through unchanged; local
+// paths collapse to their last segment so deeply-nested plugin-cache
+// directories stay readable.
+func displaySkillName(source string) string {
+	switch {
+	case source == "":
+		return "—"
+	case strings.HasPrefix(source, "http://"),
+		strings.HasPrefix(source, "https://"),
+		strings.HasPrefix(source, "git@"),
+		strings.HasPrefix(source, "ssh://"):
+		return source
+	case !strings.ContainsAny(source, `/\`):
+		return source
+	case strings.HasPrefix(source, "./"), strings.HasPrefix(source, `.\`),
+		strings.HasPrefix(source, "../"), strings.HasPrefix(source, `..\`),
+		strings.HasPrefix(source, "~/"), strings.HasPrefix(source, `~\`),
+		strings.HasPrefix(source, "/"), filepath.IsAbs(source):
+		return filepath.Base(source)
+	}
+	// owner/repo shorthand: exactly one slash, no prefixed path marker.
+	if strings.Count(source, "/") == 1 {
+		return source
+	}
+	return filepath.Base(source)
+}
+
+// displayTarget abbreviates a filesystem path for one-line rendering.
+// Home-directory prefixes are replaced with "~"; paths longer than softLimit
+// are truncated to "…/<last-three-segments>". softLimit <= 0 disables the
+// length check and only applies the ~ substitution.
+func displayTarget(path string, softLimit int) string {
+	if path == "" {
+		return path
+	}
+
+	abbreviated := path
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if path == home {
+			abbreviated = "~"
+		} else if strings.HasPrefix(path, home+string(os.PathSeparator)) {
+			abbreviated = "~" + path[len(home):]
+		}
+	}
+
+	if softLimit <= 0 || len(abbreviated) <= softLimit {
+		return abbreviated
+	}
+	return truncatePath(abbreviated, 3)
+}
+
+// truncatePath keeps the last n path segments and prepends "…/" to indicate
+// elision. If the path already has fewer than n segments, it is returned
+// unchanged.
+func truncatePath(p string, n int) string {
+	sep := string(os.PathSeparator)
+	parts := strings.Split(p, sep)
+	// Drop leading empty parts produced by a leading separator.
+	for len(parts) > 0 && parts[0] == "" {
+		parts = parts[1:]
+	}
+	if len(parts) <= n {
+		return p
+	}
+	return "…" + sep + strings.Join(parts[len(parts)-n:], sep)
+}

--- a/internal/engine/render/display_test.go
+++ b/internal/engine/render/display_test.go
@@ -1,0 +1,84 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDisplaySkillName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "—"},
+		{"anthropics/skills", "anthropics/skills"},
+		{"owner/repo", "owner/repo"},
+		{"https://github.com/owner/repo", "https://github.com/owner/repo"},
+		{"git@github.com:owner/repo.git", "git@github.com:owner/repo.git"},
+		{"ssh://git@host/path/to/repo", "ssh://git@host/path/to/repo"},
+		{"skills", "skills"},
+		{"/Users/nls/.claude/plugins/cache/claude-plugins-official/claude-md-management/1.0.0/skills/claude-md-improver", "claude-md-improver"},
+		{"/abs/path/to/skill", "skill"},
+		{"./local/path/skill", "skill"},
+		{"../other/skill-dir", "skill-dir"},
+		{"~/skills/my-skill", "my-skill"},
+		{"a/b/c", "c"},
+	}
+	for _, tc := range cases {
+		if got := displaySkillName(tc.in); got != tc.want {
+			t.Errorf("displaySkillName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDisplayTarget_HomeAbbreviation(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("UserHomeDir unavailable")
+	}
+	in := filepath.Join(home, ".config", "claude", "claude_desktop_config.json")
+	got := displayTarget(in, 0)
+	if !strings.HasPrefix(got, "~") {
+		t.Errorf("expected ~-abbreviated path, got %q", got)
+	}
+	if got == in {
+		t.Errorf("expected substitution, got unchanged %q", got)
+	}
+}
+
+func TestDisplayTarget_NoTruncationUnderLimit(t *testing.T) {
+	got := displayTarget("/short/path.json", 60)
+	if got != "/short/path.json" {
+		t.Errorf("got %q, want unchanged", got)
+	}
+}
+
+func TestDisplayTarget_TruncatesLongPath(t *testing.T) {
+	long := "/opt/very/deeply/nested/directory/tree/with/many/segments/and/more/still/config.json"
+	got := displayTarget(long, 30)
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("expected leading ellipsis, got %q", got)
+	}
+	if !strings.HasSuffix(got, "config.json") {
+		t.Errorf("expected trailing filename, got %q", got)
+	}
+	// Must be shorter than the original.
+	if len(got) >= len(long) {
+		t.Errorf("truncation did not shorten path: %q (len %d) vs original len %d", got, len(got), len(long))
+	}
+}
+
+func TestDisplayTarget_SoftLimitZeroDisablesTruncation(t *testing.T) {
+	long := "/opt/very/deeply/nested/directory/tree/that/should/not/be/truncated.json"
+	got := displayTarget(long, 0)
+	if got != long {
+		t.Errorf("got %q, want unchanged (softLimit=0 should disable truncation)", got)
+	}
+}
+
+func TestDisplayTarget_EmptyStringUnchanged(t *testing.T) {
+	if got := displayTarget("", 60); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}

--- a/internal/engine/render/plan_text.go
+++ b/internal/engine/render/plan_text.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"strings"
 )
 
@@ -62,16 +63,23 @@ type planRow struct {
 	verb   string
 	name   string
 	detail string
+	action PlanAction // retained so sections can sort by action rank
 }
 
 // writeSection prints a section header and its rows with per-section
 // alignment: each verb is padded to the longest verb length in the section,
-// and each name to the longest display-name length.
+// and each name to the longest display-name length. Rows are stably sorted
+// so errors surface first, changed resources next, and no-ops sink to the
+// bottom.
 func (pr *planTextRenderer) writeSection(w io.Writer, title string, rows []planRow) {
 	if len(rows) == 0 {
 		return
 	}
 	fmt.Fprintf(w, "  %s\n", title)
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		return actionRank(rows[i].action) < actionRank(rows[j].action)
+	})
 
 	verbWidth, nameWidth := 0, 0
 	for _, r := range rows {
@@ -103,6 +111,7 @@ func (pr *planTextRenderer) writeRepos(w io.Writer, entries []PlanRepoEntry) {
 			verb:   planVerb(e.Action, "repo"),
 			name:   e.Path,
 			detail: repoPlanDetail(e),
+			action: e.Action,
 		})
 	}
 	pr.writeSection(w, "repositories", rows)
@@ -162,6 +171,7 @@ func buildSkillPlanRows(entries []PlanSkillEntry) []planRow {
 				verb:   planVerb(PlanError, "skill"),
 				name:   displaySkillName(e.Source),
 				detail: "(" + e.Error + ")",
+				action: PlanError,
 			})
 			continue
 		case PlanCreate:
@@ -193,6 +203,7 @@ func buildSkillPlanRows(entries []PlanSkillEntry) []planRow {
 			verb:   planVerb(k.action, "skill"),
 			name:   k.name,
 			detail: detail,
+			action: k.action,
 		})
 	}
 	return rows
@@ -209,9 +220,26 @@ func (pr *planTextRenderer) writeMCPs(w io.Writer, entries []PlanMCPEntry) {
 			verb:   planVerb(e.Action, "mcp"),
 			name:   e.Name,
 			detail: mcpPlanDetail(e),
+			action: e.Action,
 		})
 	}
 	pr.writeSection(w, "mcps", rows)
+}
+
+// actionRank orders plan actions within a section: errors first (most
+// urgent), then creates/updates, then no-ops (passive / already done).
+// Stable sorts preserve input order within each rank.
+func actionRank(a PlanAction) int {
+	switch a {
+	case PlanError:
+		return 0
+	case PlanClone, PlanCreate, PlanUpdate:
+		return 1
+	case PlanNoOp:
+		return 2
+	default:
+		return 3
+	}
 }
 
 // planMarker returns the one-character leading glyph for a plan action.

--- a/internal/engine/render/plan_text.go
+++ b/internal/engine/render/plan_text.go
@@ -7,36 +7,42 @@ import (
 	"strings"
 )
 
-// planTextRenderer implements PlanRenderer producing a compact, line-per-item
-// layout matching cli/sync.mdx:
+// planTextRenderer implements PlanRenderer producing a nested, indented
+// plan for `gaal sync --dry-run`, matching the format documented at
+// https://docs.getgaal.com/cli/sync:
 //
-//	✓ src/example          cloned
-//	✓ code-review          installed in claude-code, cursor
-//	✓ filesystem           upserted in claude_desktop_config.json
-//	sync complete in 1.2s
+//	plan:
+//	  repositories
+//	    + clone     src/example          (git, main)
+//	    ~ update    src/gaal             (git, main → main, 2 commits ahead)
+//	    = unchanged src/dataset
+//	  skills
+//	    + install   code-review          → claude-code, cursor
+//	    = unchanged refactor             → claude-code
+//	  mcps
+//	    + upsert    filesystem           → ~/.config/claude/claude_desktop_config.json
 //
-// For dry-run mode the trailing summary line is replaced with a status hint.
+// Verb and name column widths are computed per-section so each block stays
+// tight. Skill names use [displaySkillName]; MCP targets use [displayTarget]
+// with a soft length cap.
 type planTextRenderer struct{}
+
+// planTargetSoftLimit is the maximum visual length of an MCP target before
+// it gets truncated to "…/<last three segments>" in the plan renderer.
+const planTargetSoftLimit = 60
 
 func (pr *planTextRenderer) Render(w io.Writer, r *PlanReport) error {
 	slog.Debug("rendering plan text output")
 
-	items := collectPlanItems(r)
-	nameWidth := 0
-	for _, it := range items {
-		if n := len(it.name); n > nameWidth {
-			nameWidth = n
-		}
-	}
-
-	for _, it := range items {
-		fmt.Fprintf(w, "%s %s  %s\n", it.marker, padText(it.name, nameWidth), it.detail)
-	}
-
-	if len(items) == 0 {
+	if len(r.Repositories) == 0 && len(r.Skills) == 0 && len(r.MCPs) == 0 {
 		fmt.Fprintln(w, "nothing to do")
 		return nil
 	}
+
+	fmt.Fprintln(w, "plan:")
+	pr.writeRepos(w, r.Repositories)
+	pr.writeSkills(w, r.Skills)
+	pr.writeMCPs(w, r.MCPs)
 
 	switch {
 	case r.HasErrors:
@@ -49,44 +55,170 @@ func (pr *planTextRenderer) Render(w io.Writer, r *PlanReport) error {
 	return nil
 }
 
-type planTextItem struct {
+// planRow captures one rendered row: marker, verb, name, and an optional
+// post-name detail clause. All strings are pre-formatted for display.
+type planRow struct {
 	marker string
+	verb   string
 	name   string
 	detail string
 }
 
-func collectPlanItems(r *PlanReport) []planTextItem {
-	items := make([]planTextItem, 0,
-		len(r.Repositories)+len(r.Skills)+len(r.MCPs))
+// writeSection prints a section header and its rows with per-section
+// alignment: each verb is padded to the longest verb length in the section,
+// and each name to the longest display-name length.
+func (pr *planTextRenderer) writeSection(w io.Writer, title string, rows []planRow) {
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "  %s\n", title)
 
-	for _, e := range r.Repositories {
-		items = append(items, planTextItem{
-			marker: markerFor(e.Action),
+	verbWidth, nameWidth := 0, 0
+	for _, r := range rows {
+		if n := len(r.verb); n > verbWidth {
+			verbWidth = n
+		}
+		if n := len(r.name); n > nameWidth {
+			nameWidth = n
+		}
+	}
+
+	for _, r := range rows {
+		line := fmt.Sprintf("    %s %s %s", r.marker, padText(r.verb, verbWidth), padText(r.name, nameWidth))
+		if r.detail != "" {
+			line += "  " + r.detail
+		}
+		fmt.Fprintln(w, strings.TrimRight(line, " "))
+	}
+}
+
+func (pr *planTextRenderer) writeRepos(w io.Writer, entries []PlanRepoEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	rows := make([]planRow, 0, len(entries))
+	for _, e := range entries {
+		rows = append(rows, planRow{
+			marker: planMarker(e.Action),
+			verb:   planVerb(e.Action, "repo"),
 			name:   e.Path,
 			detail: repoPlanDetail(e),
 		})
 	}
-	for _, e := range r.Skills {
-		items = append(items, planTextItem{
-			marker: markerFor(e.Action),
-			name:   e.Source,
-			detail: skillPlanDetail(e),
+	pr.writeSection(w, "repositories", rows)
+}
+
+func (pr *planTextRenderer) writeSkills(w io.Writer, entries []PlanSkillEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	rows := buildSkillPlanRows(entries)
+	if len(rows) == 0 {
+		return
+	}
+	pr.writeSection(w, "skills", rows)
+}
+
+// buildSkillPlanRows pivots plan.Skills (keyed by source+agent) into one row
+// per skill name so the user sees "code-review → claude-code, cursor"
+// instead of two source-level lines. PlanError entries stay ungrouped since
+// no per-skill-name information is available.
+func buildSkillPlanRows(entries []PlanSkillEntry) []planRow {
+	type key struct {
+		name   string
+		action PlanAction
+	}
+	type bucket struct {
+		agents  []string
+		seen    map[string]struct{}
+		updates []string // e.g. "v1 → v2" strings accumulated for PlanUpdate
+	}
+	byKey := map[key]*bucket{}
+	var order []key
+
+	add := func(k key, agent string) {
+		b, ok := byKey[k]
+		if !ok {
+			b = &bucket{seen: map[string]struct{}{}}
+			byKey[k] = b
+			order = append(order, k)
+		}
+		if agent == "" {
+			return
+		}
+		if _, dup := b.seen[agent]; dup {
+			return
+		}
+		b.seen[agent] = struct{}{}
+		b.agents = append(b.agents, agent)
+	}
+
+	rows := make([]planRow, 0, len(entries))
+	for _, e := range entries {
+		switch e.Action {
+		case PlanError:
+			rows = append(rows, planRow{
+				marker: planMarker(PlanError),
+				verb:   planVerb(PlanError, "skill"),
+				name:   displaySkillName(e.Source),
+				detail: "(" + e.Error + ")",
+			})
+			continue
+		case PlanCreate:
+			for _, n := range e.Install {
+				add(key{n, PlanCreate}, e.Agent)
+			}
+			for _, n := range e.Update {
+				add(key{n, PlanUpdate}, e.Agent)
+			}
+		case PlanUpdate:
+			for _, n := range e.Update {
+				add(key{n, PlanUpdate}, e.Agent)
+			}
+		case PlanNoOp:
+			for _, n := range e.NoOp {
+				add(key{n, PlanNoOp}, e.Agent)
+			}
+		}
+	}
+
+	for _, k := range order {
+		b := byKey[k]
+		detail := ""
+		if len(b.agents) > 0 {
+			detail = "→ " + strings.Join(b.agents, ", ")
+		}
+		rows = append(rows, planRow{
+			marker: planMarker(k.action),
+			verb:   planVerb(k.action, "skill"),
+			name:   k.name,
+			detail: detail,
 		})
 	}
-	for _, e := range r.MCPs {
-		items = append(items, planTextItem{
-			marker: markerFor(e.Action),
+	return rows
+}
+
+func (pr *planTextRenderer) writeMCPs(w io.Writer, entries []PlanMCPEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	rows := make([]planRow, 0, len(entries))
+	for _, e := range entries {
+		rows = append(rows, planRow{
+			marker: planMarker(e.Action),
+			verb:   planVerb(e.Action, "mcp"),
 			name:   e.Name,
 			detail: mcpPlanDetail(e),
 		})
 	}
-	return items
+	pr.writeSection(w, "mcps", rows)
 }
 
-func markerFor(a PlanAction) string {
+// planMarker returns the one-character leading glyph for a plan action.
+func planMarker(a PlanAction) string {
 	switch a {
 	case PlanNoOp:
-		return "✓"
+		return "="
 	case PlanClone, PlanCreate:
 		return "+"
 	case PlanUpdate:
@@ -98,58 +230,88 @@ func markerFor(a PlanAction) string {
 	}
 }
 
-func repoPlanDetail(e PlanRepoEntry) string {
-	switch e.Action {
-	case PlanNoOp:
-		if e.Current != "" {
-			return "up to date (" + e.Current + ")"
-		}
-		return "up to date"
-	case PlanClone:
-		if e.URL != "" {
-			return "would clone " + e.URL
-		}
-		return "would clone"
-	case PlanUpdate:
-		return "would update " + e.Current + " → " + e.Want
-	case PlanError:
-		return "error: " + e.Error
-	default:
-		return string(e.Action)
+// planVerb returns the action verb for a plan row, specialised per resource
+// kind so repositories say "clone", skills say "install", and MCPs say
+// "upsert" for the create action.
+func planVerb(a PlanAction, kind string) string {
+	if a == PlanNoOp {
+		return "unchanged"
 	}
+	switch kind {
+	case "repo":
+		switch a {
+		case PlanClone:
+			return "clone"
+		case PlanUpdate:
+			return "update"
+		case PlanError:
+			return "error"
+		}
+	case "skill":
+		switch a {
+		case PlanCreate:
+			return "install"
+		case PlanUpdate:
+			return "update"
+		case PlanError:
+			return "error"
+		}
+	case "mcp":
+		switch a {
+		case PlanCreate:
+			return "upsert"
+		case PlanUpdate:
+			return "update"
+		case PlanError:
+			return "error"
+		}
+	}
+	return string(a)
 }
 
-func skillPlanDetail(e PlanSkillEntry) string {
+func repoPlanDetail(e PlanRepoEntry) string {
 	switch e.Action {
-	case PlanNoOp:
-		return "installed in " + e.Agent
-	case PlanCreate:
-		names := append([]string{}, e.Install...)
-		names = append(names, e.Update...)
-		if len(names) == 0 {
-			return "would install in " + e.Agent
+	case PlanClone:
+		parts := []string{}
+		if e.Type != "" {
+			parts = append(parts, e.Type)
 		}
-		return "would install " + strings.Join(names, ", ") + " in " + e.Agent
+		if e.Want != "" {
+			parts = append(parts, e.Want)
+		} else if e.URL != "" {
+			parts = append(parts, e.URL)
+		}
+		if len(parts) == 0 {
+			return ""
+		}
+		return "(" + strings.Join(parts, ", ") + ")"
 	case PlanUpdate:
-		return "would update " + strings.Join(e.Update, ", ") + " in " + e.Agent
+		parts := []string{}
+		if e.Type != "" {
+			parts = append(parts, e.Type)
+		}
+		if e.Current != "" || e.Want != "" {
+			parts = append(parts, e.Current+" → "+e.Want)
+		}
+		if len(parts) == 0 {
+			return ""
+		}
+		return "(" + strings.Join(parts, ", ") + ")"
 	case PlanError:
-		return "error: " + e.Error
+		return "(" + e.Error + ")"
 	default:
-		return string(e.Action)
+		return ""
 	}
 }
 
 func mcpPlanDetail(e PlanMCPEntry) string {
 	switch e.Action {
-	case PlanNoOp:
-		return "upserted in " + e.Target
-	case PlanCreate:
-		return "would upsert in " + e.Target
-	case PlanUpdate:
-		return "would update in " + e.Target
 	case PlanError:
-		return "error: " + e.Error
+		return "(" + e.Error + ")"
 	default:
-		return string(e.Action)
+		if e.Target == "" {
+			return ""
+		}
+		return "→ " + displayTarget(e.Target, planTargetSoftLimit)
 	}
 }

--- a/internal/engine/render/plan_text_test.go
+++ b/internal/engine/render/plan_text_test.go
@@ -1,0 +1,136 @@
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPlanText_EmptyPlan(t *testing.T) {
+	var buf bytes.Buffer
+	pr := &planTextRenderer{}
+	if err := pr.Render(&buf, &PlanReport{}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "nothing to do") {
+		t.Errorf("expected 'nothing to do', got:\n%s", out)
+	}
+}
+
+func TestPlanText_NestedStructure(t *testing.T) {
+	var buf bytes.Buffer
+	pr := &planTextRenderer{}
+	report := &PlanReport{
+		Repositories: []PlanRepoEntry{
+			{Path: "src/example", Type: "git", Action: PlanClone, Want: "main"},
+			{Path: "src/dataset", Type: "git", Action: PlanNoOp},
+		},
+		Skills: []PlanSkillEntry{
+			{Source: "owner/code-review", Agent: "claude-code", Action: PlanCreate, Install: []string{"code-review"}},
+			{Source: "owner/code-review", Agent: "cursor", Action: PlanCreate, Install: []string{"code-review"}},
+		},
+		MCPs: []PlanMCPEntry{
+			{Name: "filesystem", Target: "/Users/test/.config/claude/claude_desktop_config.json", Action: PlanCreate},
+		},
+		HasChanges: true,
+	}
+	if err := pr.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"plan:",
+		"  repositories",
+		"  skills",
+		"  mcps",
+		"+ clone",
+		"= unchanged",
+		"src/example",
+		"src/dataset",
+		"claude_desktop_config.json",
+		"changes pending",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan output missing %q, full output:\n%s", want, out)
+		}
+	}
+}
+
+func TestPlanText_VerbAndNameAlignmentPerSection(t *testing.T) {
+	var buf bytes.Buffer
+	pr := &planTextRenderer{}
+	report := &PlanReport{
+		Repositories: []PlanRepoEntry{
+			{Path: "short", Type: "git", Action: PlanClone, Want: "main"},
+			{Path: "a-much-longer-path", Type: "git", Action: PlanUpdate, Current: "v1", Want: "v2"},
+			{Path: "unchanged-path", Type: "git", Action: PlanNoOp},
+		},
+		HasChanges: true,
+	}
+	if err := pr.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	// All three repo lines should line up the name column at the same visual
+	// offset. Extract the three data rows under "  repositories".
+	lines := strings.Split(buf.String(), "\n")
+	var repoLines []string
+	inRepo := false
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "repositories" {
+			inRepo = true
+			continue
+		}
+		if inRepo {
+			if strings.HasPrefix(strings.TrimSpace(l), "+") ||
+				strings.HasPrefix(strings.TrimSpace(l), "~") ||
+				strings.HasPrefix(strings.TrimSpace(l), "=") {
+				repoLines = append(repoLines, l)
+			} else if !strings.HasPrefix(l, "    ") {
+				break
+			}
+		}
+	}
+	if len(repoLines) != 3 {
+		t.Fatalf("expected 3 repo lines, got %d:\n%s", len(repoLines), strings.Join(repoLines, "\n"))
+	}
+	// The name "short" must appear at the same column as "a-much-longer-path"
+	// and "unchanged-path". Locate each.
+	find := func(line, name string) int { return strings.Index(line, name) }
+	p0 := find(repoLines[0], "short")
+	p1 := find(repoLines[1], "a-much-longer-path")
+	p2 := find(repoLines[2], "unchanged-path")
+	if p0 == -1 || p1 == -1 || p2 == -1 {
+		t.Fatalf("missing name in one of: %q / %q / %q", repoLines[0], repoLines[1], repoLines[2])
+	}
+	if !(p0 == p1 && p1 == p2) {
+		t.Errorf("name column not aligned: %d / %d / %d\n%s", p0, p1, p2, strings.Join(repoLines, "\n"))
+	}
+}
+
+func TestPlanText_SkillNameUsesBasenameForLocalSource(t *testing.T) {
+	var buf bytes.Buffer
+	pr := &planTextRenderer{}
+	report := &PlanReport{
+		Skills: []PlanSkillEntry{
+			{
+				Source:  "/deeply/nested/plugins/cache/my-skill",
+				Agent:   "claude-code",
+				Action:  PlanCreate,
+				Install: []string{"my-skill"},
+			},
+		},
+		HasChanges: true,
+	}
+	if err := pr.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	// The long source path should not appear; the basename should.
+	if strings.Contains(out, "/deeply/nested/plugins/cache/my-skill") {
+		t.Errorf("output leaks full source path:\n%s", out)
+	}
+	if !strings.Contains(out, "my-skill") {
+		t.Errorf("output missing basename 'my-skill':\n%s", out)
+	}
+}

--- a/internal/engine/render/plan_text_test.go
+++ b/internal/engine/render/plan_text_test.go
@@ -108,6 +108,40 @@ func TestPlanText_VerbAndNameAlignmentPerSection(t *testing.T) {
 	}
 }
 
+func TestPlanText_NoOpsAppearLastWithinSection(t *testing.T) {
+	var buf bytes.Buffer
+	pr := &planTextRenderer{}
+	report := &PlanReport{
+		Repositories: []PlanRepoEntry{
+			{Path: "unchanged-a", Type: "git", Action: PlanNoOp},
+			{Path: "changed-b", Type: "git", Action: PlanClone, Want: "main"},
+			{Path: "unchanged-c", Type: "git", Action: PlanNoOp},
+			{Path: "updated-d", Type: "git", Action: PlanUpdate, Current: "v1", Want: "v2"},
+		},
+		HasChanges: true,
+	}
+	if err := pr.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+
+	changedB := strings.Index(out, "changed-b")
+	updatedD := strings.Index(out, "updated-d")
+	unchangedA := strings.Index(out, "unchanged-a")
+	unchangedC := strings.Index(out, "unchanged-c")
+	if changedB < 0 || updatedD < 0 || unchangedA < 0 || unchangedC < 0 {
+		t.Fatalf("one or more rows missing from output:\n%s", out)
+	}
+	if !(changedB < unchangedA && updatedD < unchangedA) {
+		t.Errorf("expected change actions before no-ops; got offsets: changed-b=%d updated-d=%d unchanged-a=%d unchanged-c=%d\n%s",
+			changedB, updatedD, unchangedA, unchangedC, out)
+	}
+	// Stable within each rank: unchanged-a appeared before unchanged-c in input.
+	if !(unchangedA < unchangedC) {
+		t.Errorf("expected stable input order within no-op rank; got a=%d c=%d", unchangedA, unchangedC)
+	}
+}
+
 func TestPlanText_SkillNameUsesBasenameForLocalSource(t *testing.T) {
 	var buf bytes.Buffer
 	pr := &planTextRenderer{}

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -110,12 +110,16 @@ type PlanRepoEntry struct {
 }
 
 // PlanSkillEntry describes the planned action for a single skill config.
+// Install, Update, and NoOp together enumerate every skill name the entry
+// covers — they are disjoint lists that let the plan renderer aggregate
+// rows by skill name across (source, agent) pairs.
 type PlanSkillEntry struct {
 	Source  string     `json:"source"`
 	Agent   string     `json:"agent"`
 	Action  PlanAction `json:"action"`
 	Install []string   `json:"install,omitempty"`
 	Update  []string   `json:"update,omitempty"`
+	NoOp    []string   `json:"no_op,omitempty"`
 	Error   string     `json:"error,omitempty"`
 }
 

--- a/internal/engine/render/sync_text.go
+++ b/internal/engine/render/sync_text.go
@@ -45,6 +45,7 @@ type syncRow struct {
 	marker string
 	name   string
 	detail string
+	action PlanAction // retained so rows sort with no-ops at the bottom
 }
 
 func collectSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
@@ -55,60 +56,96 @@ func collectSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
 		status = &StatusReport{}
 	}
 
-	var rows []syncRow
+	// Each resource type is built and sorted independently so no-ops sink
+	// to the bottom of their own group without interleaving across groups.
+	repoRows := buildRepoSyncRows(plan, status)
+	skillRows := buildSkillSyncRows(plan, status)
+	mcpRows := buildMCPSyncRows(plan, status)
 
-	// Repositories — one row per repo, alphabetised by path.
-	repoActions := make(map[string]PlanAction, len(plan.Repositories))
-	repoErrors := make(map[string]string, len(plan.Repositories))
-	for _, r := range plan.Repositories {
-		repoActions[r.Path] = r.Action
-		repoErrors[r.Path] = r.Error
+	sortByAction := func(rows []syncRow) {
+		sort.SliceStable(rows, func(i, j int) bool {
+			return actionRank(rows[i].action) < actionRank(rows[j].action)
+		})
 	}
-	repoEntries := append([]RepoEntry(nil), status.Repositories...)
-	sort.Slice(repoEntries, func(i, j int) bool { return repoEntries[i].Path < repoEntries[j].Path })
-	for _, e := range repoEntries {
-		action := repoActions[e.Path]
+	sortByAction(repoRows)
+	sortByAction(skillRows)
+	sortByAction(mcpRows)
+
+	out := make([]syncRow, 0, len(repoRows)+len(skillRows)+len(mcpRows))
+	out = append(out, repoRows...)
+	out = append(out, skillRows...)
+	out = append(out, mcpRows...)
+	return out
+}
+
+func buildRepoSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
+	actions := make(map[string]PlanAction, len(plan.Repositories))
+	errs := make(map[string]string, len(plan.Repositories))
+	for _, r := range plan.Repositories {
+		actions[r.Path] = r.Action
+		errs[r.Path] = r.Error
+	}
+	entries := append([]RepoEntry(nil), status.Repositories...)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+
+	rows := make([]syncRow, 0, len(entries))
+	for _, e := range entries {
+		action := actions[e.Path]
 		if action == "" {
 			action = PlanNoOp
 		}
 		rows = append(rows, syncRow{
 			marker: summaryMarker(e.Status),
 			name:   e.Path,
-			detail: repoSyncDetail(action, e, repoErrors[e.Path]),
+			detail: repoSyncDetail(action, e, errs[e.Path]),
+			action: action,
 		})
 	}
+	return rows
+}
 
-	// Skills — aggregate by name and pair with the plan's per-skill action.
+func buildSkillSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
 	skillActions := skillActionIndex(plan.Skills)
-	for _, s := range aggregateSkillsByName(status.Skills) {
+	aggregated := aggregateSkillsByName(status.Skills)
+	rows := make([]syncRow, 0, len(aggregated))
+	for _, s := range aggregated {
+		action := skillActions[s.Name]
+		if action == "" {
+			action = PlanNoOp
+		}
 		rows = append(rows, syncRow{
 			marker: summaryMarker(s.Status),
 			name:   displayName(s.Name),
-			detail: skillSyncDetail(skillActions[s.Name], s),
+			detail: skillSyncDetail(action, s),
+			action: action,
 		})
 	}
+	return rows
+}
 
-	// MCPs — alphabetised by name, basename-only for the target path.
-	mcpActions := make(map[string]PlanAction, len(plan.MCPs))
-	mcpErrors := make(map[string]string, len(plan.MCPs))
+func buildMCPSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
+	actions := make(map[string]PlanAction, len(plan.MCPs))
+	errs := make(map[string]string, len(plan.MCPs))
 	for _, m := range plan.MCPs {
-		mcpActions[m.Name] = m.Action
-		mcpErrors[m.Name] = m.Error
+		actions[m.Name] = m.Action
+		errs[m.Name] = m.Error
 	}
-	mcpEntries := append([]MCPEntry(nil), status.MCPs...)
-	sort.Slice(mcpEntries, func(i, j int) bool { return mcpEntries[i].Name < mcpEntries[j].Name })
-	for _, e := range mcpEntries {
-		action := mcpActions[e.Name]
+	entries := append([]MCPEntry(nil), status.MCPs...)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+
+	rows := make([]syncRow, 0, len(entries))
+	for _, e := range entries {
+		action := actions[e.Name]
 		if action == "" {
 			action = PlanNoOp
 		}
 		rows = append(rows, syncRow{
 			marker: summaryMarker(e.Status),
 			name:   e.Name,
-			detail: mcpSyncDetail(action, e, mcpErrors[e.Name]),
+			detail: mcpSyncDetail(action, e, errs[e.Name]),
+			action: action,
 		})
 	}
-
 	return rows
 }
 

--- a/internal/engine/render/sync_text.go
+++ b/internal/engine/render/sync_text.go
@@ -1,0 +1,202 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RenderSyncSummary writes the compact per-resource sync summary documented
+// at https://docs.getgaal.com/cli/sync. Each line carries a ✓ (or ✗ on
+// error) marker, the resource name padded to the longest in the summary,
+// and a past-tense action description derived from the pre-sync plan. A
+// final "sync complete in <d>" line closes the output.
+//
+// Plan provides the "what sync did" verbs (cloned / updated / up to date /
+// installed / upserted). Status provides the post-sync state used to pick
+// the marker and — for skills — expand per-(source, agent) entries into
+// per-skill-name rows with agent lists.
+func RenderSyncSummary(w io.Writer, plan *PlanReport, status *StatusReport, duration time.Duration) error {
+	slog.Debug("rendering sync summary")
+
+	rows := collectSyncRows(plan, status)
+	if len(rows) == 0 {
+		fmt.Fprintln(w, "nothing to sync")
+	} else {
+		nameWidth := 0
+		for _, r := range rows {
+			if n := len(r.name); n > nameWidth {
+				nameWidth = n
+			}
+		}
+		for _, r := range rows {
+			fmt.Fprintf(w, "%s %s  %s\n", r.marker, padText(r.name, nameWidth), r.detail)
+		}
+	}
+	fmt.Fprintf(w, "sync complete in %s\n", duration.Round(time.Millisecond))
+	return nil
+}
+
+type syncRow struct {
+	marker string
+	name   string
+	detail string
+}
+
+func collectSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
+	if plan == nil {
+		plan = &PlanReport{}
+	}
+	if status == nil {
+		status = &StatusReport{}
+	}
+
+	var rows []syncRow
+
+	// Repositories — one row per repo, alphabetised by path.
+	repoActions := make(map[string]PlanAction, len(plan.Repositories))
+	repoErrors := make(map[string]string, len(plan.Repositories))
+	for _, r := range plan.Repositories {
+		repoActions[r.Path] = r.Action
+		repoErrors[r.Path] = r.Error
+	}
+	repoEntries := append([]RepoEntry(nil), status.Repositories...)
+	sort.Slice(repoEntries, func(i, j int) bool { return repoEntries[i].Path < repoEntries[j].Path })
+	for _, e := range repoEntries {
+		action := repoActions[e.Path]
+		if action == "" {
+			action = PlanNoOp
+		}
+		rows = append(rows, syncRow{
+			marker: summaryMarker(e.Status),
+			name:   e.Path,
+			detail: repoSyncDetail(action, e, repoErrors[e.Path]),
+		})
+	}
+
+	// Skills — aggregate by name and pair with the plan's per-skill action.
+	skillActions := skillActionIndex(plan.Skills)
+	for _, s := range aggregateSkillsByName(status.Skills) {
+		rows = append(rows, syncRow{
+			marker: summaryMarker(s.Status),
+			name:   displayName(s.Name),
+			detail: skillSyncDetail(skillActions[s.Name], s),
+		})
+	}
+
+	// MCPs — alphabetised by name, basename-only for the target path.
+	mcpActions := make(map[string]PlanAction, len(plan.MCPs))
+	mcpErrors := make(map[string]string, len(plan.MCPs))
+	for _, m := range plan.MCPs {
+		mcpActions[m.Name] = m.Action
+		mcpErrors[m.Name] = m.Error
+	}
+	mcpEntries := append([]MCPEntry(nil), status.MCPs...)
+	sort.Slice(mcpEntries, func(i, j int) bool { return mcpEntries[i].Name < mcpEntries[j].Name })
+	for _, e := range mcpEntries {
+		action := mcpActions[e.Name]
+		if action == "" {
+			action = PlanNoOp
+		}
+		rows = append(rows, syncRow{
+			marker: summaryMarker(e.Status),
+			name:   e.Name,
+			detail: mcpSyncDetail(action, e, mcpErrors[e.Name]),
+		})
+	}
+
+	return rows
+}
+
+// skillActionIndex flattens plan.Skills into a per-skill-name action lookup.
+// A skill in Install -> PlanCreate; a skill in Update -> PlanUpdate (which
+// overrides an earlier Create recorded from a different (source, agent)
+// entry). Skills that appear only in no-op plan entries are absent from the
+// index, which callers treat as PlanNoOp.
+func skillActionIndex(entries []PlanSkillEntry) map[string]PlanAction {
+	actions := make(map[string]PlanAction)
+	for _, e := range entries {
+		for _, n := range e.Install {
+			if _, seen := actions[n]; !seen {
+				actions[n] = PlanCreate
+			}
+		}
+		for _, n := range e.Update {
+			actions[n] = PlanUpdate
+		}
+	}
+	return actions
+}
+
+func summaryMarker(s StatusCode) string {
+	if s == StatusError {
+		return "✗"
+	}
+	return "✓"
+}
+
+func repoSyncDetail(a PlanAction, e RepoEntry, planErr string) string {
+	switch a {
+	case PlanClone:
+		return "cloned"
+	case PlanUpdate:
+		return "updated"
+	case PlanError:
+		return "error: " + firstNonEmpty(e.Error, planErr)
+	}
+	if e.Status == StatusError {
+		return "error: " + firstNonEmpty(e.Error, planErr)
+	}
+	return "up to date"
+}
+
+func skillSyncDetail(a PlanAction, s aggregatedSkill) string {
+	agents := "no agents"
+	if len(s.Agents) > 0 {
+		agents = strings.Join(s.Agents, ", ")
+	}
+	switch a {
+	case PlanCreate:
+		return "installed in " + agents
+	case PlanUpdate:
+		return "updated in " + agents
+	case PlanError:
+		return "error: " + s.Error
+	}
+	if s.Status == StatusError {
+		return "error: " + s.Error
+	}
+	return "up to date in " + agents
+}
+
+func mcpSyncDetail(a PlanAction, e MCPEntry, planErr string) string {
+	target := filepath.Base(e.Target)
+	if target == "" {
+		target = e.Target
+	}
+	switch a {
+	case PlanCreate:
+		return "upserted in " + target
+	case PlanUpdate:
+		return "updated in " + target
+	case PlanError:
+		return "error: " + firstNonEmpty(e.Error, planErr)
+	}
+	if e.Status == StatusError {
+		return "error: " + firstNonEmpty(e.Error, planErr)
+	}
+	return "up to date in " + target
+}
+
+func firstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/engine/render/sync_text_test.go
+++ b/internal/engine/render/sync_text_test.go
@@ -1,0 +1,173 @@
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderSyncSummary_DocsFormat(t *testing.T) {
+	// Matches the canonical docs example:
+	//   ✓ src/example          cloned
+	//   ✓ code-review          installed in claude-code, cursor
+	//   ✓ filesystem           upserted in claude_desktop_config.json
+	//   sync complete in 1.2s
+	plan := &PlanReport{
+		Repositories: []PlanRepoEntry{
+			{Path: "src/example", Action: PlanClone},
+		},
+		Skills: []PlanSkillEntry{
+			{Source: "owner/code-review", Agent: "claude-code", Action: PlanCreate, Install: []string{"code-review"}},
+			{Source: "owner/code-review", Agent: "cursor", Action: PlanCreate, Install: []string{"code-review"}},
+		},
+		MCPs: []PlanMCPEntry{
+			{Name: "filesystem", Target: "/home/user/.config/claude/claude_desktop_config.json", Action: PlanCreate},
+		},
+	}
+	status := &StatusReport{
+		Repositories: []RepoEntry{
+			{Path: "src/example", Status: StatusOK},
+		},
+		Skills: []SkillEntry{
+			{Source: "owner/code-review", Agent: "claude-code", Status: StatusOK, Installed: []string{"code-review"}},
+			{Source: "owner/code-review", Agent: "cursor", Status: StatusOK, Installed: []string{"code-review"}},
+		},
+		MCPs: []MCPEntry{
+			{Name: "filesystem", Status: StatusPresent, Target: "/home/user/.config/claude/claude_desktop_config.json"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := RenderSyncSummary(&buf, plan, status, 1200*time.Millisecond); err != nil {
+		t.Fatalf("RenderSyncSummary: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"✓ src/example",
+		"cloned",
+		"✓ code-review",
+		"installed in claude-code, cursor",
+		"✓ filesystem",
+		"upserted in claude_desktop_config.json",
+		"sync complete in 1.2s",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderSyncSummary_NoOpShowsUpToDate(t *testing.T) {
+	plan := &PlanReport{
+		Repositories: []PlanRepoEntry{{Path: "src/example", Action: PlanNoOp}},
+		Skills: []PlanSkillEntry{
+			{Source: "owner/repo", Agent: "claude-code", Action: PlanNoOp},
+		},
+		MCPs: []PlanMCPEntry{{Name: "filesystem", Target: "/x/claude_desktop_config.json", Action: PlanNoOp}},
+	}
+	status := &StatusReport{
+		Repositories: []RepoEntry{{Path: "src/example", Status: StatusOK}},
+		Skills: []SkillEntry{
+			{Source: "owner/repo", Agent: "claude-code", Status: StatusOK, Installed: []string{"already-there"}},
+		},
+		MCPs: []MCPEntry{{Name: "filesystem", Target: "/x/claude_desktop_config.json", Status: StatusPresent}},
+	}
+	var buf bytes.Buffer
+	if err := RenderSyncSummary(&buf, plan, status, 50*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "up to date") {
+		t.Errorf("expected 'up to date' for no-op, got:\n%s", out)
+	}
+}
+
+func TestRenderSyncSummary_MCPTargetShowsBasename(t *testing.T) {
+	plan := &PlanReport{
+		MCPs: []PlanMCPEntry{{Name: "filesystem", Target: "/deeply/nested/path/claude_desktop_config.json", Action: PlanCreate}},
+	}
+	status := &StatusReport{
+		MCPs: []MCPEntry{{Name: "filesystem", Target: "/deeply/nested/path/claude_desktop_config.json", Status: StatusPresent}},
+	}
+	var buf bytes.Buffer
+	if err := RenderSyncSummary(&buf, plan, status, 0); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "/deeply/nested/path") {
+		t.Errorf("output leaks full MCP target path:\n%s", out)
+	}
+	if !strings.Contains(out, "claude_desktop_config.json") {
+		t.Errorf("basename missing from output:\n%s", out)
+	}
+}
+
+func TestRenderSyncSummary_ErrorMarker(t *testing.T) {
+	plan := &PlanReport{
+		Repositories: []PlanRepoEntry{{Path: "src/broken", Action: PlanError, Error: "fetch failed"}},
+	}
+	status := &StatusReport{
+		Repositories: []RepoEntry{{Path: "src/broken", Status: StatusError, Error: "fetch failed"}},
+	}
+	var buf bytes.Buffer
+	if err := RenderSyncSummary(&buf, plan, status, 0); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "✗") {
+		t.Errorf("expected ✗ marker for error, got:\n%s", out)
+	}
+	if !strings.Contains(out, "fetch failed") {
+		t.Errorf("expected error message in output, got:\n%s", out)
+	}
+}
+
+func TestRenderSyncSummary_EmptySummaryPrintsCompleteLine(t *testing.T) {
+	var buf bytes.Buffer
+	if err := RenderSyncSummary(&buf, &PlanReport{}, &StatusReport{}, 100*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "nothing to sync") {
+		t.Errorf("expected 'nothing to sync', got:\n%s", out)
+	}
+	if !strings.Contains(out, "sync complete in") {
+		t.Errorf("expected trailing 'sync complete in', got:\n%s", out)
+	}
+}
+
+func TestRenderSyncSummary_NameColumnAlignment(t *testing.T) {
+	plan := &PlanReport{
+		Repositories: []PlanRepoEntry{{Path: "a", Action: PlanClone}},
+		MCPs:         []PlanMCPEntry{{Name: "much-longer-name", Target: "/x/config.json", Action: PlanCreate}},
+	}
+	status := &StatusReport{
+		Repositories: []RepoEntry{{Path: "a", Status: StatusOK}},
+		MCPs:         []MCPEntry{{Name: "much-longer-name", Target: "/x/config.json", Status: StatusPresent}},
+	}
+	var buf bytes.Buffer
+	if err := RenderSyncSummary(&buf, plan, status, 0); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	// Find the "a" line and the "much-longer-name" line. Their detail ("cloned"
+	// and "upserted in …") should start at the same column because the
+	// renderer pads names to the widest name in the summary.
+	var aLine, mLine string
+	for _, l := range lines {
+		if strings.Contains(l, " a ") || strings.HasSuffix(l, " a  cloned") {
+			aLine = l
+		}
+		if strings.Contains(l, "much-longer-name") {
+			mLine = l
+		}
+	}
+	if aLine == "" || mLine == "" {
+		t.Fatalf("could not find both rows in:\n%s", buf.String())
+	}
+	aDetail := strings.Index(aLine, "cloned")
+	mDetail := strings.Index(mLine, "upserted")
+	if aDetail != mDetail {
+		t.Errorf("detail column not aligned: a=%d, m=%d\n%s", aDetail, mDetail, buf.String())
+	}
+}

--- a/internal/engine/render/sync_text_test.go
+++ b/internal/engine/render/sync_text_test.go
@@ -122,6 +122,54 @@ func TestRenderSyncSummary_ErrorMarker(t *testing.T) {
 	}
 }
 
+func TestRenderSyncSummary_NoOpsSinkToBottomOfTheirGroup(t *testing.T) {
+	plan := &PlanReport{
+		Repositories: []PlanRepoEntry{
+			{Path: "changed-repo", Action: PlanClone},
+			{Path: "unchanged-repo", Action: PlanNoOp},
+		},
+		MCPs: []PlanMCPEntry{
+			{Name: "unchanged-mcp", Target: "/x/a.json", Action: PlanNoOp},
+			{Name: "changed-mcp", Target: "/x/b.json", Action: PlanCreate},
+		},
+	}
+	status := &StatusReport{
+		Repositories: []RepoEntry{
+			{Path: "changed-repo", Status: StatusOK},
+			{Path: "unchanged-repo", Status: StatusOK},
+		},
+		MCPs: []MCPEntry{
+			{Name: "unchanged-mcp", Target: "/x/a.json", Status: StatusPresent},
+			{Name: "changed-mcp", Target: "/x/b.json", Status: StatusPresent},
+		},
+	}
+	var buf bytes.Buffer
+	if err := RenderSyncSummary(&buf, plan, status, 0); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+
+	// Within repositories: change action must come before the no-op.
+	// Within MCPs: same rule, independent of repo ordering.
+	changedRepo := strings.Index(out, "changed-repo")
+	unchangedRepo := strings.Index(out, "unchanged-repo")
+	changedMCP := strings.Index(out, "changed-mcp")
+	unchangedMCP := strings.Index(out, "unchanged-mcp")
+	if changedRepo < 0 || unchangedRepo < 0 || changedMCP < 0 || unchangedMCP < 0 {
+		t.Fatalf("missing row in output:\n%s", out)
+	}
+	if !(changedRepo < unchangedRepo) {
+		t.Errorf("expected changed-repo above unchanged-repo, got %d vs %d\n%s", changedRepo, unchangedRepo, out)
+	}
+	if !(changedMCP < unchangedMCP) {
+		t.Errorf("expected changed-mcp above unchanged-mcp, got %d vs %d\n%s", changedMCP, unchangedMCP, out)
+	}
+	// Groups must not interleave: all repos come before all MCPs.
+	if !(unchangedRepo < changedMCP) {
+		t.Errorf("MCP rows interleaved with repo rows:\n%s", out)
+	}
+}
+
 func TestRenderSyncSummary_EmptySummaryPrintsCompleteLine(t *testing.T) {
 	var buf bytes.Buffer
 	if err := RenderSyncSummary(&buf, &PlanReport{}, &StatusReport{}, 100*time.Millisecond); err != nil {

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -259,7 +259,7 @@ func mergeIntoTarget(target, name string, entry serverEntry) error {
 		return fmt.Errorf("writing config %s: %w", target, err)
 	}
 
-	slog.Info("mcp config updated", "name", name, "target", target)
+	slog.Debug("mcp config updated", "name", name, "target", target)
 	return nil
 }
 

--- a/internal/repo/manager.go
+++ b/internal/repo/manager.go
@@ -74,11 +74,11 @@ func (m *Manager) syncOne(ctx context.Context, path string, cfg config.ConfigRep
 	}
 
 	if !backend.IsCloned(path) {
-		slog.Info("cloning repository", "path", path, "url", cfg.URL, "version", cfg.Version)
+		slog.Debug("cloning repository", "path", path, "url", cfg.URL, "version", cfg.Version)
 		return backend.Clone(ctx, cfg.URL, path, cfg.Version)
 	}
 
-	slog.Info("updating repository", "path", path)
+	slog.Debug("updating repository", "path", path)
 	return backend.Update(ctx, path, cfg.Version)
 }
 

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -162,7 +162,7 @@ func (m *Manager) syncOne(ctx context.Context, sc config.ConfigSkill) error {
 			if err := installSkill(sk.Dir, dest); err != nil {
 				return fmt.Errorf("installing skill %q to agent %q: %w", sk.Name, agent, err)
 			}
-			slog.Info("installed skill", "name", sk.Name, "agent", agent, "dest", dest)
+			slog.Debug("installed skill", "name", sk.Name, "agent", agent, "dest", dest)
 			m.writeSkillSnapshot(dest)
 		}
 	}
@@ -201,12 +201,12 @@ func (m *Manager) resolveSource(ctx context.Context, source string) (string, err
 	}
 
 	if !backend.IsCloned(localPath) {
-		slog.Info("cloning skill source", "url", cloneURL, "path", localPath)
+		slog.Debug("cloning skill source", "url", cloneURL, "path", localPath)
 		if err := backend.Clone(ctx, cloneURL, localPath, ""); err != nil {
 			return "", fmt.Errorf("cloning %s: %w", cloneURL, err)
 		}
 	} else {
-		slog.Info("updating skill source", "path", localPath)
+		slog.Debug("updating skill source", "path", localPath)
 		if err := backend.Update(ctx, localPath, ""); err != nil {
 			slog.Warn("could not update skill source", "path", localPath, "err", err)
 		}


### PR DESCRIPTION
Rewires \`gaal sync\` so the on-screen output actually matches the format documented at [docs.getgaal.com/cli/sync](https://docs.getgaal.com/cli/sync), and rebuilds \`gaal sync --dry-run\` into a nested plan layout.

## \`gaal sync\` — compact per-resource summary

After a successful \`RunOnce\`, the command now prints:

\`\`\`
✓ src/example          cloned
✓ code-review          installed in claude-code, cursor
✓ filesystem           upserted in claude_desktop_config.json
sync complete in 1.2s
\`\`\`

- Skill rows aggregate by **skill name** across (source, agent) pairs — one line per skill, agents comma-joined
- MCP rows show the target **file basename**, not the full path
- Failures use \`✗\` with an \`error: …\` suffix
- Global name-column alignment so \`cloned\` / \`installed in …\` / \`upserted in …\` line up

## \`gaal sync --dry-run\` — nested plan

\`\`\`
plan:
  repositories
    + clone     src/example          (git, main)
    ~ update    src/gaal             (git, main → default)
    = unchanged src/dataset
  skills
    + install   code-review          → claude-code, cursor
    = unchanged refactor             → claude-code
  mcps
    + upsert    filesystem           → ~/.config/claude/claude_desktop_config.json
\`\`\`

- \`plan:\` header, three indented sections (\`repositories\`, \`skills\`, \`mcps\`)
- Per-section verb and name alignment so each block stays visually tight
- Skills aggregate by name: a new \`NoOp []string\` field on \`PlanSkillEntry\` preserves no-op skill names from the pre-sync status report so they can be grouped alongside \`Install\` / \`Update\` entries
- Deep local skill sources (Claude Code plugin cache, vendored skills) collapse to their last path segment via a new \`displaySkillName\` helper
- MCP targets get \`\$HOME → ~\` substitution and a soft 60-char truncation (\`…/last/three/segments\`) via a new \`displayTarget\` helper

## Quieter default output

Chatty \`slog.Info\` calls in the sync path (\`sync started\`, \`syncing repositories count=N\`, \`cloning repository\`, \`installed skill\`, \`mcp config updated\`, etc.) are demoted to \`slog.Debug\`. Default \`gaal sync\` output is the summary only; pass \`-v\` / \`--verbose\` to resurface the detail. Warnings and errors still log at their original levels.

## Test plan

- [x] \`go test ./...\` — 750 tests pass (22 new across \`display_test.go\`, \`plan_text_test.go\`, \`sync_text_test.go\`)
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] Manual: \`gaal --config sample.yaml sync --dry-run\` produces nested plan; per-section alignment preserved; deep skill paths collapsed to basename; MCP targets \`~\`-abbreviated
- [x] Manual: summary renderer unit tests exercise the exact docs example (\`cloned\`, \`installed in …\`, \`upserted in …\`, trailing \`sync complete in 1.2s\`)

## Notes

- Added \`Engine.Plan(ctx)\` — exposes the existing \`ops.SyncPlan\` for the cmd layer so it can compute the plan once before \`RunOnce\`, then reuse it for the summary
- \`PlanSkillEntry.NoOp\` is JSON-tagged (\`no_op\`), so \`gaal sync --dry-run -o json\` consumers now see which skills are already installed