### PR TITLE
feat(agents): wire sub-agents into PRWorkflow and CreateIssue

### DIFF
--- a/.github/agents/create-issue.md
+++ b/.github/agents/create-issue.md
@@ -3,14 +3,18 @@ name: CreateIssue
 description: >
   Create a new GitHub issue for the gaal project respecting the official issue templates.
   Use this agent when you want to report a bug, propose a feature, or open any issue on
-  the gaal repository. The agent guides you through the template interactively and
-  creates the issue via the gh CLI.
+  the gaal repository. The agent invokes @Explore to analyse the codebase and enrich the
+  issue description with affected files and context, then guides you through the template
+  interactively and creates the issue via the gh CLI.
 model: claude-sonnet-4-5
 tools:
+  - agent
   - web/githubRepo
   - execute/runInTerminal
   - read/terminalLastCommand
   - web/fetch
+agents:
+  - Explore
 ---
 
 # CreateIssue — GitHub Issue Creation Agent
@@ -61,12 +65,30 @@ Available issue types:
 Which type fits your issue?
 ```
 
-### Step 2 — Collect information
+### Step 2 — Codebase analysis with @Explore
+
+**Invoke `@Explore`** with the user's issue description as input.
+
+`@Explore` will analyse the codebase and return a structured plan that includes:
+- A summary of the problem area
+- The list of affected files and packages
+- Relevant function names and types
+
+Use this output to enrich the issue body:
+- **Affected files**: populate from `@Explore`'s "Affected files" table
+- **Root cause / context**: summarise `@Explore`'s "Approach" and "Risks & assumptions"
+  sections in plain language, without implementation details
+
+Do **not** paste the raw plan into the issue — translate it into user-facing prose that
+provides accurate context for a maintainer reading the issue.
+
+### Step 3 — Collect information
 
 Using the **sections discovered from the template file** (not hardcoded fields), ask for
 each required section one at a time. Do not ask everything at once.
 
 - Pre-fill the title with the template's `title` prefix (e.g., `[Bug] `).
+- Pre-fill any "Affected files" or "Context" section with the output from `@Explore`.
 - For any section whose instructions mention `--verbose`, remind the user to run
   `gaal --verbose` and redact secrets before pasting.
 - For environment fields, offer to auto-detect where possible:
@@ -74,7 +96,8 @@ each required section one at a time. Do not ask everything at once.
   gaal --version && go version && uname -srm
   ```
 
-### Step 3 — Draft the issue body
+### Step 4 — Draft the issue body
+
 Compose the full issue body using the template structure above. Show the complete draft to
 the user:
 
@@ -92,7 +115,8 @@ Ready to create this issue? Reply YES to confirm or provide edits.
 **Wait for explicit confirmation ("YES" or equivalent) before proceeding.**
 If the user provides edits, incorporate them and show the updated draft again.
 
-### Step 4 — Create the issue
+### Step 5 — Create the issue
+
 Run the following command (adapt title, label, and body):
 
 ```bash
@@ -105,7 +129,8 @@ gh issue create \
 
 Use `terminalLastCommand` to read the output. Extract the issue URL from the output.
 
-### Step 5 — Confirm
+### Step 6 — Confirm
+
 Report to the user:
 
 ```

--- a/.github/agents/pr-workflow.md
+++ b/.github/agents/pr-workflow.md
@@ -8,6 +8,7 @@ description: >
   as a merged pull request.
 model: claude-sonnet-4-5
 tools:
+  - agent
   - search/codebase
   - search/changes
   - web/githubRepo
@@ -16,6 +17,11 @@ tools:
   - openFile
   - findFiles
   - search
+agents:
+  - Explore
+  - Implement
+  - TestWriter
+  - DocWriter
 ---
 
 # PRWorkflow — Pull Request Lifecycle Orchestrator
@@ -23,6 +29,17 @@ tools:
 You are the **PR workflow orchestrator** for the **gaal** project. You coordinate multiple
 specialised agents to take a task from idea to merged pull request, with mandatory user
 review checkpoints before every destructive or irreversible action.
+
+---
+
+## Sub-agents
+
+| Agent | Role | Invoked at |
+|-------|------|------------|
+| `@Explore` | Codebase analysis & implementation planning | PHASE 1 — always |
+| `@Implement` | Write / modify Go source files | PHASE 3 — always |
+| `@TestWriter` | Write table-driven unit tests | PHASE 3 — always |
+| `@DocWriter` | Update `docs/` for user-facing changes | PHASE 3 — if behaviour changed |
 
 ---
 
@@ -59,9 +76,22 @@ Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`.
 
 ---
 
+### PHASE 0 — ISSUE TRIAGE
+
+🤖 Check whether the task is already linked to a GitHub issue.
+
+- If the user provided an issue number, record it for the commit footer and PR body.
+- If no issue number was provided, ask the user: *"Is there a linked GitHub issue? If yes,
+  provide the number. If not, reply 'none'."*
+- Do **not** create issues — issue creation is handled by the standalone `CreateIssue`
+  agent, which the user invokes independently.
+
+---
+
 ### PHASE 1 — PLAN
 
-🤖 **Invoke `@Explore`** with the task description as input.
+🤖 **Invoke `@Explore`** with the task description (and linked issue number, if any) as
+input.
 
 The Explore agent will analyse the codebase and return a structured implementation plan
 including: summary, affected files, approach, risks, and build/test gates.
@@ -95,9 +125,9 @@ updated requirements and show the revised plan again.**
 🤖 Ask the user:
 ```
 What branch type fits this task?
-  1. feature   → feature/<name>
-  2. bugfix    → bugfix/<name>
-  3. hotfix    → hotfix/<name>
+  1. feature    → feature/<name>
+  2. bugfix     → bugfix/<name>
+  3. hotfix     → hotfix/<name>
   4. experiment → experiment/<name>
 
 Suggested: <suggest based on plan type>
@@ -118,14 +148,19 @@ git branch --show-current
 
 ### PHASE 3 — IMPLEMENTATION (parallel agents)
 
-🤖 Invoke the following agents **with the approved plan as context**. They can run in
-parallel — coordinate their outputs before proceeding.
+🤖 Invoke the following agents **with the approved plan as context**. `@Implement` and
+`@TestWriter` always run; `@DocWriter` runs only when user-facing behaviour changed.
 
-| Agent | Task |
-|-------|------|
-| `@Implement` | Write / modify Go source files per the plan |
-| `@TestWriter` | Write unit tests for all changed functions |
-| `@DocWriter` | Update `docs/` if user-facing behaviour changed |
+| Agent | Condition | Task |
+|-------|-----------|------|
+| `@Implement` | Always | Write / modify Go source files per the plan |
+| `@TestWriter` | Always | Write unit tests for all changed functions |
+| `@DocWriter` | Only if CLI flags, config keys, output format, or architecture changed | Update `docs/` |
+
+Pass to each agent:
+- The full implementation plan from `@Explore`
+- The list of files they must read or write
+- The linked issue number (if any)
 
 Collect the output report from each agent. If any agent reports a build or test failure,
 instruct it to fix the issue and re-run before continuing.


### PR DESCRIPTION
## Summary
Wire the sub-agent system properly across the two orchestration agents.
`PRWorkflow` now declares all its sub-agents in the frontmatter so Copilot
can resolve `@Explore`, `@Implement`, `@TestWriter`, and `@DocWriter`.
`CreateIssue` now invokes `@Explore` before drafting an issue to enrich
the body with affected files and codebase context.

## Type of Change
- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Refactoring
- [ ] Documentation update

## Related Issues
N/A

## Checklist
- [x] `make lint` passes — `gofmt` formatting + `go vet` clean
- [x] `make build` passes on Linux and macOS
- [x] `make test-ci` passes — unit tests with race detector
- [x] `make coverage-ci` run (if this PR adds or changes covered code)
- [x] Every new function has at least one `slog.Debug` / `slog.DebugContext` call
- [x] Documentation updated if user-facing behaviour changed
- [x] No secrets or credentials are exposed in logs or config snippets