### PR TITLE
fix(sync): exclude FS-discovered resources outside config from plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gaal
 
-> **G**it **A**gent **A**utomation **L**ayer — a single CLI to keep your local repositories, AI agent skills, and MCP server configurations in sync.
+> **G**overned **A**gent **A**ccess **L**ayer — a single CLI to keep your local repositories, AI agent skills, and MCP server configurations in sync.
 
 ```
   ██████╗  █████╗  █████╗ ██╗

--- a/internal/engine/ops/plan.go
+++ b/internal/engine/ops/plan.go
@@ -79,6 +79,11 @@ func RenderPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager,
 func planRepos(entries []render.RepoEntry) []render.PlanRepoEntry {
 	out := make([]render.PlanRepoEntry, 0, len(entries))
 	for _, e := range entries {
+		// Skip FS-discovered resources outside the config: sync only acts on
+		// declared resources, so the plan must not list them.
+		if e.Status == render.StatusUnmanaged {
+			continue
+		}
 		p := render.PlanRepoEntry{
 			Path:    e.Path,
 			Type:    e.Type,
@@ -105,6 +110,9 @@ func planRepos(entries []render.RepoEntry) []render.PlanRepoEntry {
 func planSkills(entries []render.SkillEntry) []render.PlanSkillEntry {
 	out := make([]render.PlanSkillEntry, 0, len(entries))
 	for _, e := range entries {
+		if e.Status == render.StatusUnmanaged {
+			continue
+		}
 		p := render.PlanSkillEntry{
 			Source: e.Source,
 			Agent:  e.Agent,
@@ -134,6 +142,9 @@ func planSkills(entries []render.SkillEntry) []render.PlanSkillEntry {
 func planMCPs(entries []render.MCPEntry) []render.PlanMCPEntry {
 	out := make([]render.PlanMCPEntry, 0, len(entries))
 	for _, e := range entries {
+		if e.Status == render.StatusUnmanaged {
+			continue
+		}
 		p := render.PlanMCPEntry{
 			Name:   e.Name,
 			Target: e.Target,

--- a/internal/engine/ops/plan_test.go
+++ b/internal/engine/ops/plan_test.go
@@ -52,6 +52,20 @@ func TestPlanRepos_Error(t *testing.T) {
 	}
 }
 
+func TestPlanRepos_UnmanagedSkipped(t *testing.T) {
+	entries := []render.RepoEntry{
+		{Path: "/repos/foo", Type: "git", Status: render.StatusOK, Current: "main", Want: "main"},
+		{Path: "/elsewhere/unrelated", Type: "git", Status: render.StatusUnmanaged},
+	}
+	result := planRepos(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry (unmanaged dropped), got %d: %+v", len(result), result)
+	}
+	if result[0].Path != "/repos/foo" {
+		t.Errorf("expected only the config-declared repo to remain, got %q", result[0].Path)
+	}
+}
+
 func TestPlanSkills_Partial(t *testing.T) {
 	entries := []render.SkillEntry{
 		{Source: "owner/repo", Agent: "claude-code", Status: render.StatusPartial, Missing: []string{"skill-a"}},
@@ -85,6 +99,20 @@ func TestPlanSkills_OK(t *testing.T) {
 	}
 }
 
+func TestPlanSkills_UnmanagedSkipped(t *testing.T) {
+	entries := []render.SkillEntry{
+		{Source: "owner/repo", Agent: "claude-code", Status: render.StatusOK, Installed: []string{"skill-a"}},
+		{Source: "/elsewhere/skills", Agent: "claude-code", Status: render.StatusUnmanaged, Installed: []string{"skill-x"}},
+	}
+	result := planSkills(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry (unmanaged dropped), got %d: %+v", len(result), result)
+	}
+	if result[0].Source != "owner/repo" {
+		t.Errorf("expected only the config-declared skill to remain, got %q", result[0].Source)
+	}
+}
+
 func TestPlanMCPs_Absent(t *testing.T) {
 	entries := []render.MCPEntry{
 		{Name: "test-mcp", Target: "/path/to/config.json", Status: render.StatusAbsent},
@@ -112,5 +140,19 @@ func TestPlanMCPs_Present(t *testing.T) {
 	result := planMCPs(entries)
 	if result[0].Action != render.PlanNoOp {
 		t.Errorf("expected action %q, got %q", render.PlanNoOp, result[0].Action)
+	}
+}
+
+func TestPlanMCPs_UnmanagedSkipped(t *testing.T) {
+	entries := []render.MCPEntry{
+		{Name: "test-mcp", Target: "/path/to/config.json", Status: render.StatusPresent},
+		{Name: "stray-mcp", Target: "/elsewhere/mcp.json", Status: render.StatusUnmanaged},
+	}
+	result := planMCPs(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry (unmanaged dropped), got %d: %+v", len(result), result)
+	}
+	if result[0].Name != "test-mcp" {
+		t.Errorf("expected only the config-declared MCP to remain, got %q", result[0].Name)
 	}
 }


### PR DESCRIPTION
## Summary

- `sync --dry-run` listed every repo/skill/MCP found on disk under the plan, not just those declared in `gaal.yaml` (issue #98).
- Root cause: `Collect` is FS-first and tags off-config resources as `StatusUnmanaged` so `status`/`audit` can surface them. `planRepos`/`planSkills`/`planMCPs` had no case for `StatusUnmanaged`, so those entries fell through to `default` → `PlanNoOp` and rendered as `= unchanged`.
- Fix: drop `StatusUnmanaged` entries in the three `plan*` helpers. `Collect` is unchanged so `status`/`audit` keep their FS-discovery behaviour.

Closes #98.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (803 passed)
- [x] New unit tests in [plan_test.go](internal/engine/ops/plan_test.go): `TestPlanRepos_UnmanagedSkipped`, `TestPlanSkills_UnmanagedSkipped`, `TestPlanMCPs_UnmanagedSkipped`
- [x] Manual: `cd ~ && gaal sync --dry-run` no longer lists unrelated repos