### PR TITLE
docs(readme): add prominent callout linking to docs.getgaal.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 
 ---
 
+> [!IMPORTANT]
+> ## 📚 Full documentation lives at [**docs.getgaal.com**](https://docs.getgaal.com)
+>
+> This README covers the essentials. For complete guides, configuration reference, agent integrations, and tutorials, head over to **[docs.getgaal.com](https://docs.getgaal.com)**.
+
+---
+
 ## What it does
 
 | Resource | Description |


### PR DESCRIPTION
## Summary
- Adds a GitHub `[!IMPORTANT]` alert block at the top of the README, directly under the ASCII banner, pointing users to the full documentation at [docs.getgaal.com](https://docs.getgaal.com).
- Renders as a large, hard-to-miss callout on GitHub so new visitors are immediately routed to the canonical docs.

## Test plan
- [x] Verify the alert renders correctly on GitHub (preview the PR)
- [x] Confirm both `docs.getgaal.com` links resolve