### PR TITLE
docs: sync all markdown files with current codebase state

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,28 @@ Runs the full sync planning pipeline but performs no writes to disk.
 Prints what sync *would* do — which repos would be cloned or updated,
 which skills would be installed, and which MCP entries would be created.
 
-Supports `--output table|json` and `--sandbox`. Incompatible with `--service`.
+Supports `--output text|table|json` and `--sandbox`. Incompatible with `--service`.
 
 Exit codes: **0** = nothing to change, **1** = changes pending, **2** = error.
+
+### Remove orphan resources
+
+```bash
+gaal sync --prune
+```
+
+After syncing, removes skills and MCP entries that are no longer declared in the
+configuration file. Incompatible with `--service`.
+
+### Force-install into all agents
+
+```bash
+gaal sync --force
+```
+
+Installs skills into every registered agent even when the agent's configuration
+directory does not exist yet. Useful when bootstrapping a machine where some
+agents are not installed yet. Only applies to `agents: ["*"]` wildcard entries.
 
 ### Continuous service mode
 
@@ -190,6 +209,16 @@ gaal doctor -o json       # machine-readable JSON output
 
 Exit codes: **0** = all checks passed, **1** = warnings, **2** = errors.
 
+### Discover what is installed
+
+```bash
+gaal audit
+```
+
+Scans all known agent directories and reports every skill and MCP server found on
+the machine, regardless of whether it is declared in `gaal.yaml`. Useful for
+spotting skills installed manually or by another tool.
+
 ### Generate the JSON Schema
 
 ```bash
@@ -223,7 +252,8 @@ gaal info repo -o json
 
 | Format | Description |
 |--------|-------------|
-| `table` | Human-friendly coloured tables (default) |
+| `text`  | Human-friendly plain-text output (default) |
+| `table` | Coloured pterm tables |
 | `json`  | Structured JSON, suitable for scripting / CI |
 
 When `--output json` is set the ASCII banner is automatically suppressed.
@@ -326,7 +356,7 @@ gaal ships with a built-in registry of supported coding agents (claude-code, git
 | macOS | `$XDG_CONFIG_HOME/gaal/agents.yaml` (defaults to `~/.config/gaal/agents.yaml`) |
 | Windows | `%AppData%\gaal\agents.yaml` |
 
-Custom entries **extend** the built-in list — they cannot override built-in entries. Each entry follows the same format as the built-in registry:
+Custom entries are merged with the built-in list. User-defined entries **can override** built-in entries. Each entry follows the same format as the built-in registry:
 
 ```yaml
 agents:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,15 +57,20 @@ All sub-commands share the global flags defined on the root command:
 | `--no-banner` | `false` | Suppress the ASCII-art banner |
 | `--sandbox` | `""` | Redirect all writes to this directory |
 | `--log-file` | `""` | Write structured JSON logs to file |
-| `--output / -o` | `table` | Output format: `table` or `json` |
+| `--output / -o` | `text` | Output format: `text`, `table`, or `json` |
 
 ### Registered sub-commands
 
 | Command | Own flags | Description |
 |---------|-----------|-------------|
-| `gaal sync` | `--service/-s`, `--interval/-i` | One-shot or continuous synchronisation |
+| `gaal sync` | `--service/-s`, `--interval/-i`, `--dry-run`, `--prune`, `--force` | One-shot or continuous synchronisation |
 | `gaal status` | — | Current state of all repositories, skills and MCP entries |
 | `gaal info <repo\|skill\|mcp\|agent> [filter]` | — | Detailed card for every entry of a resource type |
+| `gaal agents [name]` | `--installed/-i` | List registered coding agents or show details for one |
+| `gaal audit` | — | Discover all skills and MCP servers installed on this machine |
+| `gaal doctor` | `--offline`, `--no-upsell` | Run configuration health checks and report agent status |
+| `gaal init` | `--scope`, `--import-all`, `--empty`, `--force/-f` | Bootstrap a `gaal.yaml` from discovered skills and MCPs |
+| `gaal migrate` | `--to`, `--dry-run`, `--yes` | Migrate configuration to a Community Edition instance |
 | `gaal version` | — | Version string and build timestamp |
 | `gaal schema` | `--file/-f` | Print the JSON Schema (draft-07) for the config file |
 | `gaal completion <bash\|zsh\|fish\|powershell>` | — | Shell completion script (built-in Cobra) |
@@ -187,12 +192,18 @@ The public surface of the package. All `cmd/*.go` files import only this package
 
 | Symbol | Description |
 |--------|-------------|
-| `Options` | Runtime directory overrides (used by `--sandbox`) |
+| `Options` | Runtime directory overrides (`WorkDir`, `StateDir`, `Force`) — used by `--sandbox` and `--force` |
 | `Engine` | Owns the three managers + home/workDir |
 | `New()` / `NewWithOptions()` | Constructors |
 | `RunOnce()` / `RunService()` | Sync entry-points |
+| `Plan()` / `DryRun()` | Compute sync plan; `DryRun` also renders to stdout |
+| `Prune()` | Remove skills and MCP entries no longer in config |
 | `Collect()`, `Status()`, `Audit()`, `Info()`, `Init()` | Thin wrappers that delegate to `ops/` |
-| Type aliases | `OutputFormat`, `StatusCode`, `StatusReport`, `RepoEntry`, `SkillEntry`, `MCPEntry`, `AgentEntry`, `AuditReport`, `AuditSkillEntry`, `AuditMCPEntry` — all re-exported from `engine/render` for backward compatibility |
+| `ListAgents()` / `AgentDetail()` | Agent registry queries |
+| `BuildImportCandidates()` / `InitFromPlan()` | Import-mode init helpers |
+| `Migrate()` | Delegate to `ops.Migrate()` |
+| `Doctor()` | Run configuration health checks |
+| Type aliases | `OutputFormat`, `StatusCode`, `StatusReport`, `RepoEntry`, `SkillEntry`, `MCPEntry`, `AgentEntry`, `AgentDetail`, `AgentPath`, `AuditReport`, `AuditSkillEntry`, `AuditMCPEntry`, `PlanReport` — all re-exported from `engine/render` for backward compatibility |
 
 ### `engine/render/` — output types and renderers
 
@@ -201,7 +212,7 @@ Pure rendering layer with no dependencies on the manager packages.
 | File | Contents |
 |------|----------|
 | `report.go` | `StatusCode` constants, `RepoEntry`, `SkillEntry`, `MCPEntry`, `AgentEntry`, `StatusReport`, `AuditSkillEntry`, `AuditMCPEntry`, `AuditReport` |
-| `renderer.go` | `OutputFormat` (`table` / `json`), `Renderer` interface, `NewRenderer()` |
+| `renderer.go` | `OutputFormat` (`text` / `table` / `json`), `Renderer` interface, `NewRenderer()` |
 | `json.go` | `jsonRenderer` — indented JSON encoder |
 | `table.go` | `tableRenderer` — adaptive pterm tables, `StatusCell()`, `trunc()`, `varColWidth()` |
 | `audit.go` | `AuditRenderer`, `NewAuditRenderer()`, `auditTableRenderer`, `auditJSONRenderer` |
@@ -215,12 +226,22 @@ Stateless functions that implement each CLI command. Each function receives the 
 | `status.go` | `Collect()`, `Status()` | FS-first resource state via `discover.Scan` — reconciles config-declared (managed) and FS-discovered (unmanaged) resources |
 | `plan.go` | `SyncPlan()`, `RenderPlan()` | Compute sync plan without writing |
 | `audit.go` | `Audit()` | Discover all installed skills and MCP servers |
+| `agents.go` | `ListAgents()`, `AgentDetail()` | Agent registry queries and detail rendering |
+| `doctor.go` | `RunDoctor()`, `DoctorReport`, `DoctorOptions` | Configuration health checks; exit code 0/1/2 |
 | `info.go` | `Info()` | Detailed per-entry card rendering |
-| `init.go` | `Init()`, `InitTemplate` | Write the config file skeleton to disk |
+| `init.go` | `Init()` | Write the config file skeleton to disk |
+| `init_plan.go` | `BuildCandidates()`, `BuildPlan()` | Plan computation for import-mode init |
+| `init_build.go` | `BuildFromPlan()` | Generate YAML content from an import plan |
+| `init_source.go` | `ResolveSource()` | Resolve skill sources for import candidate scanning |
+| `migrate.go` | `Migrate()`, `MigrateResult` | Community Edition migration stub |
 
-### `Options.WorkDir`
+### `Options`
 
-Defaults to `os.Getwd()`. In `--sandbox` mode it is redirected to an isolated subdirectory, preventing any writes outside the sandbox.
+| Field | Description |
+|-------|-------------|
+| `WorkDir` | Defaults to `os.Getwd()`. In `--sandbox` mode it is redirected to an isolated subdirectory. |
+| `StateDir` | Overrides the snapshot state directory (default: `<cacheRoot>/gaal/state`). |
+| `Force` | When `true`, installs skills into all registered agents even when the agent directory does not exist yet (applies to `agents: ["*"]` wildcard). |
 
 ### Bootstrap via `PersistentPreRunE`
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,29 +1,31 @@
-# La commande `gaal status` — Guide de lecture
+# The `gaal status` command — Reading guide
 
-> **Pour qui ?** Ce guide s'adresse à quelqu'un qui n'a jamais utilisé `gaal`
-> et veut comprendre ce qu'affiche `gaal status` sans avoir à lire le code source.
+> **Audience:** This guide is for anyone who has never used `gaal` before
+> and wants to understand what `gaal status` prints without reading the source code.
 
 ---
 
-## Principe général
+## How it works
 
-`gaal` lit un fichier de configuration (`gaal.yaml`) qui déclare trois types de ressources à gérer sur ta machine :
+`gaal` reads a configuration file (`gaal.yaml`) that declares three types of
+resources to manage on your machine:
 
-| Type | Ce que c'est |
+| Type | Description |
 |------|-------------|
-| **Repositories** | Des dépôts de code (git, svn, hg…) à cloner et maintenir à jour localement |
-| **Skills** | Des collections de fichiers `SKILL.md` à installer dans les répertoires de tes agents IA (GitHub Copilot, Claude, Cursor…) |
-| **MCP Configs** | Des entrées de serveur MCP (*Model Context Protocol*) à injecter dans les fichiers de configuration JSON de tes agents |
+| **Repositories** | Code repositories (git, svn, hg, …) to clone and keep up-to-date locally |
+| **Skills** | Collections of `SKILL.md` files to install into your AI agent directories (GitHub Copilot, Claude, Cursor, …) |
+| **MCP Configs** | MCP (*Model Context Protocol*) server entries to inject into your agent JSON configuration files |
 
-La commande `gaal status` **ne fait rien** — elle se contente de **lire l'état actuel du disque** et de te dire si ce que tu as déclaré dans `gaal.yaml` correspond à ce qui est réellement installé.
+`gaal status` **does nothing** — it only **reads the current state from disk** and tells
+you whether what you declared in `gaal.yaml` matches what is actually installed.
 
-Pour synchroniser (installer / mettre à jour), tu utilises `gaal sync`.
+To synchronise (install / update), use `gaal sync`.
 
 ---
 
-## Structure de l'écran
+## Screen layout
 
-L'affichage est divisé en **quatre sections** présentées l'une après l'autre.
+The output is divided into **four sections** displayed one after the other.
 
 ---
 
@@ -35,22 +37,22 @@ L'affichage est divisé en **quatre sections** présentées l'une après l'autre
 │ PATH         │ TYPE │ STATUS         │ VERSION / URL    │
 ```
 
-| Colonne | Signification |
-|---------|--------------|
-| **PATH** | Chemin local où le dépôt est (ou devrait être) cloné, relatif au répertoire courant |
-| **TYPE** | Protocole utilisé : `git`, `hg`, `svn`, `bzr`, `tar`, `zip` |
-| **STATUS** | État du dépôt (voir tableau ci-dessous) |
-| **VERSION / URL** | Pour les dépôts clonés : version actuelle + version voulue. Pour les dépôts absents : URL source |
+| Column | Meaning |
+|--------|---------|
+| **PATH** | Local path where the repository is (or should be) cloned, relative to the current directory |
+| **TYPE** | Protocol in use: `git`, `hg`, `svn`, `bzr`, `tar`, `zip` |
+| **STATUS** | Current state of the repository (see table below) |
+| **VERSION / URL** | For cloned repos: current version + wanted version. For missing repos: source URL |
 
-**Valeurs possibles de STATUS :**
+**Possible STATUS values:**
 
-| Icône | Label | Signification |
-|-------|-------|--------------|
-| ✓ | `synced` | Cloné et à la bonne version |
-| ⚠ | `dirty` | Cloné mais la version locale ne correspond pas à ce que demande la config |
-| ~ | `not cloned` | Pas encore téléchargé sur le disque — fait un `gaal sync` |
-| ? | `unmanaged` | Présent sur le disque mais non déclaré dans la config |
-| ✗ | `error` | Erreur lors de la vérification (permissions, réseau…) |
+| Icon | Label | Meaning |
+|------|-------|---------|
+| ✓ | `synced` | Cloned and at the correct version |
+| ⚠ | `dirty` | Cloned but the local version does not match what the config requests |
+| ~ | `not cloned` | Not yet downloaded to disk — run `gaal sync` |
+| ? | `unmanaged` | Present on disk but not declared in the config |
+| ✗ | `error` | Error during the check (permissions, network, …) |
 
 ---
 
@@ -62,62 +64,68 @@ L'affichage est divisé en **quatre sections** présentées l'une après l'autre
 │ SKILL            │ SOURCE     │ SCOPE     │ STATUS     │ INSTALLED IN │
 ```
 
-C'est la section la plus importante si tu travailles avec des agents IA.
+This is the most important section if you work with AI agents.
 
-#### Comprendre les concepts clés
+#### Key concepts
 
-Un **skill** est un dossier contenant un fichier `SKILL.md` que les agents IA lisent pour obtenir des instructions spécialisées (ex. : "comment écrire du React performant"). `gaal` s'occupe de copier ces dossiers dans les bons répertoires de tes agents.
+A **skill** is a directory containing a `SKILL.md` file that AI agents read to obtain
+specialised instructions (e.g. "how to write performant React"). `gaal` copies these
+directories into the correct agent directories on your machine.
 
-Une **source** est le dépôt GitHub (ou chemin local) depuis lequel `gaal` télécharge les skills. Par exemple `vercel-labs/agent-skills` est un dépôt GitHub public.
+A **source** is the GitHub repository (or local path) from which `gaal` downloads
+skills. For example `vercel-labs/agent-skills` is a public GitHub repository.
 
-#### Colonnes
+#### Columns
 
-| Colonne | Signification |
-|---------|--------------|
-| **SKILL** | Nom du skill (extrait du `SKILL.md`) |
-| **SOURCE** | D'où vient ce skill : dépôt GitHub (`owner/repo`) ou chemin local |
-| **SCOPE** | `global` = installé dans `~/.copilot/skills` (pour tous tes projets) · `workspace` = installé dans `.github/skills` (uniquement pour ce projet) |
-| **STATUS** | État de l'installation (voir tableau ci-dessous) |
-| **INSTALLED IN** | Dans quels agents le skill est actuellement présent sur le disque |
+| Column | Meaning |
+|--------|---------|
+| **SKILL** | Name of the skill (extracted from `SKILL.md`) |
+| **SOURCE** | Where the skill comes from: a GitHub repository (`owner/repo`) or a local path |
+| **SCOPE** | `global` = installed in `~/.copilot/skills` (for all your projects) · `workspace` = installed in `.github/skills` (this project only) |
+| **STATUS** | Installation state (see table below) |
+| **INSTALLED IN** | Which agents currently have this skill on disk |
 
-**Valeurs possibles de STATUS :**
+**Possible STATUS values:**
 
-| Icône | Label | Signification |
-|-------|-------|--------------|
-| ✓ | `synced` | Le skill est installé et ses fichiers correspondent exactement à la source |
-| ⚠ | `dirty` | Le skill est installé mais des fichiers ont été modifiés localement depuis la dernière sync |
-| ~ | `partial` | Déclaré dans la config mais pas encore installé — fait un `gaal sync` |
-| ? | `unmanaged` | Trouvé sur le disque dans un répertoire agent mais non déclaré dans la config |
-| ✗ | `error` | Erreur (source non cachée, agent inconnu…) |
+| Icon | Label | Meaning |
+|------|-------|---------|
+| ✓ | `synced` | The skill is installed and its files exactly match the source |
+| ⚠ | `dirty` | The skill is installed but some files have been modified locally since the last sync |
+| ~ | `partial` | Declared in the config but not yet installed — run `gaal sync` |
+| ? | `unmanaged` | Found on disk in an agent directory but not declared in the config |
+| ✗ | `error` | Error (source not cached, unknown agent, …) |
 
-**Valeurs possibles de INSTALLED IN :**
+**Possible INSTALLED IN values:**
 
-| Valeur | Signification |
-|--------|--------------|
-| `all` (vert) | Installé dans tous les agents ciblés par la config |
-| `none` (jaune) | Non encore installé dans aucun agent — `gaal sync` requis |
-| liste de noms | Installé uniquement dans ces agents (sous-ensemble des agents ciblés) |
+| Value | Meaning |
+|-------|---------|
+| `all` (green) | Installed in all agents targeted by the config |
+| `none` (yellow) | Not yet installed in any agent — `gaal sync` required |
+| list of names | Installed only in these agents (a subset of the targeted agents) |
 
-> **Astuce lecture :** une ligne `~ partial | none` signifie que le skill est déclaré dans
-> `gaal.yaml` mais que sa source n'a pas encore été téléchargée localement. Lance
-> `gaal sync` pour corriger ça.
+> **Reading tip:** a `~ partial | none` line means the skill is declared in
+> `gaal.yaml` but its source has not been downloaded locally yet. Run
+> `gaal sync` to fix this.
 
-#### Exemple de lecture
+#### Example rows
 
 ```
 │ react-best-practices │ vercel-labs/agent-skills │ workspace │ ✓ synced  │ all  │
 ```
-→ Le skill `react-best-practices`, tiré du dépôt GitHub `vercel-labs/agent-skills`, est installé dans le répertoire `.github/skills` du projet et est synchronisé dans tous les agents ciblés.
+→ The `react-best-practices` skill, sourced from the `vercel-labs/agent-skills` GitHub
+repository, is installed in the project's `.github/skills` directory and is in sync
+across all targeted agents.
 
 ```
 │ canvas-design        │ anthropics/skills        │ global    │ ✓ synced  │ all  │
 ```
-→ Ce skill est installé **globalement** (`~/.copilot/skills`) : il sera disponible dans tous tes projets, pas seulement celui-ci.
+→ This skill is installed **globally** (`~/.copilot/skills`): it is available in all
+your projects, not just the current one.
 
 ```
 │ vercel-composition…  │ vercel-labs/agent-…      │ workspace │ ~ partial │ none │
 ```
-→ Ce skill est dans ta config mais pas encore téléchargé. Lance `gaal sync`.
+→ This skill is in your config but has not been downloaded yet. Run `gaal sync`.
 
 ---
 
@@ -129,20 +137,20 @@ Une **source** est le dépôt GitHub (ou chemin local) depuis lequel `gaal` tél
 │ NAME       │ STATUS     │ TARGET                            │
 ```
 
-| Colonne | Signification |
-|---------|--------------|
-| **NAME** | Nom de l'entrée MCP telle que déclarée dans `gaal.yaml` |
-| **STATUS** | État de la configuration (voir tableau ci-dessous) |
-| **TARGET** | Fichier JSON de configuration de l'agent où l'entrée doit être injectée |
+| Column | Meaning |
+|--------|---------|
+| **NAME** | Name of the MCP entry as declared in `gaal.yaml` |
+| **STATUS** | Configuration state (see table below) |
+| **TARGET** | Agent JSON config file where the entry should be injected |
 
-**Valeurs possibles de STATUS :**
+**Possible STATUS values:**
 
-| Icône | Label | Signification |
-|-------|-------|--------------|
-| ✓ | `present` | L'entrée est présente dans le fichier cible et correspond à la config |
-| ⚠ | `dirty` | L'entrée existe mais a été modifiée localement depuis la dernière sync |
-| ~ | `absent` | L'entrée n'est pas dans le fichier cible — `gaal sync` requis |
-| ✗ | `error` | Impossible de lire/écrire le fichier cible |
+| Icon | Label | Meaning |
+|------|-------|---------|
+| ✓ | `present` | The entry is present in the target file and matches the config |
+| ⚠ | `dirty` | The entry exists but has been modified locally since the last sync |
+| ~ | `absent` | The entry is not in the target file — `gaal sync` required |
+| ✗ | `error` | Cannot read / write the target file |
 
 ---
 
@@ -154,38 +162,39 @@ Une **source** est le dépôt GitHub (ou chemin local) depuis lequel `gaal` tél
 │ AGENT         │ INSTALLED │ PROJECT SKILLS DIR │ GLOBAL SKILLS DIR │ PROJECT MCP CONFIG│
 ```
 
-Cette section est **informative uniquement** — elle te montre quels agents IA `gaal` connaît et lesquels sont détectés comme présents sur ta machine.
+This section is **informational only** — it shows which AI agents `gaal` knows about
+and which ones are detected as present on your machine.
 
-| Colonne | Signification |
-|---------|--------------|
-| **AGENT** | Identifiant de l'agent (ex. `github-copilot`, `cursor`, `claude-code`) |
-| **INSTALLED** | `✓` si le répertoire de configuration de l'agent existe sur la machine · `—` si absent |
-| **PROJECT SKILLS DIR** | Répertoire (relatif au projet) où `gaal` installe les skills workspace pour cet agent |
-| **GLOBAL SKILLS DIR** | Répertoire absolu (`~/ …`) où `gaal` installe les skills globaux pour cet agent |
-| **PROJECT MCP CONFIG** | Fichier JSON de l'agent où les entrées MCP sont injectées |
+| Column | Meaning |
+|--------|---------|
+| **AGENT** | Agent identifier (e.g. `github-copilot`, `cursor`, `claude-code`) |
+| **INSTALLED** | `✓` if the agent's configuration directory exists on the machine · `—` if absent |
+| **PROJECT SKILLS DIR** | Directory (relative to the project) where `gaal` installs workspace skills for this agent |
+| **GLOBAL SKILLS DIR** | Absolute path (`~/…`) where `gaal` installs global skills for this agent |
+| **PROJECT MCP CONFIG** | Agent JSON file where MCP entries are injected |
 
-> `gaal` ne synchronise vers un agent que s'il est **installé** (`✓`). Les agents
-> marqués `—` sont ignorés lors du `gaal sync`.
-
----
-
-## Statuts en un coup d'œil
-
-| Icône | Couleur | Signification rapide |
-|-------|---------|---------------------|
-| ✓ synced / present | vert | Tout est à jour |
-| ⚠ dirty | jaune | Modifié localement depuis la dernière sync |
-| ~ partial / not cloned / absent | jaune | Déclaré mais pas encore installé → `gaal sync` |
-| ? unmanaged | cyan | Présent sur le disque mais pas dans la config |
-| ✗ error | rouge | Problème à corriger (voir le message d'erreur) |
+> `gaal` only syncs to an agent if it is **installed** (`✓`). Agents marked `—`
+> are skipped during `gaal sync`.
 
 ---
 
-## Workflow typique
+## Status at a glance
+
+| Icon | Colour | Quick meaning |
+|------|--------|---------------|
+| ✓ synced / present | green | Everything is up to date |
+| ⚠ dirty | yellow | Modified locally since the last sync |
+| ~ partial / not cloned / absent | yellow | Declared but not yet installed → `gaal sync` |
+| ? unmanaged | cyan | Present on disk but not in the config |
+| ✗ error | red | Problem to fix (see the error message) |
+
+---
+
+## Typical workflow
 
 ```
-1. Tu édites gaal.yaml          → ajoute/modifie des ressources
-2. gaal status                  → vois ce qui est désynchronisé
-3. gaal sync                    → installe / met à jour tout
-4. gaal status                  → confirme que tout est ✓ synced
+1. Edit gaal.yaml          → add / modify resources
+2. gaal status             → see what is out of sync
+3. gaal sync               → install / update everything
+4. gaal status             → confirm everything is ✓ synced
 ```


### PR DESCRIPTION
## Summary

Full documentation audit and sync pass across all \`*.md\` files. The docs had drifted from the codebase due to multiple feature additions (agents, audit, doctor, init, migrate, prune, force, dry-run, text output format). Also translates \`docs/status.md\` from French to English.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] CI / tooling

## Related Issues

Close: #52 

## Changes per file

### \`docs/status.md\`
- Full rewrite in English (entire file was in French)
- Content and structure preserved, language only

### \`docs/architecture.md\`
- Added missing sub-commands to the CLI table: \`gaal agents\`, \`gaal audit\`, \`gaal doctor\`, \`gaal init\`, \`gaal migrate\`
- Added missing flags on \`gaal sync\`: \`--dry-run\`, \`--prune\`, \`--force\`
- Fixed \`--output\` default: \`table\` → \`text\`; valid values: \`text\`, \`table\`, \`json\`
- Updated engine public API: \`Plan()\`, \`DryRun()\`, \`Prune()\`, \`Doctor()\`, \`ListAgents()\`, \`AgentDetail()\`, \`BuildImportCandidates()\`, \`InitFromPlan()\`, \`Migrate()\`
- Updated type aliases: added \`AgentDetail\`, \`AgentPath\`, \`PlanReport\`
- Updated \`Options\` struct: documented \`StateDir\` and \`Force\` fields
- Expanded \`engine/ops/\` table: added \`agents.go\`, \`doctor.go\`, \`migrate.go\`, \`init_plan.go\`, \`init_build.go\`, \`init_source.go\`
- Fixed \`renderer.go\` description: \`OutputFormat (table/json)\` → \`(text/table/json)\`

### \`README.md\`
- Added \`gaal sync --prune\` section (remove orphan resources)
- Added \`gaal sync --force\` section (install into all agents)
- Added \`gaal audit\` usage section
- Fixed output format table: added \`text\` as the default format
- Fixed agent registry override note: user entries **can** override built-ins (matches \`allowOverride: true\` in source)
- Fixed \`--dry-run\` description: \`--output table|json\` → \`text|table|json\`

## Checklist

- [x] \`make lint\` passes — \`gofmt\` formatting + \`go vet\` clean
- [x] \`make build\` passes on Linux and macOS
- [x] \`make test-ci\` passes — unit tests with race detector
- [x] Every new function has at least one \`slog.Debug\` / \`slog.DebugContext\` call
- [x] Documentation updated if user-facing behaviour changed
- [x] No secrets or credentials are exposed in logs or config snippets