### PR TITLE
fix(telemetry): defer consent file write until after sub-command completes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,6 +100,7 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 	// PersistentPostRunE runs after every sub-command. Waits briefly for
 	// in-flight telemetry events to complete before the process exits.
 	PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
+		telemetry.PersistPendingConsent()
 		telemetry.Shutdown()
 		return nil
 	},
@@ -113,6 +114,7 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 // Execute is the entry-point called by main.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		telemetry.PersistPendingConsent()
 		telemetry.Shutdown()
 		os.Exit(1)
 	}

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -54,6 +54,26 @@ func Status(cfgValue *bool) (status string, source string) {
 	return "disabled", s.Source
 }
 
+// pendingConsentWrite holds a deferred consent write so that the file is not
+// created before a sub-command (e.g. init) that targets the same path has had a
+// chance to run. Call PersistPendingConsent to flush it.
+var pendingConsentWrite *struct {
+	Path    string
+	Enabled bool
+}
+
+// PersistPendingConsent writes any deferred telemetry consent to disk. It is
+// safe to call even when there is nothing pending.
+func PersistPendingConsent() {
+	if pendingConsentWrite == nil {
+		return
+	}
+	if err := persistConsent(pendingConsentWrite.Path, pendingConsentWrite.Enabled); err != nil {
+		slog.Warn("failed to persist telemetry consent", "err", err)
+	}
+	pendingConsentWrite = nil
+}
+
 // persistConsent writes or updates the telemetry field in the user config file.
 func persistConsent(cfgPath string, enabled bool) error {
 	slog.Debug("persisting telemetry consent", "path", cfgPath, "enabled", enabled)

--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -177,6 +177,41 @@ func TestStatusUnconfigured(t *testing.T) {
 	}
 }
 
+func TestPersistPendingConsentDefersWrite(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	// Simulate deferred consent (set by Init when a prompt was answered).
+	pendingConsentWrite = &struct {
+		Path    string
+		Enabled bool
+	}{Path: cfgPath, Enabled: false}
+
+	// File must not exist yet — this is the whole point of deferring.
+	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
+		t.Fatal("config file should not exist before PersistPendingConsent")
+	}
+
+	PersistPendingConsent()
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("reading config after PersistPendingConsent: %v", err)
+	}
+	if got := string(data); got != "telemetry: false\n" {
+		t.Errorf("expected %q, got %q", "telemetry: false\n", got)
+	}
+
+	// Calling again is a no-op (pendingConsentWrite was cleared).
+	PersistPendingConsent()
+}
+
+func TestPersistPendingConsentNoopWhenNil(t *testing.T) {
+	pendingConsentWrite = nil
+	// Should not panic or error.
+	PersistPendingConsent()
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -46,9 +46,13 @@ func Init(cfgTelemetry *bool, promptFn func() (bool, error), version string) (bo
 		if err != nil {
 			return false, fmt.Errorf("telemetry prompt: %w", err)
 		}
-		if err := persistConsent(config.UserConfigFilePath(), consent); err != nil {
-			slog.Warn("failed to persist telemetry consent", "err", err)
-		}
+		// Defer the file write so that sub-commands like "init" that target
+		// the same config path are not blocked by a premature file creation.
+		// The caller flushes via PersistPendingConsent in PersistentPostRunE.
+		pendingConsentWrite = &struct {
+			Path    string
+			Enabled bool
+		}{Path: config.UserConfigFilePath(), Enabled: consent}
 		state.Enabled = consent
 
 		// Fire consent event regardless of the answer so we can track

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -21,6 +21,7 @@ func resetGlobals() {
 	baseProps = nil
 	statePath = ""
 	appVersion = ""
+	pendingConsentWrite = nil
 }
 
 func TestTrackSendsPageviewWhenEnabled(t *testing.T) {


### PR DESCRIPTION
## Summary

- Defers `persistConsent` file write from `telemetry.Init` (PersistentPreRunE) to `PersistPendingConsent` (PersistentPostRunE), so sub-commands like `init` that target `~/.config/gaal/config.yaml` are not blocked by a premature file creation.
- Adds `PersistPendingConsent()` to the telemetry package and calls it in both `PersistentPostRunE` and the error path in `Execute`.
- Adds tests for deferred and no-op flush behaviour.

Closes #74

## Test plan

- [x] `go test ./...` — all 765 tests pass
- [ ] Manual: run `gaal init --import-all --scope global` on a clean machine (no prior config) and confirm it completes without "already exists"
- [ ] Manual: run `gaal init --import-all --scope global` with an existing config and `--force` — telemetry field is preserved