### PR TITLE
chore: add tmp/ to .gitignore and remove IDEA.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,4 +124,5 @@ gaal.yaml
 dist/
 .sandbox/
 report/
+tmp/
 docs/superpowers/

--- a/IDEA.md
+++ b/IDEA.md
@@ -1,1 +1,0 @@
-profil de depoyment pour un projet.. tpl:  react_app (Meta-package)


### PR DESCRIPTION
## Summary

Add `tmp/` directory to `.gitignore` and remove the `IDEA.md` draft notes file that is no longer needed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Chore / dependency update

## Related Issues

N/A

## Checklist

- [x] `make lint` passes — `gofmt` formatting + `go vet` clean
- [x] `make build` passes on Linux and macOS
- [x] `make test-ci` passes — unit tests with race detector
- [ ] `make coverage-ci` run (if this PR adds or changes covered code)
- [x] Every new function has at least one `slog.Debug` / `slog.DebugContext` call
- [x] Documentation updated if user-facing behaviour changed
- [x] No secrets or credentials are exposed in logs or config snippets