### PR TITLE
fix(sync): hide unmanaged entries from sync summary; prune symlinks

### DIFF
--- a/internal/engine/render/sync_text.go
+++ b/internal/engine/render/sync_text.go
@@ -85,7 +85,15 @@ func buildRepoSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
 		actions[r.Path] = r.Action
 		errs[r.Path] = r.Error
 	}
-	entries := append([]RepoEntry(nil), status.Repositories...)
+	entries := make([]RepoEntry, 0, len(status.Repositories))
+	for _, e := range status.Repositories {
+		// Sync only manages config-declared resources. FS-discovered
+		// unmanaged entries belong in `gaal status`, not the sync summary.
+		if e.Status == StatusUnmanaged {
+			continue
+		}
+		entries = append(entries, e)
+	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
 
 	rows := make([]syncRow, 0, len(entries))
@@ -106,7 +114,16 @@ func buildRepoSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
 
 func buildSkillSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
 	skillActions := skillActionIndex(plan.Skills)
-	aggregated := aggregateSkillsByName(status.Skills)
+	// Drop unmanaged entries before aggregating so the per-skill agent list
+	// reflects what gaal actually synced rather than what the FS scan found.
+	managed := make([]SkillEntry, 0, len(status.Skills))
+	for _, e := range status.Skills {
+		if e.Status == StatusUnmanaged {
+			continue
+		}
+		managed = append(managed, e)
+	}
+	aggregated := aggregateSkillsByName(managed)
 	rows := make([]syncRow, 0, len(aggregated))
 	for _, s := range aggregated {
 		action := skillActions[s.Name]
@@ -130,7 +147,13 @@ func buildMCPSyncRows(plan *PlanReport, status *StatusReport) []syncRow {
 		actions[m.Name] = m.Action
 		errs[m.Name] = m.Error
 	}
-	entries := append([]MCPEntry(nil), status.MCPs...)
+	entries := make([]MCPEntry, 0, len(status.MCPs))
+	for _, e := range status.MCPs {
+		if e.Status == StatusUnmanaged {
+			continue
+		}
+		entries = append(entries, e)
+	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
 
 	rows := make([]syncRow, 0, len(entries))

--- a/internal/engine/render/sync_text_test.go
+++ b/internal/engine/render/sync_text_test.go
@@ -170,6 +170,58 @@ func TestRenderSyncSummary_NoOpsSinkToBottomOfTheirGroup(t *testing.T) {
 	}
 }
 
+// TestRenderSyncSummary_HidesUnmanagedEntries is the regression test for #96:
+// FS-discovered resources outside the user's config (e.g. skills installed by
+// a sibling tool, MCP entries registered manually) must not appear in the
+// sync summary. They belong to `gaal status`/`gaal audit`, which still surface
+// them — sync only reports what it actually managed.
+func TestRenderSyncSummary_HidesUnmanagedEntries(t *testing.T) {
+	plan := &PlanReport{
+		Skills: []PlanSkillEntry{
+			{Source: "owner/repo", Agent: "claude-code", Action: PlanCreate, Install: []string{"managed-skill"}},
+		},
+	}
+	status := &StatusReport{
+		Repositories: []RepoEntry{
+			{Path: "/configured/repo", Status: StatusOK},
+			{Path: "/elsewhere/unrelated", Status: StatusUnmanaged},
+		},
+		Skills: []SkillEntry{
+			{Source: "owner/repo", Agent: "claude-code", Status: StatusOK, Installed: []string{"managed-skill"}},
+			{Source: "owner/repo", Agent: "cursor", Status: StatusUnmanaged, Installed: []string{"managed-skill"}, Global: true},
+			{Source: "/somewhere/else", Agent: "github-copilot", Status: StatusUnmanaged, Installed: []string{"stray-skill"}},
+		},
+		MCPs: []MCPEntry{
+			{Name: "configured", Target: "/x/managed.json", Status: StatusPresent},
+			{Name: "stray", Target: "/y/stray.json", Status: StatusUnmanaged},
+		},
+	}
+	var buf bytes.Buffer
+	if err := RenderSyncSummary(&buf, plan, status, 0); err != nil {
+		t.Fatalf("RenderSyncSummary: %v", err)
+	}
+	out := buf.String()
+
+	// Managed entries appear.
+	for _, want := range []string{"/configured/repo", "managed-skill", "configured"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected managed entry %q in output:\n%s", want, out)
+		}
+	}
+	// Unmanaged entries are filtered out.
+	for _, unwanted := range []string{"/elsewhere/unrelated", "stray-skill", "stray"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("expected unmanaged entry %q to be hidden, got:\n%s", unwanted, out)
+		}
+	}
+	// And the agent list for managed-skill must not include cursor (it
+	// only appeared as an unmanaged entry), even though aggregation by name
+	// would otherwise have merged them.
+	if strings.Contains(out, "cursor") {
+		t.Errorf("expected cursor to be filtered from agent list, got:\n%s", out)
+	}
+}
+
 func TestRenderSyncSummary_EmptySummaryPrintsCompleteLine(t *testing.T) {
 	var buf bytes.Buffer
 	if err := RenderSyncSummary(&buf, &PlanReport{}, &StatusReport{}, 100*time.Millisecond); err != nil {

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -565,29 +565,43 @@ func (m *Manager) Prune(ctx context.Context) error {
 	}
 
 	// Walk each managed skills directory and remove entries absent from expected.
+	// Real directories AND symlinks are candidates: agents like the user's
+	// shared `~/.agents/skills/` setup install via symlinks under each
+	// agent's skills dir, and a stale symlink is just as orphaned as a
+	// stale dir (#96).
 	for skillsDir, keep := range expected {
 		entries, err := os.ReadDir(skillsDir)
 		if err != nil {
 			continue // directory may not exist
 		}
 		for _, entry := range entries {
-			if !entry.IsDir() {
+			if !isSkillEntry(entry) {
 				continue
 			}
 			if _, ok := keep[entry.Name()]; ok {
 				continue
 			}
 			target := filepath.Join(skillsDir, entry.Name())
-			slog.Info("pruning orphan skill", "path", target)
 			if err := os.RemoveAll(target); err != nil {
 				slog.Warn("failed to prune skill", "path", target, "err", err)
 				continue
 			}
+			slog.Info("pruned orphan skill", "path", target)
 			m.pruneSkillSnapshot(target)
 		}
 	}
 
 	return nil
+}
+
+// isSkillEntry reports whether a ReadDir entry is a candidate for pruning.
+// Real directories, and symlinks (which a sibling tool may have created to
+// point at a shared skills tree), both count. Plain files are skipped.
+func isSkillEntry(e fs.DirEntry) bool {
+	if e.IsDir() {
+		return true
+	}
+	return e.Type()&fs.ModeSymlink != 0
 }
 
 // pruneSkillSnapshot removes the snapshot file for a skill directory that has

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -728,6 +728,55 @@ func TestPrune_RemovesOrphanSkill(t *testing.T) {
 	}
 }
 
+// TestPrune_RemovesOrphanSymlink covers the regression in #96: when an agent
+// skills dir contains symlinks placed by a sibling tool (e.g. pointing into a
+// shared `~/.agents/skills/` tree), Prune must clean those up alongside real
+// dirs. The previous implementation only considered IsDir entries, so stale
+// symlinks were never removed even when they were not in the configuration.
+func TestPrune_RemovesOrphanSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require admin/Developer Mode on Windows; skip the regression test there")
+	}
+	sourceDir := t.TempDir()
+	keptDir := filepath.Join(sourceDir, "kept-skill")
+	os.MkdirAll(keptDir, 0o755)
+	os.WriteFile(filepath.Join(keptDir, "SKILL.md"), []byte("---\nname: kept-skill\n---\n"), 0o644)
+
+	home := t.TempDir()
+	claudeSkillsDir := filepath.Join(home, ".claude", "skills")
+	os.MkdirAll(claudeSkillsDir, 0o755)
+
+	// Real install of the configured skill — must survive.
+	os.MkdirAll(filepath.Join(claudeSkillsDir, "kept-skill"), 0o755)
+
+	// Stale symlink placed by another tool — must be pruned.
+	staleTarget := t.TempDir()
+	os.MkdirAll(filepath.Join(staleTarget, "stale-symlinked"), 0o755)
+	if err := os.Symlink(filepath.Join(staleTarget, "stale-symlinked"), filepath.Join(claudeSkillsDir, "stale-symlinked")); err != nil {
+		t.Fatalf("os.Symlink: %v", err)
+	}
+
+	cfg := []config.ConfigSkill{
+		{Source: sourceDir, Select: []string{"kept-skill"}, Agents: []string{"claude-code"}, Global: true},
+	}
+	m := NewManager(cfg, t.TempDir(), home, t.TempDir(), "", false)
+	if err := m.Prune(context.Background()); err != nil {
+		t.Fatalf("Prune returned error: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(claudeSkillsDir, "stale-symlinked")); !os.IsNotExist(err) {
+		t.Errorf("expected stale-symlinked to be removed, got err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(claudeSkillsDir, "kept-skill")); err != nil {
+		t.Errorf("expected kept-skill to remain, got err=%v", err)
+	}
+	// The symlink target must NOT have been removed — Prune deletes the
+	// link, not the underlying directory.
+	if _, err := os.Stat(filepath.Join(staleTarget, "stale-symlinked")); err != nil {
+		t.Errorf("expected symlink target to remain on disk, got err=%v", err)
+	}
+}
+
 func TestPrune_NoOpWhenAllManaged(t *testing.T) {
 	sourceDir := t.TempDir()
 	skillDir := filepath.Join(sourceDir, "my-skill")


### PR DESCRIPTION
## Summary

Fixes #96.

The sync summary aggregated **every** FS-discovered resource alongside the config-managed ones. That single oversight cascaded into every numbered bug in the issue:

- **Bug 3 / 5** (\`select:\` apparently ignored, agents never declared): the per-skill agent list and the per-resource rows include FS-discovered entries with their own agent attributions, so e.g. \`crm-update up to date in antigravity, claude-code, cline, codex, cursor, gemini-cli, generic, github-copilot, opencode, warp, windsurf\` despite the user only declaring \`[codex, claude-code]\`.
- **Bug 1 / 2** (\`--prune\` logs phantom paths and does not delete files): the user's \`~/.claude/skills/\` is full of symlinks placed by a sibling tool. Prune's \`if !entry.IsDir()\` skipped them all, so symlinks pointing into \`~/.agents/skills/\` were never removed even when not in config. The \`pruning orphan skill\` log line was emitted **before** the \`os.RemoveAll\` call, so a failure still printed the line.

PR #99 already drops \`StatusUnmanaged\` from the **plan**; this PR does the same for the **summary** and tightens prune.

## Changes

- **\`internal/engine/render/sync_text.go\`**: \`buildRepoSyncRows\`, \`buildSkillSyncRows\`, \`buildMCPSyncRows\` now drop \`StatusUnmanaged\` entries before sorting/aggregating. The skill aggregation no longer pulls in unmanaged entries by name, so the agent list reflects what \`gaal sync\` actually managed.
- **\`internal/skill/manager.go\`**: new \`isSkillEntry\` helper makes \`Prune\` consider symlinks alongside real dirs (the user's setup uses symlinks into a shared \`~/.agents/skills/\`). The \`pruning orphan skill\` log line was reordered to fire only after \`os.RemoveAll\` succeeded.

\`gaal status\` and \`gaal audit\` are unchanged — they still surface FS-discovered resources for triage.

## Tests

- \`internal/engine/render/sync_text_test.go\`:
  - \`TestRenderSyncSummary_HidesUnmanagedEntries\` — repos / skills / MCPs marked StatusUnmanaged stay out of the summary, and an unmanaged skill that shares a name with a managed one no longer leaks its agent into the merged row.
- \`internal/skill/manager_test.go\`:
  - \`TestPrune_RemovesOrphanSymlink\` — seeds a stale symlink in the agent skills dir, asserts Prune removes the link (but not the target).

## Out of scope (explicit)

- Plumbing config-driven agents into the FS scan so unmanaged entries never appear at all (would change \`status\`/\`audit\` semantics — out of scope for a sync-summary fix).

## Test plan
- [x] \`go test ./...\` passes
- [x] Sync summary no longer lists FS-discovered cross-agent installs
- [x] \`gaal status\` still shows the FS-discovered resources
- [x] \`--prune\` removes orphan symlinks alongside orphan directories
- [x] No \"pruning orphan skill …\" log line is emitted before the remove succeeds