### PR TITLE
fix(agents): point claude-code at ~/.claude.json + add claude-desktop agent

### DIFF
--- a/internal/core/agent/agents.yaml
+++ b/internal/core/agent/agents.yaml
@@ -85,8 +85,10 @@ agents:
   claude-code:
     project_skills_dir: .claude/skills
     global_skills_dir: ~/.claude/skills
-    global_mcp_config_file: ~/.config/claude/claude_desktop_config.json
-    project_mcp_config_file: ""
+    # ~/.claude.json carries OAuth tokens, per-project state, caches; the
+    # mcpServers key is upserted in place and unrelated keys are preserved.
+    global_mcp_config_file: ~/.claude.json
+    project_mcp_config_file: .mcp.json
     project_skills_search:
       - .claude/skills
       - .agents/skills
@@ -97,6 +99,22 @@ agents:
       - ~/.copilot/skills
     pm_skills_search:
       - ~/.claude/plugins/cache
+
+  # claude-desktop is the GUI app, distinct from claude-code (the CLI).
+  # Path below is the macOS canonical location; Claude Desktop is officially
+  # macOS- and Windows-only. Linux users get a sync-time warning.
+  # Windows users can override this path via ~/.config/gaal/agents.yaml
+  # to point at ~/AppData/Roaming/Claude/claude_desktop_config.json.
+  claude-desktop:
+    supports_generic_project: true
+    supports_generic_global: true
+    project_skills_dir: ""
+    global_skills_dir: ""
+    global_mcp_config_file: ~/Library/Application Support/Claude/claude_desktop_config.json
+    project_mcp_config_file: ""
+    project_skills_search: []
+    global_skills_search: []
+    pm_skills_search: []
 
   cline:
     supports_generic_project: true

--- a/internal/core/agent/registry.go
+++ b/internal/core/agent/registry.go
@@ -183,10 +183,18 @@ func validateEntry(name string, e agentEntry) error {
 		!strings.HasPrefix(e.GlobalMCPConfigFile, `~\`) {
 		return fmt.Errorf("agent %q: global_mcp_config_file must be empty or start with '~/', got %q", name, e.GlobalMCPConfigFile)
 	}
+	// project_mcp_config_file: may be workspace-relative (e.g. ".mcp.json"
+	// for claude-code) or home-relative (~/-prefixed). Absolute paths and
+	// ".." segments are rejected — same rule as project_skills_dir.
 	if e.ProjectMCPConfigFile != "" &&
 		!strings.HasPrefix(e.ProjectMCPConfigFile, "~/") &&
-		!strings.HasPrefix(e.ProjectMCPConfigFile, `~\\`) {
-		return fmt.Errorf("agent %q: project_mcp_config_file must be empty or start with '~/', got %q", name, e.ProjectMCPConfigFile)
+		!strings.HasPrefix(e.ProjectMCPConfigFile, `~\`) {
+		if isAbsPath(e.ProjectMCPConfigFile) {
+			return fmt.Errorf("agent %q: project_mcp_config_file must be relative or ~/-prefixed, got %q", name, e.ProjectMCPConfigFile)
+		}
+		if containsDotDot(e.ProjectMCPConfigFile) {
+			return fmt.Errorf("agent %q: project_mcp_config_file must not contain '..', got %q", name, e.ProjectMCPConfigFile)
+		}
 	}
 	for _, d := range e.ProjectSkillsSearch {
 		if isAbsPath(d) {

--- a/internal/core/agent/registry_internal_test.go
+++ b/internal/core/agent/registry_internal_test.go
@@ -149,7 +149,31 @@ func TestValidateEntry_MCPConfigWithoutTilde_Rejected(t *testing.T) {
 		ProjectMCPConfigFile: "/absolute/mcp.json",
 	}
 	if err := validateEntry("foo", e); err == nil {
-		t.Error("expected error for project_mcp_config_file without ~/")
+		t.Error("expected error for absolute project_mcp_config_file")
+	}
+}
+
+func TestValidateEntry_RelativeProjectMCPConfig_Accepted(t *testing.T) {
+	// Workspace-relative project MCP path (e.g. claude-code's .mcp.json) is
+	// allowed and resolved against cwd by callers.
+	e := agentEntry{
+		ProjectSkillsDir:     ".foo/skills",
+		GlobalSkillsDir:      "~/.foo/skills",
+		ProjectMCPConfigFile: ".mcp.json",
+	}
+	if err := validateEntry("foo", e); err != nil {
+		t.Errorf("relative project_mcp_config_file should be accepted, got %v", err)
+	}
+}
+
+func TestValidateEntry_DotDotInProjectMCPConfig_Rejected(t *testing.T) {
+	e := agentEntry{
+		ProjectSkillsDir:     ".foo/skills",
+		GlobalSkillsDir:      "~/.foo/skills",
+		ProjectMCPConfigFile: "../escape/mcp.json",
+	}
+	if err := validateEntry("foo", e); err == nil {
+		t.Error("expected error for '..' in project_mcp_config_file")
 	}
 }
 

--- a/internal/engine/ops/init_build_test.go
+++ b/internal/engine/ops/init_build_test.go
@@ -136,13 +136,9 @@ func TestBuildImportCandidates_MCPsFromAgentConfig(t *testing.T) {
 	workDir := t.TempDir()
 	cacheRoot := t.TempDir()
 
-	// claude-code's ProjectMCPConfigFile is ~/.config/claude/claude_desktop_config.json.
-	cfgDir := filepath.Join(home, ".config", "claude")
-	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	// claude-code reads its user-global MCP servers from ~/.claude.json.
 	content := `{"mcpServers":{"filesystem":{"command":"uvx","args":["mcp-server-filesystem","/tmp"]}}}`
-	cfgFile := filepath.Join(cfgDir, "claude_desktop_config.json")
+	cfgFile := filepath.Join(home, ".claude.json")
 	if err := os.WriteFile(cfgFile, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"sync"
 
 	"gaal/internal/config"
 	"gaal/internal/core/agent"
@@ -44,6 +46,7 @@ type Manager struct {
 	mcps     []config.ConfigMcp
 	home     string // user home directory for ~/ expansion and agent path resolution
 	stateDir string // gaal state root for snapshot writing
+	warnOnce sync.Once
 }
 
 // NewManager creates a new MCP Manager.
@@ -58,6 +61,7 @@ func NewManager(mcps []config.ConfigMcp, home, stateDir string) *Manager {
 // Agents + Global fields to fan out one entry per agent.
 func (m *Manager) resolvedMCPs() []config.ConfigMcp {
 	slog.Debug("resolving mcp targets", "count", len(m.mcps))
+	m.warnOnce.Do(m.emitConfigWarnings)
 	var out []config.ConfigMcp
 	for _, mc := range m.mcps {
 		if mc.Target != "" {
@@ -99,6 +103,52 @@ func (m *Manager) resolvedMCPs() []config.ConfigMcp {
 		}
 	}
 	return out
+}
+
+// emitConfigWarnings surfaces issues that depend on the user's MCP config
+// or local environment but aren't tied to a single sync entry. Runs at most
+// once per Manager (gated by warnOnce) so the messages don't repeat across
+// resolvedMCPs calls from Sync, Status, and Prune.
+func (m *Manager) emitConfigWarnings() {
+	m.warnClaudeDesktopOnLinux()
+	m.warnLegacyClaudeDesktopJSON()
+}
+
+// warnClaudeDesktopOnLinux flags MCP entries that target the claude-desktop
+// agent on Linux. Claude Desktop is officially macOS- and Windows-only; gaal
+// would write to ~/Library/Application Support/Claude/ which the (community)
+// Linux builds, if any, do not consume.
+func (m *Manager) warnClaudeDesktopOnLinux() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	for _, mc := range m.mcps {
+		for _, a := range mc.Agents {
+			if a == "claude-desktop" || a == "*" {
+				slog.Warn("mcp: claude-desktop is officially macOS- and Windows-only — sync targets ~/Library/Application Support/Claude/ which has no effect on Linux",
+					"hint", "remove claude-desktop from agents:, or list agents explicitly without it")
+				return
+			}
+		}
+	}
+}
+
+// warnLegacyClaudeDesktopJSON detects the file gaal used to write under the
+// (incorrect) claude-code path: ~/.config/claude/claude_desktop_config.json.
+// Neither Claude Code (~/.claude.json) nor Claude Desktop (macOS:
+// ~/Library/Application Support/Claude/, Windows: %APPDATA%\Claude\) reads
+// it, so users carrying it from older gaal versions can safely delete it.
+func (m *Manager) warnLegacyClaudeDesktopJSON() {
+	if m.home == "" {
+		return
+	}
+	legacy := filepath.Join(m.home, ".config", "claude", "claude_desktop_config.json")
+	if _, err := os.Stat(legacy); err != nil {
+		return
+	}
+	slog.Warn("mcp: stale ~/.config/claude/claude_desktop_config.json detected — neither Claude Code nor Claude Desktop reads this path; safe to delete",
+		"path", legacy,
+		"hint", "Claude Code now writes ~/.claude.json; Claude Desktop uses ~/Library/Application Support/Claude/")
 }
 
 // Sync applies every MCP configuration entry.

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -3,10 +3,13 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"gaal/internal/config"
@@ -816,7 +819,27 @@ func TestResolvedMCPs_AgentWithGlobalTrue_ResolvesTarget(t *testing.T) {
 }
 
 func TestResolvedMCPs_AgentWithGlobalFalse_SkipsWhenNoProjectMCP(t *testing.T) {
-	// claude-code has an empty project_mcp_config_file → should be skipped.
+	// codex has an empty project_mcp_config_file → should be skipped.
+	home := "/home/testuser"
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: false,
+			Agents: []string{"codex"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, home, "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 0 {
+		t.Errorf("expected 0 resolved entries for codex project scope (empty), got %d", len(resolved))
+	}
+}
+
+func TestResolvedMCPs_ClaudeCodeProjectScope_ResolvesToMcpJSON(t *testing.T) {
+	// claude-code's project scope writes to .mcp.json at the workspace root
+	// (the file Claude Code itself reads). Path is workspace-relative; the
+	// caller is expected to resolve it against cwd.
 	home := "/home/testuser"
 	mcps := []config.ConfigMcp{
 		{
@@ -828,8 +851,59 @@ func TestResolvedMCPs_AgentWithGlobalFalse_SkipsWhenNoProjectMCP(t *testing.T) {
 	}
 	m := NewManager(mcps, home, "")
 	resolved := m.resolvedMCPs()
-	if len(resolved) != 0 {
-		t.Errorf("expected 0 resolved entries for claude-code project scope (empty), got %d", len(resolved))
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry for claude-code project scope, got %d", len(resolved))
+	}
+	if resolved[0].Target != ".mcp.json" {
+		t.Errorf("expected target=.mcp.json, got %q", resolved[0].Target)
+	}
+}
+
+func TestResolvedMCPs_ClaudeCodeGlobalScope_ResolvesToClaudeJSON(t *testing.T) {
+	// claude-code's user-global MCPs live in ~/.claude.json, NOT in the
+	// (legacy/incorrect) ~/.config/claude/claude_desktop_config.json path
+	// gaal used to write before #92.
+	home := "/home/testuser"
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: true,
+			Agents: []string{"claude-code"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, home, "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry for claude-code global scope, got %d", len(resolved))
+	}
+	want := filepath.Join(home, ".claude.json")
+	if resolved[0].Target != want {
+		t.Errorf("expected target=%q, got %q", want, resolved[0].Target)
+	}
+}
+
+func TestResolvedMCPs_ClaudeDesktopGlobalScope_ResolvesToMacOSPath(t *testing.T) {
+	// claude-desktop's MCP config sits under macOS-style Library path. Path
+	// is expanded against the supplied home regardless of runtime.GOOS;
+	// non-mac users see a no-op write (or a sync-time warning on Linux).
+	home := "/home/testuser"
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: true,
+			Agents: []string{"claude-desktop"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, home, "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry for claude-desktop global scope, got %d", len(resolved))
+	}
+	want := filepath.Join(home, "Library/Application Support/Claude/claude_desktop_config.json")
+	if resolved[0].Target != want {
+		t.Errorf("expected target=%q, got %q", want, resolved[0].Target)
 	}
 }
 
@@ -874,5 +948,120 @@ func TestResolvedMCPs_MultipleAgents_FansOut(t *testing.T) {
 	}
 	if len(targets) != 2 {
 		t.Errorf("expected 2 distinct targets, got %d: %v", len(targets), targets)
+	}
+}
+
+// ── warning helpers ────────────────────────────────────────────────────────
+
+// captureSlog redirects slog output to a buffer for the duration of fn and
+// returns the captured text. Restores the previous default logger after.
+func captureSlog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	fn()
+	return buf.String()
+}
+
+func TestWarnLegacyClaudeDesktopJSON_DetectsStaleFile(t *testing.T) {
+	home := t.TempDir()
+	stale := filepath.Join(home, ".config", "claude", "claude_desktop_config.json")
+	if err := os.MkdirAll(filepath.Dir(stale), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(stale, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	out := captureSlog(t, func() {
+		m := NewManager(nil, home, "")
+		m.warnLegacyClaudeDesktopJSON()
+	})
+	if !strings.Contains(out, "stale ~/.config/claude/claude_desktop_config.json") {
+		t.Errorf("expected legacy warning, got: %s", out)
+	}
+}
+
+func TestWarnLegacyClaudeDesktopJSON_SilentWhenAbsent(t *testing.T) {
+	home := t.TempDir() // no legacy file present
+	out := captureSlog(t, func() {
+		m := NewManager(nil, home, "")
+		m.warnLegacyClaudeDesktopJSON()
+	})
+	if strings.Contains(out, "stale") {
+		t.Errorf("expected no warning when legacy file is absent, got: %s", out)
+	}
+}
+
+func TestWarnClaudeDesktopOnLinux_FiresForExplicitTarget(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only assertion; behavior intentionally differs on macOS/Windows")
+	}
+	mcps := []config.ConfigMcp{
+		{Name: "x", Agents: []string{"claude-desktop"}, Global: true,
+			Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(mcps, "/home/u", "")
+		m.warnClaudeDesktopOnLinux()
+	})
+	if !strings.Contains(out, "claude-desktop is officially macOS- and Windows-only") {
+		t.Errorf("expected linux unsupported warning, got: %s", out)
+	}
+}
+
+func TestWarnClaudeDesktopOnLinux_FiresForWildcardAgents(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only assertion")
+	}
+	mcps := []config.ConfigMcp{
+		{Name: "x", Agents: []string{"*"}, Global: true,
+			Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(mcps, "/home/u", "")
+		m.warnClaudeDesktopOnLinux()
+	})
+	if !strings.Contains(out, "claude-desktop") {
+		t.Errorf("expected warning for wildcard agents on Linux, got: %s", out)
+	}
+}
+
+func TestWarnClaudeDesktopOnLinux_SilentForOtherAgents(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only assertion")
+	}
+	mcps := []config.ConfigMcp{
+		{Name: "x", Agents: []string{"claude-code", "codex"}, Global: true,
+			Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(mcps, "/home/u", "")
+		m.warnClaudeDesktopOnLinux()
+	})
+	if strings.Contains(out, "claude-desktop") {
+		t.Errorf("expected no warning for non-claude-desktop agents, got: %s", out)
+	}
+}
+
+func TestEmitConfigWarnings_FiresOncePerManager(t *testing.T) {
+	home := t.TempDir()
+	stale := filepath.Join(home, ".config", "claude", "claude_desktop_config.json")
+	os.MkdirAll(filepath.Dir(stale), 0o755)
+	os.WriteFile(stale, []byte("{}"), 0o644)
+
+	out := captureSlog(t, func() {
+		m := NewManager(nil, home, "")
+		// Multiple resolvedMCPs calls (Sync, Status, Prune all use it) must
+		// not duplicate the warning.
+		_ = m.resolvedMCPs()
+		_ = m.resolvedMCPs()
+		_ = m.resolvedMCPs()
+	})
+	count := strings.Count(out, "stale ~/.config/claude/claude_desktop_config.json")
+	if count != 1 {
+		t.Errorf("expected legacy warning to fire exactly once, fired %d times", count)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #92.

The \`claude-code\` registry entry pointed at \`~/.config/claude/claude_desktop_config.json\` — a path neither Claude Code (the CLI) nor Claude Desktop (the GUI) actually reads. Any \`mcps:\` entry targeting \`claude-code\` was a silent no-op, same failure mode as the codex bug fixed in #91.

Also adds a separate \`claude-desktop\` agent for the GUI app, which is a distinct product with its own config file.

## Changes

### Registry
- \`claude-code.global_mcp_config_file\`: \`~/.config/claude/claude_desktop_config.json\` → **\`~/.claude.json\`** (per [Claude Code settings docs](https://code.claude.com/docs/en/settings.md))
- \`claude-code.project_mcp_config_file\`: \`\"\"\` → **\`.mcp.json\`** (the workspace-root file Claude Code reads)
- New **\`claude-desktop\`** agent at \`~/Library/Application Support/Claude/claude_desktop_config.json\` (macOS canonical path; per [MCP user quickstart](https://modelcontextprotocol.io/quickstart/user))

The per-OS yaml-field design (e.g. \`global_mcp_config_file_darwin\`) was considered but rejected as too much surface area for a single two-platform agent. Windows users can override the path via \`~/.config/gaal/agents.yaml\` if needed.

### Round-trip safety
\`~/.claude.json\` carries OAuth tokens, per-project state, and growthbook caches. The existing \`jsonCodec.WriteServers\` already preserves every top-level key during a write, so the user's session and history survive every sync. Verified with an end-to-end test against a hand-seeded \`~/.claude.json\` containing fake \`anonymousId\`, \`projects\`, and an existing \`mcpServers\` entry — all preserved after gaal added a new server.

### Sync warnings
Two new warnings, both visible from \`gaal sync\` AND \`gaal sync --dry-run\` (fired from \`resolvedMCPs()\`, gated with \`sync.Once\` so they emit at most once per Manager regardless of how many code paths read the resolved MCP list):

- **claude-desktop on Linux** — Claude Desktop is officially macOS- and Windows-only; sync would write to \`~/Library/...\` which has no effect on Linux. Fires when the user's \`agents:\` list contains \`claude-desktop\` or \`*\`.
- **Stale \`~/.config/claude/claude_desktop_config.json\`** — the file gaal used to write before this fix. Neither Claude Code nor Claude Desktop reads it; the warning tells the user it's safe to delete.

### Validation
\`project_mcp_config_file\` now accepts workspace-relative paths like \`.mcp.json\` (previously required \`~/-\`prefix). Absolute paths and \`..\` segments are still rejected — same rules as \`project_skills_dir\`.

## Tests

New tests in \`internal/mcp/manager_test.go\`:
- \`TestResolvedMCPs_ClaudeCodeGlobalScope_ResolvesToClaudeJSON\`
- \`TestResolvedMCPs_ClaudeCodeProjectScope_ResolvesToMcpJSON\`
- \`TestResolvedMCPs_ClaudeDesktopGlobalScope_ResolvesToMacOSPath\`
- \`TestWarnLegacyClaudeDesktopJSON_DetectsStaleFile\` / \`_SilentWhenAbsent\`
- \`TestWarnClaudeDesktopOnLinux_FiresForExplicitTarget\` / \`_FiresForWildcardAgents\` / \`_SilentForOtherAgents\` (Linux-gated)
- \`TestEmitConfigWarnings_FiresOncePerManager\` (sync.Once guard)

New tests in \`internal/core/agent/registry_internal_test.go\`:
- \`TestValidateEntry_RelativeProjectMCPConfig_Accepted\`
- \`TestValidateEntry_DotDotInProjectMCPConfig_Rejected\`

Updated \`TestBuildImportCandidates_MCPsFromAgentConfig\` to seed \`~/.claude.json\` instead of the dead path.

## Manual verification

\`\`\`console
$ cat ~/.claude.json   # before
{
  \"anonymousId\": \"abc-123\",
  \"hasCompletedOnboarding\": true,
  \"mcpServers\": { \"existing\": { \"command\": \"node\", ... } },
  \"projects\": { \"/some/path\": { \"recentChats\": [] } }
}

$ env HOME=/tmp/iso gaal sync
mcp: claude-desktop is officially macOS- and Windows-only — sync targets ~/Library/Application Support/Claude/ which has no effect on Linux
mcp: skipping entry — target parent directory does not exist (claude-desktop)
✓ context7     upserted in .claude.json
✓ project-srv  upserted in .mcp.json

$ cat ~/.claude.json   # after — every key preserved, mcpServers merged
{
  \"anonymousId\": \"abc-123\",
  \"hasCompletedOnboarding\": true,
  \"mcpServers\": {
    \"context7\": { \"command\": \"npx\", \"args\": [\"-y\", \"@upstash/context7-mcp@latest\"] },
    \"existing\": { \"command\": \"node\", ... }
  },
  \"projects\": { \"/some/path\": { \"recentChats\": [] } }
}

$ touch ~/.config/claude/claude_desktop_config.json
$ gaal sync --dry-run
mcp: stale ~/.config/claude/claude_desktop_config.json detected — neither Claude Code nor Claude Desktop reads this path; safe to delete
\`\`\`

## Out of scope (explicit)
- Per-OS registry yaml fields (rejected — single canonical path + user override is enough for now)
- Migrating users away from the dead \`~/.config/claude/claude_desktop_config.json\` file (one-shot warning instead — file is harmless)
- Linux Claude Desktop community builds (no canonical path; warning steers users away)

## Test plan
- [x] \`go test ./...\` passes
- [x] End-to-end on Linux: \`~/.claude.json\` round-trip preserves OAuth/state/projects keys
- [x] \`.mcp.json\` written to workspace root for project-scope claude-code entries
- [x] Linux warning fires for both explicit \`claude-desktop\` and \`*\` agent lists
- [x] Linux warning silent when only other agents are targeted
- [x] Stale legacy file warning fires once on \`gaal sync\` and \`gaal sync --dry-run\`
- [x] Existing JSON codec round-trip tests still pass (claude-code is a JSON file, no codec changes needed)