### PR TITLE
fix(skills): warn when skills target claude-desktop (no-op)

### DIFF
--- a/internal/core/agent/agents.yaml
+++ b/internal/core/agent/agents.yaml
@@ -85,8 +85,10 @@ agents:
   claude-code:
     project_skills_dir: .claude/skills
     global_skills_dir: ~/.claude/skills
-    global_mcp_config_file: ~/.config/claude/claude_desktop_config.json
-    project_mcp_config_file: ""
+    # ~/.claude.json carries OAuth tokens, per-project state, caches; the
+    # mcpServers key is upserted in place and unrelated keys are preserved.
+    global_mcp_config_file: ~/.claude.json
+    project_mcp_config_file: .mcp.json
     project_skills_search:
       - .claude/skills
       - .agents/skills
@@ -97,6 +99,22 @@ agents:
       - ~/.copilot/skills
     pm_skills_search:
       - ~/.claude/plugins/cache
+
+  # claude-desktop is the GUI app, distinct from claude-code (the CLI).
+  # Path below is the macOS canonical location; Claude Desktop is officially
+  # macOS- and Windows-only. Linux users get a sync-time warning.
+  # Windows users can override this path via ~/.config/gaal/agents.yaml
+  # to point at ~/AppData/Roaming/Claude/claude_desktop_config.json.
+  claude-desktop:
+    supports_generic_project: true
+    supports_generic_global: true
+    project_skills_dir: ""
+    global_skills_dir: ""
+    global_mcp_config_file: ~/Library/Application Support/Claude/claude_desktop_config.json
+    project_mcp_config_file: ""
+    project_skills_search: []
+    global_skills_search: []
+    pm_skills_search: []
 
   cline:
     supports_generic_project: true

--- a/internal/core/agent/registry.go
+++ b/internal/core/agent/registry.go
@@ -183,10 +183,18 @@ func validateEntry(name string, e agentEntry) error {
 		!strings.HasPrefix(e.GlobalMCPConfigFile, `~\`) {
 		return fmt.Errorf("agent %q: global_mcp_config_file must be empty or start with '~/', got %q", name, e.GlobalMCPConfigFile)
 	}
+	// project_mcp_config_file: may be workspace-relative (e.g. ".mcp.json"
+	// for claude-code) or home-relative (~/-prefixed). Absolute paths and
+	// ".." segments are rejected — same rule as project_skills_dir.
 	if e.ProjectMCPConfigFile != "" &&
 		!strings.HasPrefix(e.ProjectMCPConfigFile, "~/") &&
-		!strings.HasPrefix(e.ProjectMCPConfigFile, `~\\`) {
-		return fmt.Errorf("agent %q: project_mcp_config_file must be empty or start with '~/', got %q", name, e.ProjectMCPConfigFile)
+		!strings.HasPrefix(e.ProjectMCPConfigFile, `~\`) {
+		if isAbsPath(e.ProjectMCPConfigFile) {
+			return fmt.Errorf("agent %q: project_mcp_config_file must be relative or ~/-prefixed, got %q", name, e.ProjectMCPConfigFile)
+		}
+		if containsDotDot(e.ProjectMCPConfigFile) {
+			return fmt.Errorf("agent %q: project_mcp_config_file must not contain '..', got %q", name, e.ProjectMCPConfigFile)
+		}
 	}
 	for _, d := range e.ProjectSkillsSearch {
 		if isAbsPath(d) {

--- a/internal/core/agent/registry_internal_test.go
+++ b/internal/core/agent/registry_internal_test.go
@@ -149,7 +149,31 @@ func TestValidateEntry_MCPConfigWithoutTilde_Rejected(t *testing.T) {
 		ProjectMCPConfigFile: "/absolute/mcp.json",
 	}
 	if err := validateEntry("foo", e); err == nil {
-		t.Error("expected error for project_mcp_config_file without ~/")
+		t.Error("expected error for absolute project_mcp_config_file")
+	}
+}
+
+func TestValidateEntry_RelativeProjectMCPConfig_Accepted(t *testing.T) {
+	// Workspace-relative project MCP path (e.g. claude-code's .mcp.json) is
+	// allowed and resolved against cwd by callers.
+	e := agentEntry{
+		ProjectSkillsDir:     ".foo/skills",
+		GlobalSkillsDir:      "~/.foo/skills",
+		ProjectMCPConfigFile: ".mcp.json",
+	}
+	if err := validateEntry("foo", e); err != nil {
+		t.Errorf("relative project_mcp_config_file should be accepted, got %v", err)
+	}
+}
+
+func TestValidateEntry_DotDotInProjectMCPConfig_Rejected(t *testing.T) {
+	e := agentEntry{
+		ProjectSkillsDir:     ".foo/skills",
+		GlobalSkillsDir:      "~/.foo/skills",
+		ProjectMCPConfigFile: "../escape/mcp.json",
+	}
+	if err := validateEntry("foo", e); err == nil {
+		t.Error("expected error for '..' in project_mcp_config_file")
 	}
 }
 

--- a/internal/engine/ops/init_build_test.go
+++ b/internal/engine/ops/init_build_test.go
@@ -136,13 +136,9 @@ func TestBuildImportCandidates_MCPsFromAgentConfig(t *testing.T) {
 	workDir := t.TempDir()
 	cacheRoot := t.TempDir()
 
-	// claude-code's ProjectMCPConfigFile is ~/.config/claude/claude_desktop_config.json.
-	cfgDir := filepath.Join(home, ".config", "claude")
-	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	// claude-code reads its user-global MCP servers from ~/.claude.json.
 	content := `{"mcpServers":{"filesystem":{"command":"uvx","args":["mcp-server-filesystem","/tmp"]}}}`
-	cfgFile := filepath.Join(cfgDir, "claude_desktop_config.json")
+	cfgFile := filepath.Join(home, ".claude.json")
 	if err := os.WriteFile(cfgFile, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"sync"
 
 	"gaal/internal/config"
 	"gaal/internal/core/agent"
@@ -44,6 +46,7 @@ type Manager struct {
 	mcps     []config.ConfigMcp
 	home     string // user home directory for ~/ expansion and agent path resolution
 	stateDir string // gaal state root for snapshot writing
+	warnOnce sync.Once
 }
 
 // NewManager creates a new MCP Manager.
@@ -58,6 +61,7 @@ func NewManager(mcps []config.ConfigMcp, home, stateDir string) *Manager {
 // Agents + Global fields to fan out one entry per agent.
 func (m *Manager) resolvedMCPs() []config.ConfigMcp {
 	slog.Debug("resolving mcp targets", "count", len(m.mcps))
+	m.warnOnce.Do(m.emitConfigWarnings)
 	var out []config.ConfigMcp
 	for _, mc := range m.mcps {
 		if mc.Target != "" {
@@ -99,6 +103,52 @@ func (m *Manager) resolvedMCPs() []config.ConfigMcp {
 		}
 	}
 	return out
+}
+
+// emitConfigWarnings surfaces issues that depend on the user's MCP config
+// or local environment but aren't tied to a single sync entry. Runs at most
+// once per Manager (gated by warnOnce) so the messages don't repeat across
+// resolvedMCPs calls from Sync, Status, and Prune.
+func (m *Manager) emitConfigWarnings() {
+	m.warnClaudeDesktopOnLinux()
+	m.warnLegacyClaudeDesktopJSON()
+}
+
+// warnClaudeDesktopOnLinux flags MCP entries that target the claude-desktop
+// agent on Linux. Claude Desktop is officially macOS- and Windows-only; gaal
+// would write to ~/Library/Application Support/Claude/ which the (community)
+// Linux builds, if any, do not consume.
+func (m *Manager) warnClaudeDesktopOnLinux() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	for _, mc := range m.mcps {
+		for _, a := range mc.Agents {
+			if a == "claude-desktop" || a == "*" {
+				slog.Warn("mcp: claude-desktop is officially macOS- and Windows-only — sync targets ~/Library/Application Support/Claude/ which has no effect on Linux",
+					"hint", "remove claude-desktop from agents:, or list agents explicitly without it")
+				return
+			}
+		}
+	}
+}
+
+// warnLegacyClaudeDesktopJSON detects the file gaal used to write under the
+// (incorrect) claude-code path: ~/.config/claude/claude_desktop_config.json.
+// Neither Claude Code (~/.claude.json) nor Claude Desktop (macOS:
+// ~/Library/Application Support/Claude/, Windows: %APPDATA%\Claude\) reads
+// it, so users carrying it from older gaal versions can safely delete it.
+func (m *Manager) warnLegacyClaudeDesktopJSON() {
+	if m.home == "" {
+		return
+	}
+	legacy := filepath.Join(m.home, ".config", "claude", "claude_desktop_config.json")
+	if _, err := os.Stat(legacy); err != nil {
+		return
+	}
+	slog.Warn("mcp: stale ~/.config/claude/claude_desktop_config.json detected — neither Claude Code nor Claude Desktop reads this path; safe to delete",
+		"path", legacy,
+		"hint", "Claude Code now writes ~/.claude.json; Claude Desktop uses ~/Library/Application Support/Claude/")
 }
 
 // Sync applies every MCP configuration entry.

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -3,10 +3,13 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"gaal/internal/config"
@@ -816,7 +819,27 @@ func TestResolvedMCPs_AgentWithGlobalTrue_ResolvesTarget(t *testing.T) {
 }
 
 func TestResolvedMCPs_AgentWithGlobalFalse_SkipsWhenNoProjectMCP(t *testing.T) {
-	// claude-code has an empty project_mcp_config_file → should be skipped.
+	// codex has an empty project_mcp_config_file → should be skipped.
+	home := "/home/testuser"
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: false,
+			Agents: []string{"codex"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, home, "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 0 {
+		t.Errorf("expected 0 resolved entries for codex project scope (empty), got %d", len(resolved))
+	}
+}
+
+func TestResolvedMCPs_ClaudeCodeProjectScope_ResolvesToMcpJSON(t *testing.T) {
+	// claude-code's project scope writes to .mcp.json at the workspace root
+	// (the file Claude Code itself reads). Path is workspace-relative; the
+	// caller is expected to resolve it against cwd.
 	home := "/home/testuser"
 	mcps := []config.ConfigMcp{
 		{
@@ -828,8 +851,59 @@ func TestResolvedMCPs_AgentWithGlobalFalse_SkipsWhenNoProjectMCP(t *testing.T) {
 	}
 	m := NewManager(mcps, home, "")
 	resolved := m.resolvedMCPs()
-	if len(resolved) != 0 {
-		t.Errorf("expected 0 resolved entries for claude-code project scope (empty), got %d", len(resolved))
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry for claude-code project scope, got %d", len(resolved))
+	}
+	if resolved[0].Target != ".mcp.json" {
+		t.Errorf("expected target=.mcp.json, got %q", resolved[0].Target)
+	}
+}
+
+func TestResolvedMCPs_ClaudeCodeGlobalScope_ResolvesToClaudeJSON(t *testing.T) {
+	// claude-code's user-global MCPs live in ~/.claude.json, NOT in the
+	// (legacy/incorrect) ~/.config/claude/claude_desktop_config.json path
+	// gaal used to write before #92.
+	home := "/home/testuser"
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: true,
+			Agents: []string{"claude-code"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, home, "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry for claude-code global scope, got %d", len(resolved))
+	}
+	want := filepath.Join(home, ".claude.json")
+	if resolved[0].Target != want {
+		t.Errorf("expected target=%q, got %q", want, resolved[0].Target)
+	}
+}
+
+func TestResolvedMCPs_ClaudeDesktopGlobalScope_ResolvesToMacOSPath(t *testing.T) {
+	// claude-desktop's MCP config sits under macOS-style Library path. Path
+	// is expanded against the supplied home regardless of runtime.GOOS;
+	// non-mac users see a no-op write (or a sync-time warning on Linux).
+	home := "/home/testuser"
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "srv",
+			Global: true,
+			Agents: []string{"claude-desktop"},
+			Inline: &config.ConfigMcpItem{Command: "node"},
+		},
+	}
+	m := NewManager(mcps, home, "")
+	resolved := m.resolvedMCPs()
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry for claude-desktop global scope, got %d", len(resolved))
+	}
+	want := filepath.Join(home, "Library/Application Support/Claude/claude_desktop_config.json")
+	if resolved[0].Target != want {
+		t.Errorf("expected target=%q, got %q", want, resolved[0].Target)
 	}
 }
 
@@ -874,5 +948,120 @@ func TestResolvedMCPs_MultipleAgents_FansOut(t *testing.T) {
 	}
 	if len(targets) != 2 {
 		t.Errorf("expected 2 distinct targets, got %d: %v", len(targets), targets)
+	}
+}
+
+// ── warning helpers ────────────────────────────────────────────────────────
+
+// captureSlog redirects slog output to a buffer for the duration of fn and
+// returns the captured text. Restores the previous default logger after.
+func captureSlog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	fn()
+	return buf.String()
+}
+
+func TestWarnLegacyClaudeDesktopJSON_DetectsStaleFile(t *testing.T) {
+	home := t.TempDir()
+	stale := filepath.Join(home, ".config", "claude", "claude_desktop_config.json")
+	if err := os.MkdirAll(filepath.Dir(stale), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(stale, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	out := captureSlog(t, func() {
+		m := NewManager(nil, home, "")
+		m.warnLegacyClaudeDesktopJSON()
+	})
+	if !strings.Contains(out, "stale ~/.config/claude/claude_desktop_config.json") {
+		t.Errorf("expected legacy warning, got: %s", out)
+	}
+}
+
+func TestWarnLegacyClaudeDesktopJSON_SilentWhenAbsent(t *testing.T) {
+	home := t.TempDir() // no legacy file present
+	out := captureSlog(t, func() {
+		m := NewManager(nil, home, "")
+		m.warnLegacyClaudeDesktopJSON()
+	})
+	if strings.Contains(out, "stale") {
+		t.Errorf("expected no warning when legacy file is absent, got: %s", out)
+	}
+}
+
+func TestWarnClaudeDesktopOnLinux_FiresForExplicitTarget(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only assertion; behavior intentionally differs on macOS/Windows")
+	}
+	mcps := []config.ConfigMcp{
+		{Name: "x", Agents: []string{"claude-desktop"}, Global: true,
+			Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(mcps, "/home/u", "")
+		m.warnClaudeDesktopOnLinux()
+	})
+	if !strings.Contains(out, "claude-desktop is officially macOS- and Windows-only") {
+		t.Errorf("expected linux unsupported warning, got: %s", out)
+	}
+}
+
+func TestWarnClaudeDesktopOnLinux_FiresForWildcardAgents(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only assertion")
+	}
+	mcps := []config.ConfigMcp{
+		{Name: "x", Agents: []string{"*"}, Global: true,
+			Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(mcps, "/home/u", "")
+		m.warnClaudeDesktopOnLinux()
+	})
+	if !strings.Contains(out, "claude-desktop") {
+		t.Errorf("expected warning for wildcard agents on Linux, got: %s", out)
+	}
+}
+
+func TestWarnClaudeDesktopOnLinux_SilentForOtherAgents(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only assertion")
+	}
+	mcps := []config.ConfigMcp{
+		{Name: "x", Agents: []string{"claude-code", "codex"}, Global: true,
+			Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(mcps, "/home/u", "")
+		m.warnClaudeDesktopOnLinux()
+	})
+	if strings.Contains(out, "claude-desktop") {
+		t.Errorf("expected no warning for non-claude-desktop agents, got: %s", out)
+	}
+}
+
+func TestEmitConfigWarnings_FiresOncePerManager(t *testing.T) {
+	home := t.TempDir()
+	stale := filepath.Join(home, ".config", "claude", "claude_desktop_config.json")
+	os.MkdirAll(filepath.Dir(stale), 0o755)
+	os.WriteFile(stale, []byte("{}"), 0o644)
+
+	out := captureSlog(t, func() {
+		m := NewManager(nil, home, "")
+		// Multiple resolvedMCPs calls (Sync, Status, Prune all use it) must
+		// not duplicate the warning.
+		_ = m.resolvedMCPs()
+		_ = m.resolvedMCPs()
+		_ = m.resolvedMCPs()
+	})
+	count := strings.Count(out, "stale ~/.config/claude/claude_desktop_config.json")
+	if count != 1 {
+		t.Errorf("expected legacy warning to fire exactly once, fired %d times", count)
 	}
 }

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"gaal/internal/config"
 	"gaal/internal/core/vcs"
@@ -84,6 +85,7 @@ type Manager struct {
 	workDir  string // project working directory (for project-scoped installs)
 	stateDir string // gaal state root (~/.cache/gaal/state) for snapshot writing
 	force    bool   // when true, wildcard agent lists target all known agents
+	warnOnce sync.Once
 }
 
 // NewManager creates a new skill Manager.
@@ -104,12 +106,38 @@ func NewManager(skills []config.ConfigSkill, cacheDir, home, workDir, stateDir s
 
 // Sync installs or updates every skill in the configuration.
 func (m *Manager) Sync(ctx context.Context) error {
+	m.emitConfigWarnings()
 	for _, sc := range m.skills {
 		if err := m.syncOne(ctx, sc); err != nil {
 			return fmt.Errorf("skill %q: %w", sc.Source, err)
 		}
 	}
 	return nil
+}
+
+// emitConfigWarnings surfaces issues that depend on the user's skill config
+// but aren't tied to a single source. Runs at most once per Manager (gated
+// by warnOnce) so the messages don't repeat across Sync and Status.
+func (m *Manager) emitConfigWarnings() {
+	m.warnOnce.Do(m.warnSkillsTargetingClaudeDesktop)
+}
+
+// warnSkillsTargetingClaudeDesktop fires when any skill entry targets the
+// claude-desktop agent (explicitly or via the "*" wildcard). Claude Desktop
+// has no on-disk SKILL.md feature — that's a Claude Code CLI–only capability
+// — so the install would land in ~/.agents/skills/ (the generic convention)
+// where Claude Desktop never reads. Better to tell the user upfront than to
+// report a green ✓ for a no-op.
+func (m *Manager) warnSkillsTargetingClaudeDesktop() {
+	for _, sc := range m.skills {
+		for _, a := range sc.Agents {
+			if a == "claude-desktop" || a == "*" {
+				slog.Warn("skill: claude-desktop has no on-disk SKILL.md feature — entries targeting it will install under ~/.agents/skills (or .agents/skills) which Claude Desktop does not read",
+					"hint", "skills are a Claude Code CLI feature; remove claude-desktop from agents:, or list agents explicitly without it")
+				return
+			}
+		}
+	}
 }
 
 func (m *Manager) syncOne(ctx context.Context, sc config.ConfigSkill) error {
@@ -271,6 +299,7 @@ func (m *Manager) detectInstalledAgents(global bool) []string {
 
 // Status returns the installation status for every skill config.
 func (m *Manager) Status(ctx context.Context) []Status {
+	m.emitConfigWarnings()
 	statuses := make([]Status, 0, len(m.skills))
 
 	for _, sc := range m.skills {

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -2,9 +2,11 @@ package skill
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"gaal/internal/config"
@@ -747,5 +749,76 @@ func TestPrune_NoOpWhenAllManaged(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(claudeSkillsDir, "my-skill")); err != nil {
 		t.Errorf("expected my-skill to remain: %v", err)
+	}
+}
+
+// ── claude-desktop warning ──────────────────────────────────────────────────
+
+// captureSlog redirects slog output to a buffer for the duration of fn.
+func captureSlog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	fn()
+	return buf.String()
+}
+
+func TestWarnSkillsTargetingClaudeDesktop_FiresForExplicitTarget(t *testing.T) {
+	skills := []config.ConfigSkill{
+		{Source: "owner/repo", Agents: []string{"claude-desktop"}, Global: true},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(skills, t.TempDir(), "/home/u", t.TempDir(), t.TempDir(), false)
+		m.warnSkillsTargetingClaudeDesktop()
+	})
+	if !strings.Contains(out, "claude-desktop has no on-disk SKILL.md feature") {
+		t.Errorf("expected claude-desktop skills warning, got: %s", out)
+	}
+}
+
+func TestWarnSkillsTargetingClaudeDesktop_FiresForWildcardAgents(t *testing.T) {
+	skills := []config.ConfigSkill{
+		{Source: "owner/repo", Agents: []string{"*"}, Global: true},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(skills, t.TempDir(), "/home/u", t.TempDir(), t.TempDir(), false)
+		m.warnSkillsTargetingClaudeDesktop()
+	})
+	if !strings.Contains(out, "claude-desktop") {
+		t.Errorf("expected warning for wildcard agents, got: %s", out)
+	}
+}
+
+func TestWarnSkillsTargetingClaudeDesktop_SilentForOtherAgents(t *testing.T) {
+	skills := []config.ConfigSkill{
+		{Source: "owner/repo", Agents: []string{"claude-code", "codex"}, Global: true},
+		{Source: "owner/other", Agents: []string{"cursor"}, Global: false},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(skills, t.TempDir(), "/home/u", t.TempDir(), t.TempDir(), false)
+		m.warnSkillsTargetingClaudeDesktop()
+	})
+	if strings.Contains(out, "claude-desktop") {
+		t.Errorf("expected no warning for non-claude-desktop agents, got: %s", out)
+	}
+}
+
+func TestEmitConfigWarnings_FiresOncePerManager(t *testing.T) {
+	skills := []config.ConfigSkill{
+		{Source: "owner/repo", Agents: []string{"claude-desktop"}, Global: true},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(skills, t.TempDir(), "/home/u", t.TempDir(), t.TempDir(), false)
+		// Both Sync and Status invoke emitConfigWarnings; the warning must
+		// surface exactly once across however many calls.
+		m.emitConfigWarnings()
+		m.emitConfigWarnings()
+		m.emitConfigWarnings()
+	})
+	count := strings.Count(out, "claude-desktop has no on-disk SKILL.md feature")
+	if count != 1 {
+		t.Errorf("expected warning to fire exactly once, fired %d times", count)
 	}
 }


### PR DESCRIPTION
## Summary

Refs #94. **Stacked on top of #93** — that PR introduces the \`claude-desktop\` agent this warning cares about. GitHub will retarget this PR at \`main\` automatically once #93 merges.

Per the official [Claude Code skills docs](https://code.claude.com/docs/en/skills.md), Skills are a Claude Code CLI–only feature. Claude Desktop (the GUI app) has no on-disk SKILL.md mechanism. With the \`claude-desktop\` agent declaring \`supports_generic_{project,global}=true\` (so the registry validation is happy), a \`skills:\` entry targeting it would install under \`~/.agents/skills\` (or \`.agents/skills\`) and report a green \`✓\` — but Claude Desktop never reads those paths.

This is the same silent-no-op pattern we already fixed for MCPs in #84 and #92.

## Changes

- **\`internal/skill/manager.go\`**: new \`warnSkillsTargetingClaudeDesktop\` helper; new \`emitConfigWarnings\` method gated by a \`sync.Once\` on the Manager; called from both \`Sync\` and \`Status\` so the warning surfaces on both \`gaal sync\` and \`gaal sync --dry-run\`.
- Triggers when:
  - any \`skills:\` entry has \`claude-desktop\` in \`agents:\`, or
  - any entry uses the \`[\"*\"]\` wildcard (which expands to claude-desktop on every machine).

## Tests

\`internal/skill/manager_test.go\`:
- \`TestWarnSkillsTargetingClaudeDesktop_FiresForExplicitTarget\`
- \`TestWarnSkillsTargetingClaudeDesktop_FiresForWildcardAgents\`
- \`TestWarnSkillsTargetingClaudeDesktop_SilentForOtherAgents\`
- \`TestEmitConfigWarnings_FiresOncePerManager\` (sync.Once guard verified across multiple invocations)

## Manual verification

\`\`\`yaml
# gaal.yaml
skills:
  - source: vercel-labs/agent-skills
    agents: [claude-desktop]
    global: true
\`\`\`

\`\`\`console
$ gaal sync --dry-run
skill: claude-desktop has no on-disk SKILL.md feature — entries targeting it will install under ~/.agents/skills (or .agents/skills) which Claude Desktop does not read  hint=\"skills are a Claude Code CLI feature; remove claude-desktop from agents:, or list agents explicitly without it\"
\`\`\`

## Out of scope (explicit)

- Tightening the registry so \`claude-desktop\` declares no skills support at all (would also need relaxing the validator that currently requires either a path or the generic-delegation flag). The warning is the higher-impact, lower-risk move; the registry tightening can be a follow-up.

## Test plan
- [x] \`go test ./...\` passes
- [x] Warning fires on \`gaal sync\` and \`gaal sync --dry-run\`
- [x] Warning silent when only other agents are targeted
- [x] sync.Once guard prevents duplicate warnings across multiple Manager method calls