### PR TITLE
fix(config): leave empty MCP target untouched in path expansion

### DIFF
--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -88,6 +88,9 @@ func (c *Config) expandPaths(baseDir string) {
 	}
 
 	for i := range c.MCPs {
+		if c.MCPs[i].Target == "" {
+			continue
+		}
 		c.MCPs[i].Target = expandPath(c.MCPs[i].Target)
 	}
 }

--- a/internal/config/utils_test.go
+++ b/internal/config/utils_test.go
@@ -167,6 +167,34 @@ mcps:
 	}
 }
 
+// TestExpandPaths_MCPEmptyTargetUnchanged guards against a regression where
+// the optional Target field, left empty in the new agents+global flow, was
+// being rewritten to the config file's parent directory by filepath.Join.
+func TestExpandPaths_MCPEmptyTargetUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "gaal.yaml")
+	os.WriteFile(p, []byte(`
+mcps:
+  - name: context7
+    agents: ["claude-code", "codex"]
+    global: true
+    inline:
+      command: npx
+      args: ['-y', '@upstash/context7-mcp@latest']
+`), 0o644)
+
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.MCPs) == 0 {
+		t.Fatal("expected one MCP entry")
+	}
+	if cfg.MCPs[0].Target != "" {
+		t.Errorf("empty Target should remain empty, got %q", cfg.MCPs[0].Target)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // isRemoteURL / isGitHubShorthand (unit tests on the helpers directly)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #84.

`expandPath("")` fell through to `filepath.Join(baseDir, "")`, which returns `baseDir`. So any MCP entry using the new `agents` + `global` flow (no `target:` field) had its `Target` silently rewritten to the config file's parent directory.

That broke `gaal sync` three ways:
- `mc.Target != ""` triggered a spurious `'target' field is deprecated` warning,
- `resolvedMCPs()` short-circuited before computing the per-agent path,
- `mergeIntoTarget()` then tried to read a directory as JSON, producing the user-reported error: `read /Users/<u>/.config/gaal: is a directory`.

The fix skips path expansion when `Target` is empty, so the agents/global resolution path in `mcp.Manager.resolvedMCPs` runs as designed.

## Test plan
- [x] Added `TestExpandPaths_MCPEmptyTargetUnchanged` regression test
- [x] Existing `TestExpandPaths_MCPTargetRelative` still passes (legacy `target:` field continues to be expanded)
- [x] Reproduced the issue with the exact config from #84 — `gaal sync --dry-run` now resolves `context7` to `~/.codex/mcp.json` instead of erroring
- [x] `go test ./...` passes