### PR TITLE
fix(sync): suppress FS-discovered skills inside configured sources

### DIFF
--- a/internal/engine/ops/status.go
+++ b/internal/engine/ops/status.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gaal/internal/discover"
 	"gaal/internal/engine/render"
@@ -42,7 +43,7 @@ func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mc
 	// Reconcile: mark config-declared resources as managed and merge
 	// FS-discovered unmanaged resources into the report.
 	repoEntries := reconcileRepos(configRepos, discovered)
-	skillEntries := reconcileSkills(configSkills, discovered, home, workDir)
+	skillEntries := reconcileSkills(configSkills, discovered, home, workDir, skills.SourcePaths())
 	mcpEntries := reconcileMCPs(configMCPs, discovered)
 
 	return &render.StatusReport{
@@ -97,9 +98,12 @@ func reconcileRepos(config []render.RepoEntry, resources []discover.Resource) []
 
 // reconcileSkills merges config-driven skill entries with FS-discovered skills.
 // FS-discovered skills are suppressed when their parent directory is already
-// covered by a config-driven entry (same agent + same managed skills dir).
-// Remaining FS-discovered entries are appended as unmanaged.
-func reconcileSkills(config []render.SkillEntry, resources []discover.Resource, home, workDir string) []render.SkillEntry {
+// covered by a config-driven entry (same agent + same managed skills dir),
+// or when the skill itself lives inside a configured skill source path —
+// otherwise running gaal from inside a source repo would surface the source
+// SKILL.md files as duplicate installed skills (#88). Remaining FS-discovered
+// entries are appended as unmanaged.
+func reconcileSkills(config []render.SkillEntry, resources []discover.Resource, home, workDir string, sourcePaths []string) []render.SkillEntry {
 	// Build the set of managed skill directories from config entries.
 	// Key: absolute skills directory that gaal writes to for this entry.
 	managedDirs := make(map[string]struct{}, len(config))
@@ -115,6 +119,14 @@ func reconcileSkills(config []render.SkillEntry, resources []discover.Resource, 
 	}
 	slog.Debug("reconcileSkills managed dirs", "count", len(managedDirs))
 
+	cleanedSources := make([]string, 0, len(sourcePaths))
+	for _, p := range sourcePaths {
+		if p == "" {
+			continue
+		}
+		cleanedSources = append(cleanedSources, filepath.Clean(p))
+	}
+
 	out := append([]render.SkillEntry(nil), config...)
 	for _, r := range resources {
 		if r.Type != discover.ResourceSkill {
@@ -125,6 +137,11 @@ func reconcileSkills(config []render.SkillEntry, resources []discover.Resource, 
 		// showing the same skill twice (once managed, once unmanaged).
 		parent := filepath.Clean(filepath.Dir(r.Path))
 		if _, covered := managedDirs[parent]; covered {
+			continue
+		}
+		// Skills found inside a configured source are source content, not
+		// installed copies — skip so they do not appear as duplicate rows.
+		if isUnderAny(r.Path, cleanedSources) {
 			continue
 		}
 		agent := r.Meta["agent"]
@@ -139,6 +156,32 @@ func reconcileSkills(config []render.SkillEntry, resources []discover.Resource, 
 		})
 	}
 	return out
+}
+
+// isUnderAny reports whether path is at or below any of roots. Comparisons use
+// filepath.Clean / filepath.Rel so trailing separators and relative-style
+// inputs (".") are handled correctly.
+func isUnderAny(path string, roots []string) bool {
+	if len(roots) == 0 {
+		return false
+	}
+	cleaned := filepath.Clean(path)
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		rel, err := filepath.Rel(root, cleaned)
+		if err != nil {
+			continue
+		}
+		if rel == "." {
+			return true
+		}
+		if !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel) {
+			return true
+		}
+	}
+	return false
 }
 
 // reconcileMCPs merges config-driven MCP entries with FS-discovered MCP configs.

--- a/internal/engine/ops/status_test.go
+++ b/internal/engine/ops/status_test.go
@@ -1,8 +1,12 @@
 package ops
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"gaal/internal/discover"
+	"gaal/internal/engine/render"
 )
 
 // TestOrDefault verifies the orDefault helper.
@@ -54,4 +58,98 @@ func TestCollectAgents_ResolvesGenericDirs(t *testing.T) {
 	}
 
 	t.Fatal("cline agent not found")
+}
+
+// TestIsUnderAny exercises the path-containment helper that powers the source
+// suppression logic in reconcileSkills.
+func TestIsUnderAny(t *testing.T) {
+	roots := []string{"/home/u/src/personal-skills"}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/home/u/src/personal-skills", true},               // root itself
+		{"/home/u/src/personal-skills/crm-update", true},    // direct child
+		{"/home/u/src/personal-skills/a/b/c/SKILL.md", true}, // deeper descendant
+		{"/home/u/src/personal-skills-other", false},        // sibling with shared prefix
+		{"/home/u/other", false},                            // unrelated
+		{"/home/u/src", false},                              // ancestor of root
+	}
+	for _, tc := range tests {
+		if got := isUnderAny(tc.path, roots); got != tc.want {
+			t.Errorf("isUnderAny(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+
+	// Empty roots / empty entries are always false.
+	if isUnderAny("/anything", nil) {
+		t.Error("isUnderAny with nil roots should be false")
+	}
+	if isUnderAny("/x", []string{""}) {
+		t.Error("isUnderAny ignoring empty roots should be false")
+	}
+}
+
+// TestReconcileSkills_SuppressesFSDiscoveryInsideConfiguredSource is the
+// regression test for issue #88: when gaal is run from inside a configured
+// skill source (e.g. the user's `~/.config/gaal/src/personal-skills` clone),
+// scanWorkspace finds the source's SKILL.md files and emits them as
+// agent-less workspace skills. They must not surface as duplicate rows.
+func TestReconcileSkills_SuppressesFSDiscoveryInsideConfiguredSource(t *testing.T) {
+	home := "/home/test"
+	workDir := "/home/test/work"
+	src := filepath.Join(home, ".config", "gaal", "src", "personal-skills")
+
+	// Config-driven entry: claude-code installs crm-update globally.
+	config := []render.SkillEntry{{
+		Source:    src,
+		Agent:     "claude-code",
+		Global:    true,
+		Status:    render.StatusOK,
+		Installed: []string{"crm-update"},
+		Missing:   []string{},
+		Modified:  []string{},
+	}}
+
+	// Workspace scan finds the SKILL.md inside the source clone — no agent.
+	resources := []discover.Resource{{
+		Type:  discover.ResourceSkill,
+		Scope: discover.ScopeWorkspace,
+		Path:  filepath.Join(src, "crm-update"),
+		Name:  "crm-update",
+	}}
+
+	got := reconcileSkills(config, resources, home, workDir, []string{src})
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly the config entry, got %d entries: %+v", len(got), got)
+	}
+	if got[0].Agent != "claude-code" {
+		t.Errorf("expected the surviving entry to be the config one, got Agent=%q", got[0].Agent)
+	}
+}
+
+// TestReconcileSkills_KeepsUnrelatedFSDiscovery makes sure the source-path
+// filter only suppresses skills inside *configured* sources. A workspace
+// skill found elsewhere is still surfaced as unmanaged.
+func TestReconcileSkills_KeepsUnrelatedFSDiscovery(t *testing.T) {
+	home := "/home/test"
+	workDir := "/home/test/work"
+
+	resources := []discover.Resource{{
+		Type:  discover.ResourceSkill,
+		Scope: discover.ScopeWorkspace,
+		Path:  "/some/random/skill-dir",
+		Name:  "stray",
+	}}
+
+	got := reconcileSkills(nil, resources, home, workDir, []string{"/configured/source"})
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 unmanaged entry, got %d: %+v", len(got), got)
+	}
+	if got[0].Status != render.StatusUnmanaged {
+		t.Errorf("expected StatusUnmanaged, got %q", got[0].Status)
+	}
 }

--- a/internal/engine/ops/status_test.go
+++ b/internal/engine/ops/status_test.go
@@ -69,12 +69,12 @@ func TestIsUnderAny(t *testing.T) {
 		path string
 		want bool
 	}{
-		{"/home/u/src/personal-skills", true},               // root itself
-		{"/home/u/src/personal-skills/crm-update", true},    // direct child
+		{"/home/u/src/personal-skills", true},                // root itself
+		{"/home/u/src/personal-skills/crm-update", true},     // direct child
 		{"/home/u/src/personal-skills/a/b/c/SKILL.md", true}, // deeper descendant
-		{"/home/u/src/personal-skills-other", false},        // sibling with shared prefix
-		{"/home/u/other", false},                            // unrelated
-		{"/home/u/src", false},                              // ancestor of root
+		{"/home/u/src/personal-skills-other", false},         // sibling with shared prefix
+		{"/home/u/other", false},                             // unrelated
+		{"/home/u/src", false},                               // ancestor of root
 	}
 	for _, tc := range tests {
 		if got := isUnderAny(tc.path, roots); got != tc.want {

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -102,6 +102,24 @@ func NewManager(skills []config.ConfigSkill, cacheDir, home, workDir, stateDir s
 	}
 }
 
+// SourcePaths returns the absolute, home-expanded local paths of every
+// configured skill source. Remote sources (URLs and GitHub shorthands) are
+// reported by their on-disk cache path. The result lets callers identify
+// directories that hold *source* skill content rather than installed copies,
+// e.g. so the FS scan does not surface them as unmanaged installs (#88).
+func (m *Manager) SourcePaths() []string {
+	out := make([]string, 0, len(m.skills))
+	for _, sc := range m.skills {
+		if isLocalPath(sc.Source) {
+			out = append(out, expandHome(sc.Source, m.home))
+			continue
+		}
+		cloneURL := toCloneURL(sc.Source)
+		out = append(out, filepath.Join(m.cacheDir, urlToCacheKey(cloneURL)))
+	}
+	return out
+}
+
 // Sync installs or updates every skill in the configuration.
 func (m *Manager) Sync(ctx context.Context) error {
 	for _, sc := range m.skills {

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"gaal/internal/config"
@@ -235,6 +236,50 @@ func TestIsLocalPath(t *testing.T) {
 		got := isLocalPath(tc.input)
 		if got != tc.want {
 			t.Errorf("isLocalPath(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager.SourcePaths
+// ---------------------------------------------------------------------------
+
+func TestManager_SourcePaths_ExpandsHomeAndKeepsAbsolute(t *testing.T) {
+	skills := []config.ConfigSkill{
+		{Source: "~/skills/personal"},
+		{Source: "/abs/skills"},
+	}
+	m := NewManager(skills, "/cache", "/home/u", "/work", "", false)
+
+	got := m.SourcePaths()
+	want := []string{"/home/u/skills/personal", "/abs/skills"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("SourcePaths[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestManager_SourcePaths_RemoteResolvesToCachePath(t *testing.T) {
+	skills := []config.ConfigSkill{
+		{Source: "owner/repo"},
+		{Source: "https://github.com/owner/repo2"},
+	}
+	m := NewManager(skills, "/cache", "/home/u", "/work", "", false)
+
+	got := m.SourcePaths()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 paths, got %v", got)
+	}
+	for _, p := range got {
+		if !filepath.IsAbs(p) {
+			t.Errorf("expected absolute cache path, got %q", p)
+		}
+		if !strings.HasPrefix(p, "/cache") {
+			t.Errorf("expected path under /cache, got %q", p)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #88.

When gaal is run from inside a configured skill source (e.g. the local clone of \`~/.config/gaal/src/personal-skills\`), the workspace FS scan walks the source's \`SKILL.md\` files and emits them as agent-less workspace skills. The aggregator buckets entries by (name, scope), so each source skill ends up as a separate row from the config-driven row — surfacing as a duplicate \`up to date in \` line with an empty agent list, once per skill in the source.

## Changes

- **\`internal/skill/manager.go\`**: new \`Manager.SourcePaths()\` returning the absolute on-disk path of every configured source. Local paths are home-expanded; remote sources resolve to their \`cacheDir + urlToCacheKey\` location, matching how the rest of the manager keeps source state.
- **\`internal/engine/ops/status.go\`**: \`reconcileSkills\` now also drops any FS-discovered skill whose path lives at or below one of those source paths. New \`isUnderAny\` helper handles cleanly cleaned/relative comparisons (no false hits on shared prefixes like \`personal-skills-other\`).

## Tests

- \`internal/skill/manager_test.go\`:
  - \`TestManager_SourcePaths_ExpandsHomeAndKeepsAbsolute\`
  - \`TestManager_SourcePaths_RemoteResolvesToCachePath\`
- \`internal/engine/ops/status_test.go\`:
  - \`TestIsUnderAny\` — the path-containment helper, including the \`personal-skills-other\` shared-prefix case
  - \`TestReconcileSkills_SuppressesFSDiscoveryInsideConfiguredSource\` — the regression test for #88
  - \`TestReconcileSkills_KeepsUnrelatedFSDiscovery\` — guards against over-suppression

## Test plan
- [x] \`go test ./...\` passes
- [x] New unit tests cover the duplicate-rows regression and the path helper
- [x] Workspace skills outside any configured source still appear as unmanaged