### PR TITLE
ci: migrate to GitHub-hosted runners, expand platform coverage

### DIFF
--- a/.github/workflows/ci-selfhosted.yml
+++ b/.github/workflows/ci-selfhosted.yml
@@ -1,0 +1,123 @@
+name: CI (self-hosted)
+
+# Manual-only workflow for running the full CI suite on internal self-hosted
+# runners. Useful for validating platform-specific behaviour or testing on
+# private infrastructure without consuming GitHub-hosted runner minutes.
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for triggering self-hosted CI'
+        required: false
+        default: 'Manual validation on internal infrastructure'
+
+permissions:
+  contents: read
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────────────
+  # Lint: gofmt formatting check + go vet (make lint)
+  # ──────────────────────────────────────────────────────────────────────────
+  lint:
+    name: Lint
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false  # self-hosted runners persist ~/go/pkg/mod across runs
+
+      - name: Lint (gofmt + go vet)
+        run: make lint
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Build: compile the binary on Linux and macOS (make build)
+  # ──────────────────────────────────────────────────────────────────────────
+  build:
+    name: Build / ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux, runner: [self-hosted, Linux, X64] }
+          - { name: macOS, runner: [self-hosted, macOS, ARM64] }
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false  # self-hosted runners persist ~/go/pkg/mod across runs
+
+      - name: Build
+        run: make build
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Test: unit tests with race detector on Linux and macOS (make test-ci)
+  # ──────────────────────────────────────────────────────────────────────────
+  test:
+    name: Test / ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux, runner: [self-hosted, Linux, X64] }
+          - { name: macOS, runner: [self-hosted, macOS, ARM64] }
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false  # self-hosted runners persist ~/go/pkg/mod across runs
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Run tests
+        run: make test-ci
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-selfhosted-${{ matrix.name }}
+          path: report/tests.xml
+          retention-days: 30
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Coverage: generate HTML report
+  # ──────────────────────────────────────────────────────────────────────────
+  coverage:
+    name: Coverage
+    runs-on: [self-hosted, Linux, X64]
+    needs: test
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false  # self-hosted runners persist ~/go/pkg/mod across runs
+
+      - name: Generate coverage report
+        run: make coverage-ci
+
+      - name: Post coverage summary
+        run: |
+          echo "## Coverage Report" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat report/coverage-summary.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report-selfhosted
+          path: report/
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-# Triggered on every pull request.
+# Triggered on every pull request and push to main.
 # Also exposed as a reusable workflow so release.yml can call it.
 on:
   pull_request:
@@ -17,57 +17,56 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   lint:
     name: Lint
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
+          cache: true
 
       - name: Lint (gofmt + go vet)
         run: make lint
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Build: compile the binary on Linux and macOS (make build).
-  # Windows native build is omitted because the org's GitHub-hosted runner
-  # billing is currently restricted; release.yml's binaries job still
-  # cross-compiles Windows on the linux self-hosted runner.
+  # Build: cross-compile all release targets from the cheapest runners.
+  # Validates every platform/arch compiles cleanly — no native runner needed.
   # ──────────────────────────────────────────────────────────────────────────
   build:
-    name: Build / ${{ matrix.name }}
+    name: Build / ${{ matrix.goos }}-${{ matrix.goarch }}
     runs-on: ${{ matrix.runner }}
     needs: lint
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { name: linux, runner: [self-hosted, Linux, X64] }
-          - { name: macOS, runner: [self-hosted, macOS, ARM64] }
+          - { goos: linux,   goarch: amd64, runner: ubuntu-latest }
+          - { goos: linux,   goarch: arm64, runner: ubuntu-latest }
+          - { goos: darwin,  goarch: amd64, runner: macos-latest  }
+          - { goos: darwin,  goarch: arm64, runner: macos-latest  }
+          - { goos: windows, goarch: amd64, runner: ubuntu-latest, ext: .exe }
+          - { goos: windows, goarch: arm64, runner: ubuntu-latest, ext: .exe }
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
+          cache: true
 
-      - name: Build
-        run: make build
-
-      - name: Upload binary
-        if: github.event_name == 'push' || github.event_name == 'workflow_call'
-        uses: actions/upload-artifact@v7
-        with:
-          name: gaal-${{ matrix.name }}
-          path: dist/
-          retention-days: 7
+      - name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: >
+          make build-cross
+          BIN_CROSS=dist/gaal-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Test: unit tests with race detector on Linux and macOS (make test-ci)
-  #   - -count=1 forces re-execution (no (cached) results)
-  #   - gotestsum produces GitHub inline annotations + JUnit XML
+  # Test: unit tests with race detector — fast feedback on the two main targets.
+  # Full platform coverage is done in release.yml.
   # ──────────────────────────────────────────────────────────────────────────
   test:
     name: Test / ${{ matrix.name }}
@@ -77,17 +76,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux, runner: [self-hosted, Linux, X64] }
-          - { name: macOS, runner: [self-hosted, macOS, ARM64] }
+          - { name: linux, runner: ubuntu-latest }
+          - { name: macOS, runner: macos-latest  }
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
+          cache: true
+
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
+
       - name: Run tests
         run: make test-ci
 
@@ -120,7 +121,6 @@ jobs:
               skipped = sum(int(s.get("skipped",  0)) for s in suites)
               passed  = tests - failed - skipped
 
-              # Collect per-test details
               failures_list = []
               skipped_list  = []
               for suite in suites:
@@ -181,7 +181,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   coverage:
     name: Coverage
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: test
     steps:
       - uses: actions/checkout@v6
@@ -189,7 +189,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
+          cache: true
 
       - name: Generate coverage report
         run: make coverage-ci

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   shellcheck:
     name: Shellcheck (POSIX sh)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -45,15 +45,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux, runner: [self-hosted, Linux, X64] }
-          - { name: macOS, runner: [self-hosted, macOS, ARM64] }
+          - { name: linux, runner: ubuntu-latest }
+          - { name: macOS, runner: macos-latest }
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
+          cache: true
 
       - name: Run install script integration tests
         run: go test -race ./internal/installscript/ -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 
 # Triggered on:
 #   - semver release tags (v0.1.0, v1.2.3) → builds + publishes GitHub Release
-#   - pull requests → smoke-tests the release pipeline (no publishing)
 #   - workflow_dispatch → manual run from any branch (no publishing unless tagged)
 on:
   push:
@@ -15,43 +14,39 @@ permissions:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────────────
-  # Reuse the full CI workflow: lint + build (3 OS) + test (3 OS) + coverage.
-  # Skipped on pull_request because ci.yml already runs standalone on PRs.
+  # Reuse the CI workflow: lint + cross-compile builds + test (linux + macOS).
   # ──────────────────────────────────────────────────────────────────────────
   ci:
     name: CI
-    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
 
   # ──────────────────────────────────────────────────────────────────────────
   # Cross-compile release binaries for all supported platforms / architectures.
-  # Darwin builds run on macOS for code signing and notarization.
-  # Runs even when `ci` is skipped (PR runs) so the release pipeline is exercised.
+  # Darwin builds run on macos-latest for code signing and notarization.
   # ──────────────────────────────────────────────────────────────────────────
   binaries:
     name: Binary / ${{ matrix.goos }}-${{ matrix.goarch }}
     runs-on: ${{ matrix.runner }}
     needs: ci
-    if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { goos: linux,   goarch: amd64, runner: [self-hosted, Linux, X64] }
-          - { goos: linux,   goarch: arm64, runner: [self-hosted, Linux, X64] }
-          - { goos: darwin,  goarch: amd64, runner: [self-hosted, macOS, ARM64] }
-          - { goos: darwin,  goarch: arm64, runner: [self-hosted, macOS, ARM64] }
-          - { goos: windows, goarch: amd64, runner: [self-hosted, Linux, X64], ext: .exe }
-          - { goos: windows, goarch: arm64, runner: [self-hosted, Linux, X64], ext: .exe }
+          - { goos: linux,   goarch: amd64, runner: ubuntu-latest }
+          - { goos: linux,   goarch: arm64, runner: ubuntu-latest }
+          - { goos: darwin,  goarch: amd64, runner: macos-latest }
+          - { goos: darwin,  goarch: arm64, runner: macos-latest }
+          - { goos: windows, goarch: amd64, runner: ubuntu-latest, ext: .exe }
+          - { goos: windows, goarch: arm64, runner: ubuntu-latest, ext: .exe }
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          # cache disabled: self-hosted runners persist ~/go/pkg/mod across runs
+          cache: true
 
       - name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
         env:
@@ -81,7 +76,7 @@ jobs:
           RCODESIGN_VERSION: "0.29.0"
           RCODESIGN_SHA256: "d1a532150adaf90048260d76359261aa716abafc45c53c5dc18845029184334a"
         run: |
-          # Self-hosted runner is aarch64 regardless of $GOARCH (we cross-compile).
+          # macos-latest GitHub-hosted runners are ARM64 (M-series).
           ARCHIVE="apple-codesign-${RCODESIGN_VERSION}-aarch64-apple-darwin.tar.gz"
           curl -fsSL -o "$RUNNER_TEMP/$ARCHIVE" \
             "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${ARCHIVE}"
@@ -153,15 +148,59 @@ jobs:
           if-no-files-found: error
 
   # ──────────────────────────────────────────────────────────────────────────
+  # Test: run the full test suite natively on every release platform.
+  # Guarantees that deliverables are 100% validated on their target platform.
+  # Runs in parallel with binaries (both need ci to pass first).
+  # ──────────────────────────────────────────────────────────────────────────
+  test:
+    name: Test / ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    needs: ci
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux,       runner: ubuntu-latest    }
+          - { name: linux-arm64, runner: ubuntu-24.04-arm }
+          - { name: macOS,       runner: macos-latest     }
+          - { name: macOS-amd64, runner: macos-13         }
+          - { name: windows,     runner: windows-latest   }
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install gotestsum
+        shell: bash
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Run tests
+        shell: bash
+        run: |
+          mkdir -p report
+          gotestsum --junitfile report/tests.xml --format github-actions -- -race -count=1 -timeout 5m ./...
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-release-${{ matrix.name }}
+          path: report/tests.xml
+          retention-days: 30
+
+  # ──────────────────────────────────────────────────────────────────────────
   # Create the GitHub Release and attach all compiled binaries + checksums.
-  # Only runs on semver tag pushes — PRs and manual dispatches build artifacts
+  # Only runs on semver tag pushes — manual dispatches build artifacts
   # but do not publish.
   # ──────────────────────────────────────────────────────────────────────────
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: [self-hosted, Linux, X64]
-    needs: binaries
+    runs-on: ubuntu-latest
+    needs: [binaries, test]
     steps:
       - uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
## Summary

The project is now public under `getgaal`. This PR switches all CI workflows from self-hosted runners to GitHub-hosted runners and expands platform coverage.

**CI workflow** (`ci.yml`) — fast feedback loop:
- Cross-compiles all 6 targets (linux/darwin/windows × amd64/arm64)
- Runs tests natively on **Linux x86_64** + **macOS ARM64** only

**Release workflow** (`release.yml`) — full validation before publish:
- Same cross-compile step
- New `test` job runs natively on **5 platforms**: Linux x86_64, Linux ARM64, macOS ARM64, macOS AMD64, Windows amd64
- The `release` job is now gated on both `binaries` AND `test` passing

**Self-hosted workflow** (`ci-selfhosted.yml`) — new, manual only:
- `workflow_dispatch` only — self-hosted runners kept available for internal validation

## Type of Change
- [x] CI/CD change (no production code changed)

## Checklist
- [x] `make lint` passes — `gofmt` formatting + `go vet` clean
- [x] `make build` passes on Linux
- [x] No secrets or credentials are exposed in logs or config snippets
- [x] Self-hosted runners preserved via manual workflow