### PR TITLE
fix(telemetry): defer consent persist during gaal init to prevent prewrite conflict

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,7 +48,24 @@
         "init"
       ],
       "env": {},
-      "cwd": "${workspaceFolder}",
+      "cwd": "${workspaceFolder}/.sandbox/workspace",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "gaal: init (sandbox) --import-all",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}",
+      "args": [
+        "--sandbox", "${workspaceFolder}/.sandbox",
+        "--log-file", "${workspaceFolder}/.sandbox/gaal.log",
+        "--verbose",
+        "init",
+        "--import-all"
+      ],
+      "env": {},
+      "cwd": "${workspaceFolder}/.sandbox/workspace",
       "console": "integratedTerminal"
     },
     {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -207,3 +207,38 @@ func TestInit_BuildPlanGroupsSkills(t *testing.T) {
 		t.Errorf("expected 2 entries, got %d: %+v", len(cfg.Skills), cfg.Skills)
 	}
 }
+
+// TestInit_GlobalScope_NoTelemetryPrewrite is a regression test for GitHub
+// issue #74. It verifies that calling runInit with global scope on a fresh
+// machine (no pre-existing user config) does NOT fail with "already exists"
+// — which would happen if telemetry.Init wrote the user config file before
+// preflightDestination ran.
+func TestInit_GlobalScope_NoTelemetryPrewrite(t *testing.T) {
+	resetInitFlags(t)
+
+	home := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	// Pre-condition: fresh machine simulation — user config must not exist.
+	userConfigPath := config.UserConfigFilePath()
+	if _, err := os.Stat(userConfigPath); err == nil {
+		t.Fatalf("pre-condition failed: user config already exists at %s", userConfigPath)
+	}
+
+	// Default cfgFile triggers global-scope path resolution via resolveInitDestination.
+	cfgFile = "gaal.yaml"
+	initScopeFlag = "global"
+	initImportAll = true
+	forceInit = false
+	engineOpts = engine.Options{WorkDir: workDir}
+
+	err := runInit(initCmd, nil)
+
+	// The test only asserts the specific regression: preflightDestination must
+	// not reject a non-existent file. Other engine failures are acceptable.
+	if err != nil && strings.Contains(err.Error(), "already exists — use --force to overwrite") {
+		t.Errorf("telemetry pre-wrote user config before runInit: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,7 +90,7 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 			if term.IsTerminal(int(os.Stdin.Fd())) {
 				promptFn = showConsentPrompt
 			}
-			if _, err := telemetry.Init(userCfg, promptFn, Version); err != nil {
+			if _, err := telemetry.Init(userCfg, promptFn, Version, cmd.Name() == "init"); err != nil {
 				slog.Debug("telemetry init failed", "err", err)
 			}
 		}
@@ -100,6 +100,9 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 	// PersistentPostRunE runs after every sub-command. Waits briefly for
 	// in-flight telemetry events to complete before the process exits.
 	PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
+		if err := telemetry.FlushConsent(); err != nil {
+			slog.Warn("failed to persist telemetry consent", "err", err)
+		}
 		telemetry.Shutdown()
 		return nil
 	},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestApplyOptions_SandboxRedirectsUserDirs(t *testing.T) {
@@ -51,5 +53,57 @@ func TestApplyOptions_SandboxRedirectsUserDirs(t *testing.T) {
 	}
 	if got, want := os.Getenv("XDG_CACHE_HOME"), filepath.Join(sandboxDir, ".cache"); got != want {
 		t.Fatalf("XDG_CACHE_HOME = %q, want %q", got, want)
+	}
+}
+
+func TestSkipTelemetry(t *testing.T) {
+	completionParent := &cobra.Command{Use: "completion"}
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		want bool
+	}{
+		{
+			name: "version",
+			cmd:  &cobra.Command{Use: "version"},
+			want: true,
+		},
+		{
+			name: "schema",
+			cmd:  &cobra.Command{Use: "schema"},
+			want: true,
+		},
+		{
+			name: "init",
+			cmd:  &cobra.Command{Use: "init"},
+			want: false,
+		},
+		{
+			name: "sync",
+			cmd:  &cobra.Command{Use: "sync"},
+			want: false,
+		},
+		{
+			name: "status",
+			cmd:  &cobra.Command{Use: "status"},
+			want: false,
+		},
+		{
+			name: "subcommand of completion",
+			cmd: func() *cobra.Command {
+				child := &cobra.Command{Use: "bash"}
+				completionParent.AddCommand(child)
+				return child
+			}(),
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := skipTelemetry(tc.cmd); got != tc.want {
+				t.Errorf("skipTelemetry(%q) = %v, want %v", tc.cmd.Name(), got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -24,6 +24,11 @@ var (
 	statePath  string
 	appVersion string
 	pending    sync.WaitGroup
+
+	// pendingConsentPath and pendingConsentValue hold a deferred consent write
+	// requested by Init when deferPersist is true. FlushConsent drains them.
+	pendingConsentPath  string
+	pendingConsentValue *bool
 )
 
 // milestoneState tracks which one-time events have already been sent.
@@ -35,7 +40,7 @@ type milestoneState struct {
 // Init resolves consent state and initialises the telemetry client.
 // version is the gaal binary version string (passed from cmd.Version to avoid
 // circular import).
-func Init(cfgTelemetry *bool, promptFn func() (bool, error), version string) (bool, error) {
+func Init(cfgTelemetry *bool, promptFn func() (bool, error), version string, deferPersist bool) (bool, error) {
 	appVersion = version
 
 	state := resolveState(cfgTelemetry)
@@ -46,8 +51,15 @@ func Init(cfgTelemetry *bool, promptFn func() (bool, error), version string) (bo
 		if err != nil {
 			return false, fmt.Errorf("telemetry prompt: %w", err)
 		}
-		if err := persistConsent(config.UserConfigFilePath(), consent); err != nil {
-			slog.Warn("failed to persist telemetry consent", "err", err)
+		if deferPersist {
+			path := config.UserConfigFilePath()
+			slog.Debug("deferring telemetry consent persist", "path", path, "enabled", consent)
+			pendingConsentPath = path
+			pendingConsentValue = &consent
+		} else {
+			if err := persistConsent(config.UserConfigFilePath(), consent); err != nil {
+				slog.Warn("failed to persist telemetry consent", "err", err)
+			}
 		}
 		state.Enabled = consent
 
@@ -113,6 +125,24 @@ func Shutdown() {
 	case <-time.After(2 * time.Second):
 		slog.Debug("telemetry shutdown timed out, some events may be lost")
 	}
+}
+
+// FlushConsent writes any deferred telemetry consent choice to disk.
+// It is a no-op when Init was called without deferPersist or when consent
+// was already persisted immediately. Called from PersistentPostRunE so that
+// it runs after the command (e.g. "init") has written the config file itself,
+// allowing persistConsent to merge the telemetry field into the full config.
+func FlushConsent() error {
+	slog.Debug("flushing pending telemetry consent",
+		"path", pendingConsentPath, "pending", pendingConsentValue != nil)
+	if pendingConsentValue == nil {
+		return nil
+	}
+	path := pendingConsentPath
+	value := *pendingConsentValue
+	pendingConsentPath = ""
+	pendingConsentValue = nil
+	return persistConsent(path, value)
 }
 
 // Track sends a pageview event for the given command in a fire-and-forget

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -21,6 +21,8 @@ func resetGlobals() {
 	baseProps = nil
 	statePath = ""
 	appVersion = ""
+	pendingConsentPath = ""
+	pendingConsentValue = nil
 }
 
 func TestTrackSendsPageviewWhenEnabled(t *testing.T) {
@@ -190,4 +192,99 @@ func TestCopyProps(t *testing.T) {
 	if src["a"] == "changed" {
 		t.Error("copy is not independent of source")
 	}
+}
+
+func TestInit_DeferPersistDoesNotWriteFile(t *testing.T) {
+	resetGlobals()
+	defer resetGlobals()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
+
+	// Use consent=false to avoid spawning a real HTTP goroutine.
+	promptFn := func() (bool, error) { return false, nil }
+
+	_, err := Init(nil, promptFn, "0.0.0", true)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// File must NOT exist: consent was deferred, not written yet.
+	cfgPath := home + "/.config/gaal/config.yaml"
+	if _, statErr := os.Stat(cfgPath); statErr == nil {
+		t.Errorf("Init with deferPersist=true must not write the config file; found %s", cfgPath)
+	}
+
+	// But the pending state must be populated.
+	if pendingConsentValue == nil {
+		t.Error("pendingConsentValue must be non-nil after deferred Init")
+	}
+}
+
+func TestFlushConsent_WritesPendingConsent(t *testing.T) {
+	resetGlobals()
+	defer resetGlobals()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
+
+	// Use consent=false to avoid spawning a real HTTP goroutine.
+	promptFn := func() (bool, error) { return false, nil }
+
+	_, err := Init(nil, promptFn, "0.0.0", true)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := FlushConsent(); err != nil {
+		t.Fatalf("FlushConsent: %v", err)
+	}
+
+	// File must now exist with telemetry: false (the user declined).
+	cfgPath := home + "/.config/gaal/config.yaml"
+	data, readErr := os.ReadFile(cfgPath)
+	if readErr != nil {
+		t.Fatalf("expected config file after FlushConsent; got: %v", readErr)
+	}
+	if !containsStr(string(data), "telemetry: false") {
+		t.Errorf("expected telemetry: false in config, got:\n%s", data)
+	}
+
+	// Pending state must be cleared.
+	if pendingConsentValue != nil {
+		t.Error("pendingConsentValue must be nil after FlushConsent")
+	}
+}
+
+func TestFlushConsent_NoopWhenNoPending(t *testing.T) {
+	resetGlobals()
+	defer resetGlobals()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
+
+	if err := FlushConsent(); err != nil {
+		t.Fatalf("FlushConsent with no pending state returned error: %v", err)
+	}
+
+	// No file should be created.
+	cfgPath := home + "/.config/gaal/config.yaml"
+	if _, statErr := os.Stat(cfgPath); statErr == nil {
+		t.Errorf("FlushConsent with no pending state must not create a file")
+	}
+}
+
+// containsStr is a helper for substring checks in test output.
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})())
 }


### PR DESCRIPTION
## Summary

On a fresh machine, `gaal init --import-all` with scope `global` failed with:
```
Error: /home/<user>/.config/gaal/config.yaml already exists — use --force to overwrite
```

**Root cause:** `PersistentPreRunE` called `telemetry.Init()`, which prompted for consent then immediately wrote `~/.config/gaal/config.yaml` (containing only `telemetry: false`). When `runInit` later called `preflightDestination` on that same path, it found the file present and aborted.

**Fix:** Pass `deferPersist=true` to `telemetry.Init` when the command is `init`. The consent choice is held in memory and flushed by `PersistentPostRunE` via the new `FlushConsent()` function, which merges the `telemetry` field into the config file already written by `runInit`. All other commands retain immediate persist behaviour (`deferPersist=false`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Closes #74

## Checklist

- [x] `make lint` passes — `gofmt` formatting + `go vet` clean
- [x] `make build` passes on Linux and macOS
- [x] `make test` passes — unit tests with race detector
- [x] Every new function has at least one `slog.Debug` / `slog.DebugContext` call
- [x] Documentation updated if user-facing behaviour changed
- [x] No secrets or credentials are exposed in logs or config snippets