### PR TITLE
fix(mcp): write codex MCP servers to ~/.codex/config.toml (TOML)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
+	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/mattn/go-runewidth v0.0.20 h1:WcT52H91ZUAwy8+HUkdM3THM6gXqXuLJi9O3rjc
 github.com/mattn/go-runewidth v0.0.20/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
+github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
+github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/core/agent/agents.yaml
+++ b/internal/core/agent/agents.yaml
@@ -113,7 +113,7 @@ agents:
     supports_generic_project: true
     project_skills_dir: ""
     global_skills_dir: ~/.codex/skills
-    global_mcp_config_file: ~/.codex/mcp.json
+    global_mcp_config_file: ~/.codex/config.toml
     project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search:

--- a/internal/mcp/codec.go
+++ b/internal/mcp/codec.go
@@ -1,0 +1,208 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// mcpCodec abstracts reading and writing the MCP-server table inside an
+// agent's config file. JSON-based agents use the "mcpServers" object at the
+// document root; codex uses a TOML "mcp_servers" table inside config.toml
+// alongside unrelated keys (model, sandbox, [analytics]…) that must survive
+// a round-trip.
+type mcpCodec interface {
+	// ReadServers returns the current servers map. A missing file or a
+	// missing servers table both return (nil, nil); only parse errors are
+	// surfaced.
+	ReadServers(path string) (map[string]serverEntry, error)
+
+	// WriteServers replaces the servers table with the given map while
+	// preserving every other top-level key that already exists in path.
+	WriteServers(path string, servers map[string]serverEntry) error
+}
+
+// codecFor picks a codec based on the target's file extension. Unknown
+// extensions default to JSON, matching every JSON-based MCP client (Claude
+// Desktop, VS Code, Cursor…).
+func codecFor(path string) mcpCodec {
+	if strings.EqualFold(extOf(path), ".toml") {
+		return tomlCodec{}
+	}
+	return jsonCodec{}
+}
+
+func extOf(path string) string {
+	if i := strings.LastIndex(path, "."); i >= 0 {
+		return path[i:]
+	}
+	return ""
+}
+
+// ── JSON ────────────────────────────────────────────────────────────────────
+
+type jsonCodec struct{}
+
+func (jsonCodec) ReadServers(path string) (map[string]serverEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	serversRaw, ok := raw["mcpServers"]
+	if !ok {
+		return nil, nil
+	}
+	var servers map[string]serverEntry
+	if err := json.Unmarshal(serversRaw, &servers); err != nil {
+		return nil, fmt.Errorf("parsing mcpServers in %s: %w", path, err)
+	}
+	return servers, nil
+}
+
+func (jsonCodec) WriteServers(path string, servers map[string]serverEntry) error {
+	raw := map[string]json.RawMessage{}
+	if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("parsing existing config %s: %w", path, err)
+		}
+	}
+
+	updated, err := json.Marshal(servers)
+	if err != nil {
+		return err
+	}
+	raw["mcpServers"] = updated
+
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644) //nolint:gosec
+}
+
+// ── TOML ────────────────────────────────────────────────────────────────────
+
+const tomlServersKey = "mcp_servers"
+
+type tomlCodec struct{}
+
+func (tomlCodec) ReadServers(path string) (map[string]serverEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	doc := map[string]any{}
+	if err := toml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	rawTable, ok := doc[tomlServersKey].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+
+	servers := make(map[string]serverEntry, len(rawTable))
+	for name, v := range rawTable {
+		entry, ok := v.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("parsing %s: %s.%s is not a table", path, tomlServersKey, name)
+		}
+		servers[name] = decodeTOMLEntry(entry)
+	}
+	return servers, nil
+}
+
+func (tomlCodec) WriteServers(path string, servers map[string]serverEntry) error {
+	doc := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
+		if err := toml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("parsing existing config %s: %w", path, err)
+		}
+	}
+
+	if len(servers) == 0 {
+		delete(doc, tomlServersKey)
+	} else {
+		table := make(map[string]any, len(servers))
+		for name, e := range servers {
+			table[name] = encodeTOMLEntry(e)
+		}
+		doc[tomlServersKey] = table
+	}
+
+	out, err := toml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("encoding %s: %w", path, err)
+	}
+	return os.WriteFile(path, out, 0o644) //nolint:gosec
+}
+
+// decodeTOMLEntry converts a parsed TOML table into a serverEntry, normalising
+// the args slice (TOML decodes arrays as []any) and env table types.
+func decodeTOMLEntry(t map[string]any) serverEntry {
+	var e serverEntry
+	if v, ok := t["command"].(string); ok {
+		e.Command = v
+	}
+	if rawArgs, ok := t["args"].([]any); ok {
+		e.Args = make([]string, 0, len(rawArgs))
+		for _, a := range rawArgs {
+			if s, ok := a.(string); ok {
+				e.Args = append(e.Args, s)
+			}
+		}
+	}
+	if rawEnv, ok := t["env"].(map[string]any); ok && len(rawEnv) > 0 {
+		e.Env = make(map[string]string, len(rawEnv))
+		for k, v := range rawEnv {
+			if s, ok := v.(string); ok {
+				e.Env[k] = s
+			}
+		}
+	}
+	return e
+}
+
+// encodeTOMLEntry produces the inverse of decodeTOMLEntry, omitting empty
+// fields so the rendered TOML stays minimal.
+func encodeTOMLEntry(e serverEntry) map[string]any {
+	out := map[string]any{}
+	if e.Command != "" {
+		out["command"] = e.Command
+	}
+	if len(e.Args) > 0 {
+		args := make([]any, len(e.Args))
+		for i, a := range e.Args {
+			args[i] = a
+		}
+		out["args"] = args
+	}
+	if len(e.Env) > 0 {
+		env := make(map[string]any, len(e.Env))
+		for k, v := range e.Env {
+			env[k] = v
+		}
+		out["env"] = env
+	}
+	return out
+}

--- a/internal/mcp/codec_test.go
+++ b/internal/mcp/codec_test.go
@@ -1,0 +1,221 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// codecFor dispatch ----------------------------------------------------------
+
+func TestCodecFor_DispatchesByExtension(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/x/claude_desktop_config.json", "json"},
+		{"/x/config.toml", "toml"},
+		{"/x/CONFIG.TOML", "toml"}, // case-insensitive
+		{"/x/no-extension", "json"},
+	}
+	for _, tc := range cases {
+		got := "json"
+		if _, ok := codecFor(tc.path).(tomlCodec); ok {
+			got = "toml"
+		}
+		if got != tc.want {
+			t.Errorf("codecFor(%q) = %s, want %s", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TOML codec -----------------------------------------------------------------
+
+func TestTOMLCodec_RoundTripPreservesUnrelatedKeys(t *testing.T) {
+	// Mimic a real ~/.codex/config.toml that already carries user settings
+	// gaal must not stomp.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	original := `model = "gpt-5.4"
+sandbox = "macos"
+approval_policy = "on-request"
+
+[analytics]
+enabled = true
+
+[features]
+child_agents_md = true
+`
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	c := tomlCodec{}
+	servers, err := c.ReadServers(path)
+	if err != nil {
+		t.Fatalf("ReadServers: %v", err)
+	}
+	if servers != nil {
+		t.Errorf("expected nil servers map, got %v", servers)
+	}
+
+	servers = map[string]serverEntry{
+		"context7": {Command: "npx", Args: []string{"-y", "@upstash/context7-mcp@latest"}},
+	}
+	if err := c.WriteServers(path, servers); err != nil {
+		t.Fatalf("WriteServers: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var doc map[string]any
+	if err := toml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse back: %v", err)
+	}
+
+	// Unrelated keys must survive.
+	if doc["model"] != "gpt-5.4" {
+		t.Errorf("model lost: %v", doc["model"])
+	}
+	if doc["sandbox"] != "macos" {
+		t.Errorf("sandbox lost: %v", doc["sandbox"])
+	}
+	if doc["approval_policy"] != "on-request" {
+		t.Errorf("approval_policy lost: %v", doc["approval_policy"])
+	}
+	analytics, ok := doc["analytics"].(map[string]any)
+	if !ok || analytics["enabled"] != true {
+		t.Errorf("[analytics] table lost: %v", doc["analytics"])
+	}
+	features, ok := doc["features"].(map[string]any)
+	if !ok || features["child_agents_md"] != true {
+		t.Errorf("[features] table lost: %v", doc["features"])
+	}
+
+	// Server entry must be the codex-expected shape.
+	servers, err = c.ReadServers(path)
+	if err != nil {
+		t.Fatalf("ReadServers (after write): %v", err)
+	}
+	got, ok := servers["context7"]
+	if !ok {
+		t.Fatalf("context7 missing after round-trip; got %v", servers)
+	}
+	if got.Command != "npx" {
+		t.Errorf("command = %q, want npx", got.Command)
+	}
+	if len(got.Args) != 2 || got.Args[0] != "-y" || got.Args[1] != "@upstash/context7-mcp@latest" {
+		t.Errorf("args = %v, want [-y @upstash/context7-mcp@latest]", got.Args)
+	}
+
+	// And the rendered file must contain the [mcp_servers.context7] header
+	// so codex's parser actually sees it.
+	if !strings.Contains(string(data), "mcp_servers") {
+		t.Errorf("rendered TOML missing mcp_servers table:\n%s", data)
+	}
+}
+
+func TestTOMLCodec_UpsertReplacesExistingEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	seed := `[mcp_servers.context7]
+command = "old"
+args = ["x"]
+
+[mcp_servers.other]
+command = "keep"
+`
+	os.WriteFile(path, []byte(seed), 0o644)
+
+	c := tomlCodec{}
+	servers, err := c.ReadServers(path)
+	if err != nil {
+		t.Fatalf("ReadServers: %v", err)
+	}
+	if servers["context7"].Command != "old" {
+		t.Fatalf("seed not parsed: %+v", servers)
+	}
+
+	servers["context7"] = serverEntry{Command: "npx", Args: []string{"-y", "ctx"}}
+	if err := c.WriteServers(path, servers); err != nil {
+		t.Fatalf("WriteServers: %v", err)
+	}
+
+	got, _ := c.ReadServers(path)
+	if got["context7"].Command != "npx" {
+		t.Errorf("upsert failed for context7: %+v", got["context7"])
+	}
+	if got["other"].Command != "keep" {
+		t.Errorf("sibling entry lost: %+v", got["other"])
+	}
+}
+
+func TestTOMLCodec_MissingFileReturnsNil(t *testing.T) {
+	servers, err := tomlCodec{}.ReadServers(filepath.Join(t.TempDir(), "no-such.toml"))
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if servers != nil {
+		t.Errorf("expected nil servers map, got %v", servers)
+	}
+}
+
+func TestTOMLCodec_PreservesEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	c := tomlCodec{}
+	in := map[string]serverEntry{
+		"with-env": {
+			Command: "node",
+			Args:    []string{"server.js"},
+			Env:     map[string]string{"API_KEY": "secret", "DEBUG": "1"},
+		},
+	}
+	if err := c.WriteServers(path, in); err != nil {
+		t.Fatalf("WriteServers: %v", err)
+	}
+	out, err := c.ReadServers(path)
+	if err != nil {
+		t.Fatalf("ReadServers: %v", err)
+	}
+	got := out["with-env"]
+	if got.Env["API_KEY"] != "secret" || got.Env["DEBUG"] != "1" {
+		t.Errorf("env not preserved: %+v", got.Env)
+	}
+}
+
+// End-to-end via mergeIntoTarget --------------------------------------------
+
+func TestMergeIntoTarget_TOMLDispatch(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(target, []byte("model = \"gpt-5.4\"\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	entry := serverEntry{Command: "npx", Args: []string{"-y", "@upstash/context7-mcp@latest"}}
+	if err := mergeIntoTarget(target, "context7", entry); err != nil {
+		t.Fatalf("mergeIntoTarget: %v", err)
+	}
+
+	// File must still parse as TOML — not JSON.
+	data, _ := os.ReadFile(target)
+	if json.Valid(data) && !strings.Contains(string(data), "mcp_servers") {
+		t.Errorf("target was rewritten as JSON; got:\n%s", data)
+	}
+
+	servers, err := tomlCodec{}.ReadServers(target)
+	if err != nil {
+		t.Fatalf("ReadServers: %v", err)
+	}
+	if servers["context7"].Command != "npx" {
+		t.Errorf("context7 not written: %+v", servers)
+	}
+}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -103,12 +103,30 @@ func (m *Manager) resolvedMCPs() []config.ConfigMcp {
 
 // Sync applies every MCP configuration entry.
 func (m *Manager) Sync(ctx context.Context) error {
+	m.warnLegacyCodexJSON()
 	for _, mc := range m.resolvedMCPs() {
 		if err := m.syncOne(ctx, mc); err != nil {
 			return fmt.Errorf("mcp %q: %w", mc.Name, err)
 		}
 	}
 	return nil
+}
+
+// warnLegacyCodexJSON surfaces a one-shot notice when a stale ~/.codex/mcp.json
+// file exists. Earlier gaal releases wrote MCP entries there, but the official
+// Codex CLI only reads ~/.codex/config.toml — the JSON file was a silent
+// no-op. Users who upgraded carry both files; the JSON one can be deleted.
+func (m *Manager) warnLegacyCodexJSON() {
+	if m.home == "" {
+		return
+	}
+	legacy := filepath.Join(m.home, ".codex", "mcp.json")
+	if _, err := os.Stat(legacy); err != nil {
+		return
+	}
+	slog.Warn("mcp: stale ~/.codex/mcp.json detected — codex CLI ignores it; safe to delete",
+		"path", legacy,
+		"hint", "MCP entries are now written to ~/.codex/config.toml")
 }
 
 func (m *Manager) syncOne(ctx context.Context, mc config.ConfigMcp) error {
@@ -204,11 +222,12 @@ func fetchRemoteEntry(ctx context.Context, rawURL, name string) (serverEntry, er
 	return serverEntry{}, fmt.Errorf("no server entry found in %s", rawURL)
 }
 
-// mergeIntoTarget reads the target JSON file, upserts the named entry, and
-// writes it back. If the target's parent directory does not already exist
-// the entry is silently skipped: sync never creates agent-owned directories
-// as a side effect. A parent that exists but is not a directory is reported
-// as an error (user misconfiguration).
+// mergeIntoTarget reads the target config file (JSON or TOML, picked by
+// extension), upserts the named entry, and writes it back. If the target's
+// parent directory does not already exist the entry is silently skipped:
+// sync never creates agent-owned directories as a side effect. A parent
+// that exists but is not a directory is reported as an error (user
+// misconfiguration).
 func mergeIntoTarget(target, name string, entry serverEntry) error {
 	slog.Debug("merging mcp entry into target", "name", name, "target", target)
 
@@ -226,36 +245,17 @@ func mergeIntoTarget(target, name string, entry serverEntry) error {
 		return fmt.Errorf("%s is not a directory", parent)
 	}
 
-	// Load existing document (or start fresh).
-	raw := map[string]json.RawMessage{}
-	if data, err := os.ReadFile(target); err == nil {
-		if err := json.Unmarshal(data, &raw); err != nil {
-			return fmt.Errorf("parsing existing config %s: %w", target, err)
-		}
+	codec := codecFor(target)
+	servers, err := codec.ReadServers(target)
+	if err != nil {
+		return err
 	}
-
-	// Get or initialise the mcpServers key.
-	servers := map[string]serverEntry{}
-	if existing, ok := raw["mcpServers"]; ok {
-		if err := json.Unmarshal(existing, &servers); err != nil {
-			return fmt.Errorf("parsing mcpServers: %w", err)
-		}
+	if servers == nil {
+		servers = map[string]serverEntry{}
 	}
-
 	servers[name] = entry
 
-	updated, err := json.Marshal(servers)
-	if err != nil {
-		return err
-	}
-	raw["mcpServers"] = updated
-
-	out, err := json.MarshalIndent(raw, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	if err := os.WriteFile(target, out, 0o644); err != nil { //nolint:gosec
+	if err := codec.WriteServers(target, servers); err != nil {
 		return fmt.Errorf("writing config %s: %w", target, err)
 	}
 
@@ -280,28 +280,13 @@ func (m *Manager) Prune(ctx context.Context) error {
 	}
 
 	for target, keep := range keepPerTarget {
-		data, err := os.ReadFile(target)
+		codec := codecFor(target)
+		servers, err := codec.ReadServers(target)
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
 			slog.Warn("mcp prune: cannot read target", "target", target, "err", err)
 			continue
 		}
-
-		raw := map[string]json.RawMessage{}
-		if err := json.Unmarshal(data, &raw); err != nil {
-			slog.Warn("mcp prune: cannot parse target", "target", target, "err", err)
-			continue
-		}
-
-		serversRaw, ok := raw["mcpServers"]
-		if !ok {
-			continue
-		}
-		servers := map[string]json.RawMessage{}
-		if err := json.Unmarshal(serversRaw, &servers); err != nil {
-			slog.Warn("mcp prune: cannot parse mcpServers", "target", target, "err", err)
+		if len(servers) == 0 {
 			continue
 		}
 
@@ -317,26 +302,8 @@ func (m *Manager) Prune(ctx context.Context) error {
 			continue
 		}
 
-		updated, err := json.Marshal(servers)
-		if err != nil {
-			slog.Warn("mcp prune: marshal error", "target", target, "err", err)
-			continue
-		}
-		raw["mcpServers"] = updated
-
-		out, err := json.MarshalIndent(raw, "", "  ")
-		if err != nil {
-			slog.Warn("mcp prune: indent error", "target", target, "err", err)
-			continue
-		}
-
-		tmp := target + ".tmp"
-		if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		if err := codec.WriteServers(target, servers); err != nil {
 			slog.Warn("mcp prune: write error", "target", target, "err", err)
-			continue
-		}
-		if err := os.Rename(tmp, target); err != nil {
-			slog.Warn("mcp prune: rename error", "target", target, "err", err)
 			continue
 		}
 		// Refresh snapshot so next status check reflects the pruned state.
@@ -355,38 +322,22 @@ func (m *Manager) Status(_ context.Context) []Status {
 	for _, mc := range resolved {
 		st := Status{Name: mc.Name, Target: mc.Target}
 
-		data, err := os.ReadFile(mc.Target)
+		servers, err := codecFor(mc.Target).ReadServers(mc.Target)
 		if err != nil {
-			if os.IsNotExist(err) {
-				statuses = append(statuses, st) // not present
-				continue
-			}
 			st.Err = err
 			statuses = append(statuses, st)
 			continue
 		}
-
-		var raw map[string]json.RawMessage
-		if err := json.Unmarshal(data, &raw); err != nil {
-			st.Err = fmt.Errorf("parsing %s: %w", mc.Target, err)
-			statuses = append(statuses, st)
-			continue
-		}
-
-		if serversRaw, ok := raw["mcpServers"]; ok {
-			var servers map[string]serverEntry
-			if err := json.Unmarshal(serversRaw, &servers); err == nil {
-				stored, found := servers[mc.Name]
-				st.Present = found
-				// For inline configs we can detect divergence without I/O.
-				if found && mc.Inline != nil {
-					want := serverEntry{
-						Command: mc.Inline.Command,
-						Args:    mc.Inline.Args,
-						Env:     mc.Inline.Env,
-					}
-					st.Dirty = !serverEntryEqual(stored, want)
+		if stored, found := servers[mc.Name]; found {
+			st.Present = true
+			// For inline configs we can detect divergence without I/O.
+			if mc.Inline != nil {
+				want := serverEntry{
+					Command: mc.Inline.Command,
+					Args:    mc.Inline.Args,
+					Env:     mc.Inline.Env,
 				}
+				st.Dirty = !serverEntryEqual(stored, want)
 			}
 		}
 
@@ -422,33 +373,18 @@ func serverEntryEqual(a, b serverEntry) bool {
 }
 
 // LoadServers reads the given MCP config file and returns the full inline
-// definition of every server found in the "mcpServers" object, keyed by name.
-// Returns nil, nil when the file does not exist or has no "mcpServers" entry.
+// definition of every server, keyed by name. JSON and TOML config files are
+// both supported (extension-based dispatch). Returns nil, nil when the file
+// does not exist or has no servers entry.
 func LoadServers(configFile string) (map[string]config.ConfigMcpItem, error) {
 	slog.Debug("loading mcp servers", "file", configFile)
-	data, err := os.ReadFile(configFile)
+	servers, err := codecFor(configFile).ReadServers(configFile)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("reading %s: %w", configFile, err)
+		return nil, err
 	}
-
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", configFile, err)
-	}
-
-	serversRaw, ok := raw["mcpServers"]
-	if !ok {
+	if len(servers) == 0 {
 		return nil, nil
 	}
-
-	var servers map[string]serverEntry
-	if err := json.Unmarshal(serversRaw, &servers); err != nil {
-		return nil, fmt.Errorf("parsing mcpServers in %s: %w", configFile, err)
-	}
-
 	out := make(map[string]config.ConfigMcpItem, len(servers))
 	for name, s := range servers {
 		out[name] = config.ConfigMcpItem{
@@ -461,33 +397,17 @@ func LoadServers(configFile string) (map[string]config.ConfigMcpItem, error) {
 }
 
 // ListServers reads the given MCP config file and returns a sorted list of
-// server names found in the "mcpServers" object. Returns nil, nil when the
-// file does not exist (the agent is simply not installed on this machine).
+// server names. Returns nil, nil when the file does not exist (the agent is
+// simply not installed on this machine).
 func ListServers(configFile string) ([]string, error) {
 	slog.Debug("listing mcp servers", "file", configFile)
-	data, err := os.ReadFile(configFile)
+	servers, err := codecFor(configFile).ReadServers(configFile)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("reading %s: %w", configFile, err)
+		return nil, err
 	}
-
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", configFile, err)
-	}
-
-	serversRaw, ok := raw["mcpServers"]
-	if !ok {
+	if len(servers) == 0 {
 		return nil, nil
 	}
-
-	var servers map[string]json.RawMessage
-	if err := json.Unmarshal(serversRaw, &servers); err != nil {
-		return nil, fmt.Errorf("parsing mcpServers in %s: %w", configFile, err)
-	}
-
 	names := make([]string, 0, len(servers))
 	for name := range servers {
 		names = append(names, name)

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -103,7 +103,6 @@ func (m *Manager) resolvedMCPs() []config.ConfigMcp {
 
 // Sync applies every MCP configuration entry.
 func (m *Manager) Sync(ctx context.Context) error {
-	m.warnLegacyCodexJSON()
 	for _, mc := range m.resolvedMCPs() {
 		if err := m.syncOne(ctx, mc); err != nil {
 			return fmt.Errorf("mcp %q: %w", mc.Name, err)
@@ -112,22 +111,6 @@ func (m *Manager) Sync(ctx context.Context) error {
 	return nil
 }
 
-// warnLegacyCodexJSON surfaces a one-shot notice when a stale ~/.codex/mcp.json
-// file exists. Earlier gaal releases wrote MCP entries there, but the official
-// Codex CLI only reads ~/.codex/config.toml — the JSON file was a silent
-// no-op. Users who upgraded carry both files; the JSON one can be deleted.
-func (m *Manager) warnLegacyCodexJSON() {
-	if m.home == "" {
-		return
-	}
-	legacy := filepath.Join(m.home, ".codex", "mcp.json")
-	if _, err := os.Stat(legacy); err != nil {
-		return
-	}
-	slog.Warn("mcp: stale ~/.codex/mcp.json detected — codex CLI ignores it; safe to delete",
-		"path", legacy,
-		"hint", "MCP entries are now written to ~/.codex/config.toml")
-}
 
 func (m *Manager) syncOne(ctx context.Context, mc config.ConfigMcp) error {
 	slog.DebugContext(ctx, "syncing mcp entry", "name", mc.Name, "target", mc.Target)


### PR DESCRIPTION
## Summary

Fixes #90.

The official OpenAI Codex CLI reads MCP server definitions from \`~/.codex/config.toml\` under \`[mcp_servers.<name>]\` tables ([codex docs](https://github.com/openai/codex/blob/main/docs/config.md)). gaal was writing them to \`~/.codex/mcp.json\` instead, which Codex never reads — so any \`mcps:\` entry targeting codex was a silent no-op.

## Changes

- **Registry**: \`codex.global_mcp_config_file\` is now \`~/.codex/config.toml\`.
- **\`internal/mcp/codec.go\`** (new): \`mcpCodec\` interface with \`jsonCodec\` and \`tomlCodec\` implementations, dispatched by file extension via \`codecFor(target)\`. JSON-based agents (claude-code, cursor, etc.) keep their exact existing behavior.
- **TOML codec** uses a \`map[string]any\` round-trip so unrelated top-level keys (\`model\`, \`sandbox\`, \`[analytics]\`, \`[features]\`, …) survive every write. Comments are not preserved — acceptable tradeoff vs. needing an AST-aware library; flagged as out of scope in #90.
- **\`internal/mcp/manager.go\`**: \`mergeIntoTarget\`, \`Status\`, \`Prune\`, \`LoadServers\`, \`ListServers\` all delegate to \`codecFor(target)\` instead of hand-rolled JSON parsing. Net -136 / +59 lines in that file.
- **One-shot legacy warning**: \`Manager.Sync\` logs a notice when \`~/.codex/mcp.json\` exists, telling the user the file is no longer used and safe to delete. Not auto-removed (avoid surprise).

## Tests

\`internal/mcp/codec_test.go\` (new) covers:
- Format dispatch by extension (case-insensitive)
- TOML round-trip preserves unrelated \`model\`, \`sandbox\`, \`[analytics]\`, \`[features]\` keys
- Upsert replaces existing \`[mcp_servers.X]\` entries without disturbing siblings
- Env vars round-trip correctly through TOML's nested-table syntax
- Missing file returns \`(nil, nil)\`
- \`mergeIntoTarget\` end-to-end with TOML target

## Manual verification

\`\`\`console
$ env HOME=/tmp/iso XDG_CONFIG_HOME=/tmp/iso/.config gaal sync
✓ context7  upserted in config.toml
sync complete in 0s

$ cat /tmp/iso/.codex/config.toml
approval_policy = 'on-request'
model = 'gpt-5.4'
sandbox = 'macos'

[analytics]
enabled = true

[mcp_servers]
[mcp_servers.context7]
args = ['-y', '@upstash/context7-mcp@latest']
command = 'npx'
\`\`\`

All pre-existing keys preserved; codex now picks up the entry.

## Out of scope (explicit)

- Migrating users' existing \`~/.codex/mcp.json\` (they get a one-shot warning instead — the file is harmless).
- Comment preservation in TOML.
- Project-scoped codex MCP config (codex doesn't currently expose one).

## Test plan
- [x] \`go test ./...\` passes
- [x] New TOML codec unit tests
- [x] End-to-end: \`gaal sync\` against an isolated \`\$HOME\` containing a hand-written \`~/.codex/config.toml\` produces a valid TOML file with the entry added and unrelated keys preserved
- [x] Legacy \`~/.codex/mcp.json\` warning fires once per sync
- [x] Existing JSON-based MCP tests still pass (regression check)