### PR TITLE
fix(readme): correct acronym expansion for GAAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gaal
 
-> **G**it **A**gent **A**utomation **L**ayer — a single CLI to keep your local repositories, AI agent skills, and MCP server configurations in sync.
+> **G**overned **A**gent **A**ccess **L**ayer — a single CLI to keep your local repositories, AI agent skills, and MCP server configurations in sync.
 
 ```
   ██████╗  █████╗  █████╗ ██╗


### PR DESCRIPTION
## Summary
- Corrects the GAAL acronym from "Git Agent Automation Layer" to "Governed Agent Access Layer" in the README introduction.