### PR TITLE
fix(skills): skip VCS metadata dirs when installing a skill

### DIFF
--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -399,7 +399,23 @@ func filterSkills(all []SkillMeta, selectNames []string) []SkillMeta {
 	return out
 }
 
+// vcsMetaDirs lists the on-disk metadata directories that gaal must never
+// copy when installing a skill. They belong to the source's VCS bookkeeping,
+// not the skill itself, and re-syncing them surfaces two problems:
+//   - they bloat the install with megabytes of pack files;
+//   - go-git creates pack files with mode 0o444, which prevents the next
+//     sync from overwriting them (the second os.WriteFile cannot truncate
+//     a read-only file). See issue #86.
+var vcsMetaDirs = map[string]struct{}{
+	".git": {},
+	".hg":  {},
+	".svn": {},
+	".bzr": {},
+}
+
 // installSkill copies the skill directory content from src to dst.
+// VCS metadata directories at the top level of src are skipped — see
+// [vcsMetaDirs] for the rationale.
 func installSkill(src, dst string) error {
 	slog.Debug("installing skill", "src", src, "dst", dst)
 	if err := os.MkdirAll(dst, 0o755); err != nil {
@@ -409,6 +425,11 @@ func installSkill(src, dst string) error {
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		if d.IsDir() {
+			if _, skip := vcsMetaDirs[d.Name()]; skip && path != src {
+				return filepath.SkipDir
+			}
 		}
 		rel, _ := filepath.Rel(src, path)
 		target := filepath.Join(dst, rel)

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -184,6 +184,86 @@ func TestInstallSkill_CreatesNestedDirs(t *testing.T) {
 	}
 }
 
+// TestInstallSkill_SkipsVCSMetadata exercises the fix for issue #86: when a
+// skill source is a VCS clone, copying the .git/ tree to the destination
+// burdens it with read-only pack files (mode 0o444) that the next sync cannot
+// overwrite. installSkill must skip the VCS metadata directories entirely.
+func TestInstallSkill_SkipsVCSMetadata(t *testing.T) {
+	src := t.TempDir()
+	os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# skill"), 0o644)
+	for _, meta := range []string{".git", ".hg", ".svn", ".bzr"} {
+		dir := filepath.Join(src, meta, "objects", "pack")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Mode 0o444 mimics go-git's read-only pack files. If installSkill
+		// walked into the metadata dir the second sync would fail.
+		if err := os.WriteFile(filepath.Join(dir, "pack-x.idx"), []byte("x"), 0o444); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dst := filepath.Join(t.TempDir(), "installed")
+	if err := installSkill(src, dst); err != nil {
+		t.Fatalf("installSkill: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, "SKILL.md")); err != nil {
+		t.Errorf("expected SKILL.md in dst: %v", err)
+	}
+	for _, meta := range []string{".git", ".hg", ".svn", ".bzr"} {
+		if _, err := os.Stat(filepath.Join(dst, meta)); !os.IsNotExist(err) {
+			t.Errorf("expected %s/ to be skipped, got err=%v", meta, err)
+		}
+	}
+}
+
+// TestInstallSkill_IsIdempotent ensures a second install over an existing
+// destination does not fail. This guards the regression in issue #86: the
+// previous implementation copied read-only pack files from .git/ on the
+// first run, which the second run could not overwrite.
+func TestInstallSkill_IsIdempotent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only enforcement on Windows differs from POSIX")
+	}
+	src := t.TempDir()
+	os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# skill"), 0o644)
+	gitPack := filepath.Join(src, ".git", "objects", "pack")
+	if err := os.MkdirAll(gitPack, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitPack, "pack-1.idx"), []byte("idx"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "installed")
+	if err := installSkill(src, dst); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := installSkill(src, dst); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+}
+
+// TestInstallSkill_PreservesNestedNonVCSDotDirs ensures only the well-known
+// VCS metadata dirs are skipped. A skill that ships its own dotdir (e.g. a
+// `.config/` directory of templates) must still be copied through.
+func TestInstallSkill_PreservesNestedNonVCSDotDirs(t *testing.T) {
+	src := t.TempDir()
+	os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# skill"), 0o644)
+	cfgDir := filepath.Join(src, ".config")
+	os.MkdirAll(cfgDir, 0o755)
+	os.WriteFile(filepath.Join(cfgDir, "template.yml"), []byte("a: 1"), 0o644)
+
+	dst := filepath.Join(t.TempDir(), "installed")
+	if err := installSkill(src, dst); err != nil {
+		t.Fatalf("installSkill: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, ".config", "template.yml")); err != nil {
+		t.Errorf("expected .config/template.yml to be copied, got err=%v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Manager.detectInstalledAgents (project scope)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #86.

`installSkill` walked the entire source tree, which for git-cloned skills meant the destination ended up with a copy of `.git/`. go-git writes pack files (`.git/objects/pack/*.idx`, `.pack`) with mode `0o444`. On the second sync, `os.WriteFile` opens the destination with `O_WRONLY|O_TRUNC` — truncation fails on a read-only file, producing the user-reported `permission denied`.

## Changes

- **`internal/skill/manager.go`**: new `vcsMetaDirs` set; `installSkill` returns `filepath.SkipDir` when it descends into one of `.git`, `.hg`, `.svn`, `.bzr` (only top-level inside the skill source — nested dirs at depth >0 are not relevant since they would be inside another VCS metadata dir).

## Tests

`internal/skill/manager_test.go`:
- `TestInstallSkill_SkipsVCSMetadata` — seeds .git/.hg/.svn/.bzr with read-only pack-style files, asserts none are copied.
- `TestInstallSkill_IsIdempotent` — installs twice over the same destination; the previous code panicked on the second run with permission denied.
- `TestInstallSkill_PreservesNestedNonVCSDotDirs` — guards against over-skipping; a skill that ships a `.config/` template dir is still copied.

## Out of scope (explicit)

- Cleaning up stale `.git/` trees from skills installed with the old code. They are harmless; users can `rm -rf ~/.<agent>/skills/<skill>/.git` once. Adding auto-cleanup would risk deleting user content.

## Test plan
- [x] \`go test ./...\` passes
- [x] New unit tests cover the VCS skip and the idempotency regression
- [x] No behaviour change for skill sources that do not ship a VCS metadata dir