### PR TITLE
feat: summary-first default text output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ dist/
 report/
 tmp/
 docs/superpowers/
+.worktrees/

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/pterm/pterm"
@@ -81,7 +82,10 @@ func runAgentList(eng *engine.Engine, w io.Writer, format engine.OutputFormat) e
 	case engine.FormatTable:
 		return renderAgentsTable(w, entries)
 	default:
-		return renderAgentsText(w, entries)
+		if verbose {
+			return renderAgentsText(w, entries)
+		}
+		return renderAgentsSummary(w, entries)
 	}
 }
 
@@ -200,7 +204,10 @@ func runAgentDetail(eng *engine.Engine, w io.Writer, name string, format engine.
 	case engine.FormatTable:
 		return renderAgentDetailCard(w, detail)
 	default:
-		return renderAgentDetailText(w, detail)
+		if verbose {
+			return renderAgentDetailText(w, detail)
+		}
+		return renderAgentDetailSummary(w, detail)
 	}
 }
 

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -89,6 +89,46 @@ func runAgentList(eng *engine.Engine, w io.Writer, format engine.OutputFormat) e
 	}
 }
 
+func renderAgentsSummary(w io.Writer, entries []render.AgentEntry) error {
+	var installed, available []string
+	for _, e := range entries {
+		if e.Installed {
+			installed = append(installed, e.Name)
+		} else {
+			available = append(available, e.Name)
+		}
+	}
+	sort.Strings(installed)
+	sort.Strings(available)
+	if len(installed) > 0 {
+		fmt.Fprintf(w, "Installed: %s\n", strings.Join(installed, ", "))
+	}
+	if len(available) > 0 {
+		fmt.Fprintf(w, "Available: %s\n", strings.Join(available, ", "))
+	}
+	return nil
+}
+
+func renderAgentDetailSummary(w io.Writer, d *render.AgentDetail) error {
+	status := "installed"
+	if !d.Installed {
+		status = "not installed"
+	}
+	fmt.Fprintf(w, "%s (%s)\n", d.Name, status)
+
+	skillCount := 0
+	for _, p := range d.Paths {
+		skillCount += p.SkillCount
+	}
+	if d.MCPExists {
+		fmt.Fprintf(w, "  Skills: %d\n", skillCount)
+		fmt.Fprintf(w, "  MCP:    %s\n", d.MCPConfig)
+	} else {
+		fmt.Fprintf(w, "  Skills: %d\n", skillCount)
+	}
+	return nil
+}
+
 // renderAgentsText prints the agent list as space-aligned columns matching
 // the sample in docs/content/cli/agents.mdx.
 func renderAgentsText(w io.Writer, entries []render.AgentEntry) error {

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"gaal/internal/engine/render"
+)
+
+func TestRenderAgentsSummary(t *testing.T) {
+	entries := []render.AgentEntry{
+		{Name: "claude-code", Installed: true},
+		{Name: "cursor", Installed: true},
+		{Name: "windsurf", Installed: false},
+	}
+	var buf bytes.Buffer
+	if err := renderAgentsSummary(&buf, entries); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Installed:") {
+		t.Errorf("missing Installed, got:\n%s", out)
+	}
+	if !strings.Contains(out, "claude-code") {
+		t.Errorf("missing claude-code, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Available:") {
+		t.Errorf("missing Available, got:\n%s", out)
+	}
+	if !strings.Contains(out, "windsurf") {
+		t.Errorf("missing windsurf, got:\n%s", out)
+	}
+}

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"gaal/internal/config"
 	"gaal/internal/engine"
+	"gaal/internal/engine/render"
 	"gaal/internal/telemetry"
 )
 
@@ -33,6 +36,13 @@ func init() {
 func runAudit(_ *cobra.Command, _ []string) error {
 	telemetry.Track("audit")
 	// Audit does not require a gaal.yaml — pass an empty config.
-	return engine.NewWithOptions(&config.Config{}, engineOpts).
-		Audit(context.Background(), engine.OutputFormat(effectiveOutputFormat()))
+	format := effectiveOutputFormat()
+	if err := engine.NewWithOptions(&config.Config{}, engineOpts).
+		Audit(context.Background(), engine.OutputFormat(format)); err != nil {
+		return err
+	}
+	if format == string(render.FormatText) || format == "" {
+		render.WriteTip(os.Stdout, term.IsTerminal(int(os.Stdout.Fd())))
+	}
+	return nil
 }

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -34,5 +34,5 @@ func runAudit(_ *cobra.Command, _ []string) error {
 	telemetry.Track("audit")
 	// Audit does not require a gaal.yaml — pass an empty config.
 	return engine.NewWithOptions(&config.Config{}, engineOpts).
-		Audit(context.Background(), engine.OutputFormat(outputFormat))
+		Audit(context.Background(), engine.OutputFormat(effectiveOutputFormat()))
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -66,7 +66,11 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	case "table":
 		renderDoctorTable(report)
 	default:
-		renderDoctorText(report)
+		if verbose {
+			renderDoctorText(report)
+		} else {
+			renderDoctorSummary(report)
+		}
 	}
 	if !doctorNoUpsell {
 		renderCommunityBlock()
@@ -76,6 +80,120 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		os.Exit(report.ExitCode)
 	}
 	return nil
+}
+
+// renderDoctorSummary emits a compact one-line-per-section summary suitable for
+// non-verbose output. Each line is prefixed with ✓, !, or ✗ depending on the
+// worst finding severity for that section.
+func renderDoctorSummary(report *ops.DoctorReport) {
+	type sectionSpec struct {
+		id    string
+		label string
+	}
+	sections := []sectionSpec{
+		{"config", "Config valid"},
+		{"telemetry", "Telemetry configured"},
+		{"skills", "sources reachable"},
+		{"mcps", "MCP targets valid"},
+		{"tools", "tools configured"},
+	}
+
+	for _, s := range sections {
+		var findings []ops.Finding
+		for _, f := range report.Findings {
+			if f.Section == s.id {
+				findings = append(findings, f)
+			}
+		}
+		if len(findings) == 0 {
+			continue
+		}
+
+		errs, warns, infos := 0, 0, 0
+		for _, f := range findings {
+			switch f.Severity {
+			case ops.SeverityError:
+				errs++
+			case ops.SeverityWarning:
+				warns++
+			default:
+				infos++
+			}
+		}
+
+		total := errs + warns + infos
+		var icon, line string
+		switch {
+		case errs > 0:
+			icon = "✗"
+			if s.id == "skills" {
+				ok := total - errs
+				line = fmt.Sprintf("%s %d/%d %s (%d unreachable)", icon, ok, total, s.label, errs)
+			} else {
+				line = fmt.Sprintf("%s %s", icon, s.label)
+			}
+		case warns > 0:
+			icon = "!"
+			if s.id == "skills" {
+				ok := total - warns
+				line = fmt.Sprintf("%s %d/%d %s (%d unreachable)", icon, ok, total, s.label, warns)
+			} else {
+				line = fmt.Sprintf("%s %s", icon, s.label)
+			}
+		default:
+			icon = "✓"
+			if s.id == "skills" {
+				line = fmt.Sprintf("%s %d %s", icon, total, s.label)
+			} else if s.id == "mcps" {
+				line = fmt.Sprintf("%s %d %s", icon, total, s.label)
+			} else {
+				line = fmt.Sprintf("%s %s", icon, s.label)
+			}
+		}
+		fmt.Println(line)
+	}
+
+	// Agents summary line.
+	installed, misconfigured := 0, 0
+	for _, f := range report.Findings {
+		if f.Section != "agents" {
+			continue
+		}
+		switch f.Severity {
+		case ops.SeverityInfo:
+			var n int
+			if _, err := fmt.Sscanf(f.Message, "%d ", &n); err == nil {
+				installed = n
+			}
+		case ops.SeverityError:
+			misconfigured++
+		}
+	}
+	// Only show agents line if there are agent findings.
+	hasAgentFindings := false
+	for _, f := range report.Findings {
+		if f.Section == "agents" {
+			hasAgentFindings = true
+			break
+		}
+	}
+	if hasAgentFindings {
+		agentIcon := "✓"
+		if misconfigured > 0 {
+			agentIcon = "!"
+		}
+		fmt.Printf("%s %d agents installed, %d misconfigured\n", agentIcon, installed, misconfigured)
+	}
+
+	fmt.Println()
+	switch report.ExitCode {
+	case 0:
+		fmt.Println("All checks passed.")
+	case 1:
+		fmt.Println("Checks passed with warnings. Use --verbose for details.")
+	default:
+		fmt.Println("Checks failed. Use --verbose for details.")
+	}
 }
 
 // renderDoctorText emits the section-per-line layout shown in docs/content/cli/doctor.mdx.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/pterm/pterm"
@@ -112,7 +113,9 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	pterm.DefaultBox.WithTitle("Preview").Println(previewText(dest, plan))
+	if verbose {
+		pterm.DefaultBox.WithTitle("Preview").Println(previewText(dest, plan))
+	}
 
 	if isTTY && !initImportAll {
 		confirmed, err := pterm.DefaultInteractiveConfirm.
@@ -131,11 +134,33 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	if err := eng.InitFromPlan(dest, plan, forceInit); err != nil {
 		return err
 	}
-	pterm.Success.Printfln("Created %s", dest)
-	if len(plan.Skills) > 0 {
-		pterm.Info.Println(`Tip: each skill entry targets a single agent. To sync a skill to every installed agent, edit its "agents:" field to ["*"].`)
+	if verbose {
+		pterm.Success.Printfln("Created %s", dest)
+		if len(plan.Skills) > 0 {
+			pterm.Info.Println(`Tip: each skill entry targets a single agent. To sync a skill to every installed agent, edit its "agents:" field to ["*"].`)
+		}
+		printNextSteps(dest)
+	} else {
+		agentSet := map[string]struct{}{}
+		for _, s := range plan.Skills {
+			for _, a := range s.Agents {
+				agentSet[a] = struct{}{}
+			}
+		}
+		agentNames := make([]string, 0, len(agentSet))
+		for a := range agentSet {
+			agentNames = append(agentNames, a)
+		}
+		sort.Strings(agentNames)
+		if len(agentNames) > 0 {
+			fmt.Printf("Detected: %s\n", strings.Join(agentNames, ", "))
+		}
+		fmt.Printf("Found %d %s.\n", len(plan.Skills), pluralize(len(plan.Skills), "skill entry", "skill entries"))
+		fmt.Printf("Found %d %s.\n", len(plan.MCPs), pluralize(len(plan.MCPs), "MCP server", "MCP servers"))
+		fmt.Printf("Generated %s.\n", dest)
+		fmt.Println()
+		fmt.Println("Next: gaal sync")
 	}
-	printNextSteps(dest)
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,7 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 			return err
 		}
 		engineOpts = opts
+		engineOpts.Verbose = verbose
 
 		// Load config once and cache it for all sub-commands and telemetry.
 		// Always capture the error so sub-commands can surface the real cause.
@@ -215,6 +216,17 @@ func loadMergedTelemetryConfig() *bool {
 		return uc.Telemetry
 	}
 	return nil
+}
+
+// effectiveOutputFormat returns the output format to use for the current
+// invocation. When --verbose is set and the format is "text" (or the empty
+// default), it returns "verbose" so that renderers can switch to a detailed
+// view. In all other cases it returns outputFormat unchanged.
+func effectiveOutputFormat() string {
+	if verbose && (outputFormat == "" || outputFormat == "text") {
+		return "verbose"
+	}
+	return outputFormat
 }
 
 // showConsentPrompt displays the opt-in telemetry prompt.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -56,6 +56,37 @@ func TestApplyOptions_SandboxRedirectsUserDirs(t *testing.T) {
 	}
 }
 
+func TestVerboseEffectiveOutputFormat(t *testing.T) {
+	tests := []struct {
+		name         string
+		verbose      bool
+		outputFormat string
+		want         string
+	}{
+		{name: "verbose+text returns verbose", verbose: true, outputFormat: "text", want: "verbose"},
+		{name: "verbose+empty returns verbose", verbose: true, outputFormat: "", want: "verbose"},
+		{name: "verbose+json unchanged", verbose: true, outputFormat: "json", want: "json"},
+		{name: "verbose+table unchanged", verbose: true, outputFormat: "table", want: "table"},
+		{name: "non-verbose+text unchanged", verbose: false, outputFormat: "text", want: "text"},
+		{name: "non-verbose+json unchanged", verbose: false, outputFormat: "json", want: "json"},
+	}
+	origVerbose := verbose
+	origFormat := outputFormat
+	t.Cleanup(func() {
+		verbose = origVerbose
+		outputFormat = origFormat
+	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			verbose = tc.verbose
+			outputFormat = tc.outputFormat
+			if got := effectiveOutputFormat(); got != tc.want {
+				t.Errorf("effectiveOutputFormat() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSkipTelemetry(t *testing.T) {
 	completionParent := &cobra.Command{Use: "completion"}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -28,5 +28,5 @@ func runStatus(_ *cobra.Command, _ []string) error {
 
 	telemetry.Track("status")
 	return engine.NewWithOptions(cfg.Config, engineOpts).
-		Status(context.Background(), engine.OutputFormat(outputFormat))
+		Status(context.Background(), engine.OutputFormat(effectiveOutputFormat()))
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"gaal/internal/engine"
+	"gaal/internal/engine/render"
 	"gaal/internal/telemetry"
 )
 
@@ -27,6 +30,13 @@ func runStatus(_ *cobra.Command, _ []string) error {
 	cfg := resolvedCfg
 
 	telemetry.Track("status")
-	return engine.NewWithOptions(cfg.Config, engineOpts).
-		Status(context.Background(), engine.OutputFormat(effectiveOutputFormat()))
+	format := effectiveOutputFormat()
+	if err := engine.NewWithOptions(cfg.Config, engineOpts).
+		Status(context.Background(), engine.OutputFormat(format)); err != nil {
+		return err
+	}
+	if format == string(render.FormatText) || format == "" {
+		render.WriteTip(os.Stdout, term.IsTerminal(int(os.Stdout.Fd())))
+	}
+	return nil
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -69,7 +69,7 @@ func runSync(_ *cobra.Command, _ []string) error {
 
 	if dryRun {
 		slog.Info("dry-run mode", "config", cfgFile)
-		format := engine.OutputFormat(outputFormat)
+		format := engine.OutputFormat(effectiveOutputFormat())
 		plan, err := eng.DryRun(ctx, format)
 		if err != nil {
 			telemetry.TrackError("sync", err)
@@ -115,8 +115,16 @@ func runSync(_ *cobra.Command, _ []string) error {
 	status, err := eng.Collect(ctx)
 	if err != nil {
 		slog.Debug("post-sync status collection failed; skipping summary", "err", err)
-	} else if rerr := render.RenderSyncSummary(os.Stdout, plan, status, duration); rerr != nil {
-		slog.Debug("rendering sync summary failed", "err", rerr)
+	} else {
+		var rerr error
+		if effectiveOutputFormat() == "verbose" {
+			rerr = render.RenderSyncSummary(os.Stdout, plan, status, duration)
+		} else {
+			rerr = render.RenderSyncBrief(os.Stdout, plan, status, duration)
+		}
+		if rerr != nil {
+			slog.Debug("rendering sync summary failed", "err", rerr)
+		}
 	}
 
 	telemetry.Track("sync")

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -62,6 +62,10 @@ type Options struct {
 	// that skills are installed into every registered agent regardless of
 	// whether the agent's config directory is already present on the machine.
 	Force bool
+	// Verbose enables detailed output in renderers that support it.
+	// When true, full per-resource detail is shown instead of the compact
+	// summary that is the default for text output.
+	Verbose bool
 }
 
 // Engine orchestrates repository, skill and MCP synchronisation.

--- a/internal/engine/render/audit.go
+++ b/internal/engine/render/audit.go
@@ -23,8 +23,10 @@ func NewAuditRenderer(format OutputFormat) AuditRenderer {
 		return &auditJSONRenderer{}
 	case FormatTable:
 		return &auditTableRenderer{}
-	default:
+	case FormatVerbose:
 		return &auditTextRenderer{}
+	default:
+		return &summaryAuditRenderer{}
 	}
 }
 

--- a/internal/engine/render/renderer.go
+++ b/internal/engine/render/renderer.go
@@ -10,9 +10,10 @@ import (
 type OutputFormat string
 
 const (
-	FormatText  OutputFormat = "text"
-	FormatTable OutputFormat = "table"
-	FormatJSON  OutputFormat = "json"
+	FormatText    OutputFormat = "text"
+	FormatVerbose OutputFormat = "verbose"
+	FormatTable   OutputFormat = "table"
+	FormatJSON    OutputFormat = "json"
 )
 
 // Renderer formats a StatusReport and writes it to an io.Writer.
@@ -25,13 +26,15 @@ func NewRenderer(f OutputFormat) (Renderer, error) {
 	slog.Debug("creating renderer", "format", f)
 	switch f {
 	case FormatText, "":
+		return &summaryRenderer{}, nil
+	case FormatVerbose:
 		return &textRenderer{}, nil
 	case FormatTable:
 		return &tableRenderer{}, nil
 	case FormatJSON:
 		return &jsonRenderer{}, nil
 	default:
-		return nil, fmt.Errorf("unknown output format %q (want: text, table, json)", f)
+		return nil, fmt.Errorf("unknown output format %q (want: text, verbose, table, json)", f)
 	}
 }
 
@@ -45,12 +48,14 @@ func NewPlanRenderer(f OutputFormat) (PlanRenderer, error) {
 	slog.Debug("creating plan renderer", "format", f)
 	switch f {
 	case FormatText, "":
+		return &summaryPlanRenderer{}, nil
+	case FormatVerbose:
 		return &planTextRenderer{}, nil
 	case FormatTable:
 		return &planTableRenderer{}, nil
 	case FormatJSON:
 		return &planJSONRenderer{}, nil
 	default:
-		return nil, fmt.Errorf("unknown output format %q (want: text, table, json)", f)
+		return nil, fmt.Errorf("unknown output format %q (want: text, verbose, table, json)", f)
 	}
 }

--- a/internal/engine/render/summary.go
+++ b/internal/engine/render/summary.go
@@ -1,0 +1,148 @@
+package render
+
+import (
+	"fmt"
+	"io"
+)
+
+// summaryRenderer implements Renderer producing a compact count-based summary.
+type summaryRenderer struct{}
+
+func (sr *summaryRenderer) Render(w io.Writer, r *StatusReport) error {
+	repoCounts := repoSummaryCounts(r.Repositories)
+	skillCounts := skillSummaryCounts(r.Skills)
+	mcpCounts := mcpSummaryCounts(r.MCPs)
+
+	installedAgents := 0
+	for _, a := range r.Agents {
+		if a.Installed {
+			installedAgents++
+		}
+	}
+
+	hasRepos := len(r.Repositories) > 0
+	hasSkills := skillCounts.total > 0
+	hasMCPs := mcpCounts.total > 0
+	hasAgents := len(r.Agents) > 0
+
+	if !hasRepos && !hasSkills && !hasMCPs && !hasAgents {
+		fmt.Fprintln(w, "no managed resources")
+		return nil
+	}
+
+	drift := 0
+
+	if hasRepos {
+		icon := "✓"
+		dirtyNote := ""
+		if repoCounts.dirty > 0 {
+			dirtyNote = fmt.Sprintf(" (%d dirty)", repoCounts.dirty)
+		}
+		if repoCounts.cloned < repoCounts.total {
+			icon = "!"
+			drift += repoCounts.total - repoCounts.cloned
+		}
+		fmt.Fprintf(w, "%s %d/%d repos cloned%s\n", icon, repoCounts.cloned, repoCounts.total, dirtyNote)
+	}
+
+	if hasSkills {
+		icon := "✓"
+		if skillCounts.installed < skillCounts.total {
+			icon = "!"
+			drift += skillCounts.total - skillCounts.installed
+		}
+		fmt.Fprintf(w, "%s %d/%d skills installed\n", icon, skillCounts.installed, skillCounts.total)
+	}
+
+	if hasMCPs {
+		icon := "✓"
+		if mcpCounts.registered < mcpCounts.total {
+			icon = "!"
+			drift += mcpCounts.total - mcpCounts.registered
+		}
+		fmt.Fprintf(w, "%s %d/%d MCP servers registered\n", icon, mcpCounts.registered, mcpCounts.total)
+	}
+
+	if hasAgents {
+		fmt.Fprintf(w, "✓ %d agents configured\n", installedAgents)
+	}
+
+	fmt.Fprintf(w, "%d drift\n", drift)
+	return nil
+}
+
+type repoCounts struct {
+	total  int
+	cloned int
+	dirty  int
+}
+
+func repoSummaryCounts(entries []RepoEntry) repoCounts {
+	var c repoCounts
+	c.total = len(entries)
+	for _, e := range entries {
+		switch e.Status {
+		case StatusOK:
+			c.cloned++
+		case StatusDirty:
+			c.cloned++
+			c.dirty++
+		}
+	}
+	return c
+}
+
+type skillCounts struct {
+	total     int
+	installed int
+}
+
+// skillSummaryCounts counts unique skill names across all non-unmanaged entries.
+// A skill name is counted as "installed" if it appears in any entry's Installed
+// list, and "missing" if it appears only in Missing lists.
+func skillSummaryCounts(entries []SkillEntry) skillCounts {
+	installedNames := make(map[string]bool)
+	missingNames := make(map[string]bool)
+
+	for _, e := range entries {
+		if e.Status == StatusUnmanaged {
+			continue
+		}
+		for _, name := range e.Installed {
+			installedNames[name] = true
+		}
+		for _, name := range e.Missing {
+			missingNames[name] = true
+		}
+	}
+
+	// A name that appears in both installed and missing is considered installed.
+	for name := range installedNames {
+		delete(missingNames, name)
+	}
+
+	var c skillCounts
+	c.installed = len(installedNames)
+	c.total = len(installedNames) + len(missingNames)
+	return c
+}
+
+type mcpCounts struct {
+	total      int
+	registered int
+}
+
+func mcpSummaryCounts(entries []MCPEntry) mcpCounts {
+	var c mcpCounts
+	for _, e := range entries {
+		if e.Status == StatusUnmanaged {
+			continue
+		}
+		c.total++
+		switch e.Status {
+		case StatusOK, StatusPresent, StatusDirty:
+			c.registered++
+		}
+	}
+	return c
+}

--- a/internal/engine/render/summary_audit.go
+++ b/internal/engine/render/summary_audit.go
@@ -51,13 +51,16 @@ func (r *summaryAuditRenderer) Render(w io.Writer, report *AuditReport) error {
 	}
 	sort.Strings(agents)
 
+	// "Found 3 skills across 2 agents." / "Found 1 skill across 1 agent."
 	fmt.Fprintf(w, "Found %s across %s.\n",
 		pluralise(len(skillNames), "skill", "skills"),
 		pluralise(len(agents), "agent", "agents"),
 	)
+	// "Found 3 MCP servers." / "Found 1 MCP server."
 	fmt.Fprintf(w, "Found %s.\n", pluralise(len(mcpNames), "MCP server", "MCP servers"))
+	// "2 agents scanned: claude-code, cursor"
 	fmt.Fprintf(w, "%s scanned: %s\n",
-		strings.Title(pluralise(len(agents), "agent", "agents")), //nolint:staticcheck
+		pluralise(len(agents), "agent", "agents"),
 		strings.Join(agents, ", "),
 	)
 

--- a/internal/engine/render/summary_audit.go
+++ b/internal/engine/render/summary_audit.go
@@ -1,0 +1,65 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// summaryAuditRenderer implements AuditRenderer producing a compact count-based
+// audit summary. It shows unique skill names, unique MCP server names, and the
+// number of agents scanned.
+type summaryAuditRenderer struct{}
+
+func (r *summaryAuditRenderer) Render(w io.Writer, report *AuditReport) error {
+	if len(report.Skills) == 0 && len(report.MCPs) == 0 {
+		fmt.Fprintln(w, "No skills or MCP servers discovered.")
+		return nil
+	}
+
+	// Count unique skill names.
+	skillNames := map[string]struct{}{}
+	for _, s := range report.Skills {
+		skillNames[s.Name] = struct{}{}
+	}
+
+	// Count unique MCP server names across all entries.
+	mcpNames := map[string]struct{}{}
+	for _, m := range report.MCPs {
+		for _, s := range m.Servers {
+			mcpNames[s] = struct{}{}
+		}
+	}
+
+	// Collect unique agents (from both skills and MCPs).
+	agentNames := map[string]struct{}{}
+	for _, s := range report.Skills {
+		if s.Agent != "" {
+			agentNames[s.Agent] = struct{}{}
+		}
+	}
+	for _, m := range report.MCPs {
+		if m.Agent != "" {
+			agentNames[m.Agent] = struct{}{}
+		}
+	}
+
+	agents := make([]string, 0, len(agentNames))
+	for a := range agentNames {
+		agents = append(agents, a)
+	}
+	sort.Strings(agents)
+
+	fmt.Fprintf(w, "Found %s across %s.\n",
+		pluralise(len(skillNames), "skill", "skills"),
+		pluralise(len(agents), "agent", "agents"),
+	)
+	fmt.Fprintf(w, "Found %s.\n", pluralise(len(mcpNames), "MCP server", "MCP servers"))
+	fmt.Fprintf(w, "%s scanned: %s\n",
+		strings.Title(pluralise(len(agents), "agent", "agents")), //nolint:staticcheck
+		strings.Join(agents, ", "),
+	)
+
+	return nil
+}

--- a/internal/engine/render/summary_audit_test.go
+++ b/internal/engine/render/summary_audit_test.go
@@ -1,0 +1,90 @@
+package render
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSummaryAudit_WithData(t *testing.T) {
+	r := &AuditReport{
+		Skills: []AuditSkillEntry{
+			{Name: "code-review", Agent: "claude-code", Source: "project", Path: "/home/user/.claude/skills/code-review"},
+			{Name: "code-review", Agent: "cursor", Source: "project", Path: "/home/user/.cursor/skills/code-review"},
+			{Name: "commit", Agent: "claude-code", Source: "project", Path: "/home/user/.claude/skills/commit"},
+			{Name: "summarise", Agent: "cursor", Source: "global", Path: "/home/user/.cursor/skills/summarise"},
+		},
+		MCPs: []AuditMCPEntry{
+			{Agent: "claude-code", ConfigFile: "/home/user/.claude/claude_desktop_config.json", Servers: []string{"filesystem", "git"}},
+			{Agent: "cursor", ConfigFile: "/home/user/.cursor/mcp.json", Servers: []string{"git", "github"}},
+		},
+	}
+
+	var buf strings.Builder
+	sr := &summaryAuditRenderer{}
+	if err := sr.Render(&buf, r); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	out := buf.String()
+
+	// 3 unique skill names: code-review, commit, summarise
+	if !strings.Contains(out, "Found 3 skills") {
+		t.Errorf("expected 'Found 3 skills', got:\n%s", out)
+	}
+	// 3 unique MCP servers: filesystem, git, github
+	if !strings.Contains(out, "Found 3 MCP servers") {
+		t.Errorf("expected 'Found 3 MCP servers', got:\n%s", out)
+	}
+	// 2 unique agents: claude-code, cursor
+	if !strings.Contains(out, "2 agents scanned") {
+		t.Errorf("expected '2 agents scanned', got:\n%s", out)
+	}
+	// Agent list sorted alphabetically
+	if !strings.Contains(out, "claude-code, cursor") {
+		t.Errorf("expected 'claude-code, cursor', got:\n%s", out)
+	}
+}
+
+func TestSummaryAudit_WithData_SingleSkillAndAgent(t *testing.T) {
+	r := &AuditReport{
+		Skills: []AuditSkillEntry{
+			{Name: "commit", Agent: "claude-code", Source: "project", Path: "/home/user/.claude/skills/commit"},
+		},
+		MCPs: []AuditMCPEntry{
+			{Agent: "claude-code", ConfigFile: "/home/user/.claude/mcp.json", Servers: []string{"filesystem"}},
+		},
+	}
+
+	var buf strings.Builder
+	sr := &summaryAuditRenderer{}
+	if err := sr.Render(&buf, r); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	out := buf.String()
+
+	// Singular: "1 skill"
+	if !strings.Contains(out, "Found 1 skill ") {
+		t.Errorf("expected 'Found 1 skill ', got:\n%s", out)
+	}
+	// Singular: "1 MCP server"
+	if !strings.Contains(out, "Found 1 MCP server") {
+		t.Errorf("expected 'Found 1 MCP server', got:\n%s", out)
+	}
+	// Singular: "1 agent"
+	if !strings.Contains(out, "1 agent scanned") {
+		t.Errorf("expected '1 agent scanned', got:\n%s", out)
+	}
+}
+
+func TestSummaryAudit_Empty(t *testing.T) {
+	r := &AuditReport{}
+
+	var buf strings.Builder
+	sr := &summaryAuditRenderer{}
+	if err := sr.Render(&buf, r); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	out := strings.TrimSpace(buf.String())
+	if out != "No skills or MCP servers discovered." {
+		t.Errorf("expected 'No skills or MCP servers discovered.', got %q", out)
+	}
+}

--- a/internal/engine/render/summary_plan.go
+++ b/internal/engine/render/summary_plan.go
@@ -1,0 +1,233 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"sort"
+	"strings"
+)
+
+// summaryPlanRenderer implements PlanRenderer producing a compact one-line-per-
+// change plan for `gaal sync --dry-run`. Changed resources get individual rows
+// with +/~/! markers; unchanged resources collapse into a single summary line.
+//
+// Example output:
+//
+//	Plan:
+//	  + clone   src/example
+//	  + install code-review, refactor (2 skills)
+//	  ~ update  memory-mcp config
+//	  = 10 skills, 3 MCP servers unchanged
+//
+//	Run gaal sync to apply.
+type summaryPlanRenderer struct{}
+
+// planSummaryRow is a single rendered row in the compact plan output.
+type planSummaryRow struct {
+	marker string
+	verb   string
+	name   string
+	action PlanAction
+}
+
+func (r *summaryPlanRenderer) Render(w io.Writer, report *PlanReport) error {
+	slog.Debug("rendering summary plan output")
+
+	if len(report.Repositories) == 0 && len(report.Skills) == 0 && len(report.MCPs) == 0 {
+		fmt.Fprintln(w, "nothing to do")
+		return nil
+	}
+
+	rows, noopCount := buildSummaryPlanRows(report)
+
+	fmt.Fprintln(w, "Plan:")
+
+	// Compute verb width for alignment across all changed rows.
+	verbWidth := 0
+	for _, row := range rows {
+		if n := len(row.verb); n > verbWidth {
+			verbWidth = n
+		}
+	}
+
+	for _, row := range rows {
+		fmt.Fprintf(w, "  %s %s  %s\n", row.marker, padText(row.verb, verbWidth), row.name)
+	}
+
+	if noopCount > 0 {
+		// Pad the "=" line to match verb alignment of changed rows.
+		marker := "="
+		verb := padText("", verbWidth)
+		_ = verb
+		fmt.Fprintf(w, "  %s %s  %d %s unchanged\n", marker, padText("", verbWidth), noopCount, resourceWord(noopCount))
+	}
+
+	fmt.Fprintln(w)
+	switch {
+	case report.HasErrors:
+		fmt.Fprintln(w, "Plan completed with errors.")
+	case report.HasChanges:
+		fmt.Fprintln(w, "Run gaal sync to apply.")
+	default:
+		fmt.Fprintln(w, "Everything up to date.")
+	}
+	return nil
+}
+
+// buildSummaryPlanRows builds the list of changed rows and counts no-ops.
+// Skills are aggregated by name across (source, agent) entries.
+func buildSummaryPlanRows(report *PlanReport) (rows []planSummaryRow, noopCount int) {
+	// --- Repositories ---
+	for _, e := range report.Repositories {
+		switch e.Action {
+		case PlanNoOp:
+			noopCount++
+		default:
+			rows = append(rows, planSummaryRow{
+				marker: planMarker(e.Action),
+				verb:   planVerb(e.Action, "repo"),
+				name:   e.Path,
+				action: e.Action,
+			})
+		}
+	}
+
+	// --- Skills ---
+	// Aggregate by name using skillActionIndex for changed skills; count no-ops.
+	skillActions := skillActionIndex(report.Skills)
+	noopSkillNames := collectNoOpSkillNames(report.Skills)
+
+	// Build install/update groups: name -> action
+	type skillGroup struct {
+		names  []string
+		action PlanAction
+	}
+	// Collect ordered unique changed skill names.
+	seen := map[string]bool{}
+	var installNames, updateNames []string
+	for _, e := range report.Skills {
+		for _, n := range e.Install {
+			if !seen[n] {
+				seen[n] = true
+				if skillActions[n] == PlanCreate {
+					installNames = append(installNames, n)
+				}
+			}
+		}
+		for _, n := range e.Update {
+			if !seen[n] {
+				seen[n] = true
+				if skillActions[n] == PlanUpdate {
+					updateNames = append(updateNames, n)
+				}
+			}
+		}
+	}
+
+	if len(installNames) > 0 {
+		rows = append(rows, planSummaryRow{
+			marker: planMarker(PlanCreate),
+			verb:   planVerb(PlanCreate, "skill"),
+			name:   skillListName(installNames),
+			action: PlanCreate,
+		})
+	}
+	if len(updateNames) > 0 {
+		rows = append(rows, planSummaryRow{
+			marker: planMarker(PlanUpdate),
+			verb:   planVerb(PlanUpdate, "skill"),
+			name:   skillListName(updateNames),
+			action: PlanUpdate,
+		})
+	}
+	// Handle error entries
+	for _, e := range report.Skills {
+		if e.Action == PlanError {
+			rows = append(rows, planSummaryRow{
+				marker: planMarker(PlanError),
+				verb:   planVerb(PlanError, "skill"),
+				name:   displaySkillName(e.Source),
+				action: PlanError,
+			})
+		}
+	}
+	noopCount += len(noopSkillNames)
+
+	// --- MCPs ---
+	for _, e := range report.MCPs {
+		switch e.Action {
+		case PlanNoOp:
+			noopCount++
+		default:
+			name := e.Name
+			if e.Action != PlanError && e.Target != "" {
+				name = e.Name + " config"
+			}
+			rows = append(rows, planSummaryRow{
+				marker: planMarker(e.Action),
+				verb:   planVerb(e.Action, "mcp"),
+				name:   name,
+				action: e.Action,
+			})
+		}
+	}
+
+	// Sort: errors first, then changes, no-ops are collapsed already.
+	sort.SliceStable(rows, func(i, j int) bool {
+		return actionRank(rows[i].action) < actionRank(rows[j].action)
+	})
+
+	return rows, noopCount
+}
+
+// collectNoOpSkillNames returns the deduplicated set of skill names that appear
+// only in NoOp entries (i.e. not in Install or Update of any entry).
+func collectNoOpSkillNames(entries []PlanSkillEntry) []string {
+	changed := map[string]bool{}
+	for _, e := range entries {
+		for _, n := range e.Install {
+			changed[n] = true
+		}
+		for _, n := range e.Update {
+			changed[n] = true
+		}
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, e := range entries {
+		for _, n := range e.NoOp {
+			if !changed[n] && !seen[n] {
+				seen[n] = true
+				out = append(out, n)
+			}
+		}
+	}
+	return out
+}
+
+// skillListName formats a list of skill names for display:
+// a single name is shown as-is; multiple names are comma-joined with a
+// "(N skills)" count suffix.
+func skillListName(names []string) string {
+	if len(names) == 1 {
+		return names[0]
+	}
+	return strings.Join(names, ", ") + " (" + pluralise(len(names), "skill", "skills") + ")"
+}
+
+// resourceWord returns "resource" or "resources" for a count of mixed unchanged items.
+func resourceWord(n int) string {
+	if n == 1 {
+		return "resource"
+	}
+	return "resources"
+}
+
+// pluralise returns "N one" when n==1, else "N many".
+func pluralise(n int, one, many string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, one)
+	}
+	return fmt.Sprintf("%d %s", n, many)
+}

--- a/internal/engine/render/summary_plan_test.go
+++ b/internal/engine/render/summary_plan_test.go
@@ -1,0 +1,234 @@
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSummaryPlan_NothingToDo(t *testing.T) {
+	var buf bytes.Buffer
+	r := &summaryPlanRenderer{}
+	if err := r.Render(&buf, &PlanReport{}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if strings.TrimSpace(out) != "nothing to do" {
+		t.Errorf("expected 'nothing to do', got: %q", out)
+	}
+}
+
+func TestSummaryPlan_AllUnchanged(t *testing.T) {
+	var buf bytes.Buffer
+	r := &summaryPlanRenderer{}
+	report := &PlanReport{
+		Skills: []PlanSkillEntry{
+			{Source: "owner/code-review", Agent: "claude-code", Action: PlanNoOp, NoOp: []string{"code-review", "refactor"}},
+		},
+		MCPs: []PlanMCPEntry{
+			{Name: "filesystem", Target: "/some/path", Action: PlanNoOp},
+		},
+		HasChanges: false,
+		HasErrors:  false,
+	}
+	if err := r.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+
+	// Must have Plan: header
+	if !strings.Contains(out, "Plan:") {
+		t.Errorf("missing 'Plan:' header, got:\n%s", out)
+	}
+	// Must have unchanged summary line
+	if !strings.Contains(out, "unchanged") {
+		t.Errorf("missing 'unchanged' summary, got:\n%s", out)
+	}
+	// Footer must be "Everything up to date."
+	if !strings.Contains(out, "Everything up to date.") {
+		t.Errorf("missing 'Everything up to date.' footer, got:\n%s", out)
+	}
+	// Must NOT have "Run gaal sync" footer
+	if strings.Contains(out, "Run gaal sync") {
+		t.Errorf("should not have 'Run gaal sync' footer for all-unchanged, got:\n%s", out)
+	}
+}
+
+func TestSummaryPlan_WithChanges(t *testing.T) {
+	var buf bytes.Buffer
+	r := &summaryPlanRenderer{}
+	report := &PlanReport{
+		Repositories: []PlanRepoEntry{
+			{Path: "src/example", Type: "git", Action: PlanClone, Want: "main"},
+		},
+		Skills: []PlanSkillEntry{
+			{Source: "owner/code-review", Agent: "claude-code", Action: PlanCreate, Install: []string{"code-review", "refactor"}},
+			{Source: "owner/memory", Agent: "claude-code", Action: PlanNoOp, NoOp: []string{"memory"}},
+			{Source: "owner/search", Agent: "claude-code", Action: PlanNoOp, NoOp: []string{"search", "browser", "fetch", "perplexity", "brave", "ddg", "exa", "tavily", "serp", "google"}},
+		},
+		MCPs: []PlanMCPEntry{
+			{Name: "memory-mcp", Target: "/some/path", Action: PlanUpdate},
+			{Name: "filesystem", Target: "/some/other/path", Action: PlanNoOp},
+		},
+		HasChanges: true,
+		HasErrors:  false,
+	}
+	if err := r.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+
+	// Must have Plan: header
+	if !strings.Contains(out, "Plan:") {
+		t.Errorf("missing 'Plan:' header, got:\n%s", out)
+	}
+	// Must have clone row for repo
+	if !strings.Contains(out, "clone") || !strings.Contains(out, "src/example") {
+		t.Errorf("missing clone repo row, got:\n%s", out)
+	}
+	// Must have install row for skills
+	if !strings.Contains(out, "install") {
+		t.Errorf("missing install skills row, got:\n%s", out)
+	}
+	// Must show skill names
+	if !strings.Contains(out, "code-review") {
+		t.Errorf("missing skill name 'code-review', got:\n%s", out)
+	}
+	// Must have update row for MCP
+	if !strings.Contains(out, "update") || !strings.Contains(out, "memory-mcp") {
+		t.Errorf("missing update MCP row, got:\n%s", out)
+	}
+	// Must have unchanged summary line (collapsing no-ops)
+	if !strings.Contains(out, "unchanged") {
+		t.Errorf("missing unchanged summary, got:\n%s", out)
+	}
+	// Footer must be "Run gaal sync to apply."
+	if !strings.Contains(out, "Run gaal sync to apply.") {
+		t.Errorf("missing 'Run gaal sync to apply.' footer, got:\n%s", out)
+	}
+	// The unchanged line should use = marker
+	lines := strings.Split(out, "\n")
+	var unchangedLine string
+	for _, l := range lines {
+		if strings.Contains(l, "unchanged") {
+			unchangedLine = l
+			break
+		}
+	}
+	if unchangedLine == "" {
+		t.Fatalf("no unchanged line found in:\n%s", out)
+	}
+	if !strings.Contains(unchangedLine, "=") {
+		t.Errorf("unchanged line missing '=' marker: %q", unchangedLine)
+	}
+}
+
+func TestSummaryPlan_WithErrors(t *testing.T) {
+	var buf bytes.Buffer
+	r := &summaryPlanRenderer{}
+	report := &PlanReport{
+		Repositories: []PlanRepoEntry{
+			{Path: "src/broken", Action: PlanError, Error: "network timeout"},
+		},
+		HasChanges: false,
+		HasErrors:  true,
+	}
+	if err := r.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	// Footer must be "Plan completed with errors."
+	if !strings.Contains(out, "Plan completed with errors.") {
+		t.Errorf("missing 'Plan completed with errors.' footer, got:\n%s", out)
+	}
+}
+
+func TestSummaryPlan_VerbAlignment(t *testing.T) {
+	var buf bytes.Buffer
+	r := &summaryPlanRenderer{}
+	report := &PlanReport{
+		Repositories: []PlanRepoEntry{
+			{Path: "src/example", Type: "git", Action: PlanClone},
+		},
+		MCPs: []PlanMCPEntry{
+			{Name: "memory-mcp", Target: "/some/path", Action: PlanUpdate},
+		},
+		HasChanges: true,
+	}
+	if err := r.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	lines := strings.Split(out, "\n")
+	var actionLines []string
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "+") || strings.HasPrefix(trimmed, "~") || strings.HasPrefix(trimmed, "=") || strings.HasPrefix(trimmed, "!") {
+			actionLines = append(actionLines, l)
+		}
+	}
+	if len(actionLines) < 2 {
+		t.Fatalf("expected at least 2 action lines, got %d:\n%s", len(actionLines), out)
+	}
+	// Each action line should have the verb at a consistent offset (after marker + space)
+	// Find where the verb starts — it should be at the same column for all rows
+	verbPositions := make([]int, len(actionLines))
+	for i, l := range actionLines {
+		// marker is at some indent; verb comes after "  X " (2 spaces, marker, space)
+		// Find the first non-space char after the marker
+		idx := strings.IndexAny(l, "+=~!")
+		if idx < 0 {
+			t.Fatalf("no marker found in line: %q", l)
+		}
+		// verb starts right after marker + space
+		verbStart := idx + 2
+		if verbStart >= len(l) {
+			t.Fatalf("line too short after marker: %q", l)
+		}
+		verbPositions[i] = verbStart
+	}
+	for i := 1; i < len(verbPositions); i++ {
+		if verbPositions[i] != verbPositions[0] {
+			t.Errorf("verb positions differ: line 0 at %d, line %d at %d\nlines:\n%s",
+				verbPositions[0], i, verbPositions[i], strings.Join(actionLines, "\n"))
+		}
+	}
+}
+
+func TestSummaryPlan_PluraliseHelper(t *testing.T) {
+	cases := []struct {
+		n    int
+		one  string
+		many string
+		want string
+	}{
+		{1, "skill", "skills", "1 skill"},
+		{2, "skill", "skills", "2 skills"},
+		{0, "skill", "skills", "0 skills"},
+	}
+	for _, tc := range cases {
+		got := pluralise(tc.n, tc.one, tc.many)
+		if got != tc.want {
+			t.Errorf("pluralise(%d, %q, %q) = %q, want %q", tc.n, tc.one, tc.many, got, tc.want)
+		}
+	}
+}
+
+func TestSummaryPlan_SkillCountInParens(t *testing.T) {
+	var buf bytes.Buffer
+	r := &summaryPlanRenderer{}
+	report := &PlanReport{
+		Skills: []PlanSkillEntry{
+			{Source: "owner/pkg", Agent: "claude-code", Action: PlanCreate, Install: []string{"code-review", "refactor"}},
+		},
+		HasChanges: true,
+	}
+	if err := r.Render(&buf, report); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	// When multiple skills in one install row, should show count in parens
+	if !strings.Contains(out, "(2 skills)") {
+		t.Errorf("expected '(2 skills)' count in install row, got:\n%s", out)
+	}
+}

--- a/internal/engine/render/summary_sync.go
+++ b/internal/engine/render/summary_sync.go
@@ -117,9 +117,9 @@ func collectChangeLines(plan *PlanReport) []string {
 
 // agentRollupEntry holds the per-agent counts for the rollup display.
 type agentRollupEntry struct {
-	name      string
+	name       string
 	skillCount int
-	mcpCount  int
+	mcpCount   int
 }
 
 // buildAgentRollup produces one "→ agent: N skills, M MCP servers" line per
@@ -149,9 +149,9 @@ func buildAgentRollup(status *StatusReport) []string {
 			continue
 		}
 		entries = append(entries, agentRollupEntry{
-			name:      a.Name,
+			name:       a.Name,
 			skillCount: skillsByAgent[a.Name],
-			mcpCount:  mcpCount,
+			mcpCount:   mcpCount,
 		})
 	}
 

--- a/internal/engine/render/summary_sync.go
+++ b/internal/engine/render/summary_sync.go
@@ -1,12 +1,182 @@
 package render
 
 import (
+	"fmt"
 	"io"
+	"sort"
+	"strings"
 	"time"
 )
 
-// RenderSyncBrief renders a brief sync summary with verb phrases and agent rollups.
-// Implementation is a stub — see Task: Add RenderSyncBrief.
+// RenderSyncBrief writes a compact one-shot sync summary to w. It shows
+// change lines derived from the plan (cloned repos, installed/updated skills,
+// added/updated MCP configs), followed by a per-agent rollup from the
+// post-sync status, and a final duration line.
+//
+// Example with changes:
+//
+//	Cloned src/example.
+//	Installed 2 new skills.
+//	Updated memory-mcp config.
+//	→ claude-code: 2 skills, 1 MCP server
+//	→ cursor: 2 skills, 1 MCP server
+//	✓ Synced in 1.2s.
+//
+// Example with no changes:
+//
+//	→ claude-code: 2 skills, 1 MCP server
+//	✓ In sync (500ms).
 func RenderSyncBrief(w io.Writer, plan *PlanReport, status *StatusReport, duration time.Duration) error {
-	panic("RenderSyncBrief not yet implemented")
+	if plan == nil {
+		plan = &PlanReport{}
+	}
+	if status == nil {
+		status = &StatusReport{}
+	}
+
+	// Change lines from plan
+	changes := collectChangeLines(plan)
+	for _, line := range changes {
+		fmt.Fprintln(w, line)
+	}
+
+	// Per-agent rollup from post-sync status
+	rollup := buildAgentRollup(status)
+	for _, line := range rollup {
+		fmt.Fprintln(w, line)
+	}
+
+	// Duration line
+	d := fmtDuration(duration)
+	if plan.HasChanges {
+		fmt.Fprintf(w, "✓ Synced in %s.\n", d)
+	} else {
+		fmt.Fprintf(w, "✓ In sync (%s).\n", d)
+	}
+
+	return nil
+}
+
+// collectChangeLines builds the list of human-readable change lines from the
+// plan. Each class of change is represented by one aggregated line.
+func collectChangeLines(plan *PlanReport) []string {
+	var lines []string
+
+	// Cloned repos (PlanClone actions)
+	for _, r := range plan.Repositories {
+		if r.Action == PlanClone {
+			lines = append(lines, fmt.Sprintf("Cloned %s.", r.Path))
+		}
+	}
+
+	// Updated repos (PlanUpdate actions)
+	for _, r := range plan.Repositories {
+		if r.Action == PlanUpdate {
+			lines = append(lines, fmt.Sprintf("Updated %s.", r.Path))
+		}
+	}
+
+	// Installed skills (aggregate count across all PlanCreate entries)
+	installCount := 0
+	for _, e := range plan.Skills {
+		if e.Action == PlanCreate {
+			installCount += len(e.Install)
+		}
+	}
+	if installCount > 0 {
+		lines = append(lines, fmt.Sprintf("Installed %s.", pluralise(installCount, "new skill", "new skills")))
+	}
+
+	// Updated skills (aggregate count across PlanUpdate entries)
+	updateSkillCount := 0
+	for _, e := range plan.Skills {
+		if e.Action == PlanUpdate {
+			updateSkillCount += len(e.Update)
+		}
+	}
+	if updateSkillCount > 0 {
+		lines = append(lines, fmt.Sprintf("Updated %s.", pluralise(updateSkillCount, "skill", "skills")))
+	}
+
+	// Added MCP configs (PlanCreate)
+	for _, m := range plan.MCPs {
+		if m.Action == PlanCreate {
+			lines = append(lines, fmt.Sprintf("Added %s config.", m.Name))
+		}
+	}
+
+	// Updated MCP configs (PlanUpdate)
+	for _, m := range plan.MCPs {
+		if m.Action == PlanUpdate {
+			lines = append(lines, fmt.Sprintf("Updated %s config.", m.Name))
+		}
+	}
+
+	return lines
+}
+
+// agentRollupEntry holds the per-agent counts for the rollup display.
+type agentRollupEntry struct {
+	name      string
+	skillCount int
+	mcpCount  int
+}
+
+// buildAgentRollup produces one "→ agent: N skills, M MCP servers" line per
+// installed agent, ordered by agent name. Unmanaged skills are excluded.
+func buildAgentRollup(status *StatusReport) []string {
+	// Count skills per agent from status.Skills (exclude unmanaged).
+	skillsByAgent := map[string]int{}
+	for _, e := range status.Skills {
+		if e.Status == StatusUnmanaged {
+			continue
+		}
+		skillsByAgent[e.Agent] += len(e.Installed)
+	}
+
+	// Count managed MCPs (exclude unmanaged).
+	mcpCount := 0
+	for _, m := range status.MCPs {
+		if m.Status != StatusUnmanaged {
+			mcpCount++
+		}
+	}
+
+	// Build rollup per installed agent.
+	var entries []agentRollupEntry
+	for _, a := range status.Agents {
+		if !a.Installed {
+			continue
+		}
+		entries = append(entries, agentRollupEntry{
+			name:      a.Name,
+			skillCount: skillsByAgent[a.Name],
+			mcpCount:  mcpCount,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].name < entries[j].name
+	})
+
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		parts := []string{
+			pluralise(e.skillCount, "skill", "skills"),
+		}
+		if e.mcpCount > 0 {
+			parts = append(parts, pluralise(e.mcpCount, "MCP server", "MCP servers"))
+		}
+		lines = append(lines, fmt.Sprintf("→ %s: %s", e.name, strings.Join(parts, ", ")))
+	}
+	return lines
+}
+
+// fmtDuration formats a duration for the brief sync output. Sub-second
+// durations use milliseconds; >= 1 second uses one decimal place in seconds.
+func fmtDuration(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
 }

--- a/internal/engine/render/summary_sync.go
+++ b/internal/engine/render/summary_sync.go
@@ -1,0 +1,12 @@
+package render
+
+import (
+	"io"
+	"time"
+)
+
+// RenderSyncBrief renders a brief sync summary with verb phrases and agent rollups.
+// Implementation is a stub — see Task: Add RenderSyncBrief.
+func RenderSyncBrief(w io.Writer, plan *PlanReport, status *StatusReport, duration time.Duration) error {
+	panic("RenderSyncBrief not yet implemented")
+}

--- a/internal/engine/render/summary_sync_test.go
+++ b/internal/engine/render/summary_sync_test.go
@@ -1,0 +1,149 @@
+package render
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderSyncBrief_WithChanges(t *testing.T) {
+	plan := &PlanReport{
+		HasChanges: true,
+		Repositories: []PlanRepoEntry{
+			{Path: "src/example", Action: PlanClone},
+		},
+		Skills: []PlanSkillEntry{
+			{
+				Source:  "github.com/org/skills",
+				Agent:   "claude-code",
+				Action:  PlanCreate,
+				Install: []string{"code-review", "refactor"},
+			},
+		},
+		MCPs: []PlanMCPEntry{
+			{Name: "memory-mcp", Target: "~/.config/claude/claude_desktop_config.json", Action: PlanUpdate},
+		},
+	}
+	status := &StatusReport{
+		Skills: []SkillEntry{
+			{
+				Source:    "github.com/org/skills",
+				Agent:     "claude-code",
+				Status:    StatusOK,
+				Installed: []string{"code-review", "refactor"},
+			},
+			{
+				Source:    "github.com/org/skills",
+				Agent:     "cursor",
+				Status:    StatusOK,
+				Installed: []string{"code-review", "refactor"},
+			},
+		},
+		MCPs: []MCPEntry{
+			{Name: "memory-mcp", Status: StatusOK, Target: "~/.config/claude/claude_desktop_config.json"},
+		},
+		Agents: []AgentEntry{
+			{Name: "claude-code", Installed: true},
+			{Name: "cursor", Installed: true},
+		},
+	}
+
+	var buf strings.Builder
+	err := RenderSyncBrief(&buf, plan, status, 1200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("RenderSyncBrief error: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "Cloned src/example") {
+		t.Errorf("expected 'Cloned src/example', got:\n%s", out)
+	}
+	if !strings.Contains(out, "Installed 2 new skill") {
+		t.Errorf("expected 'Installed 2 new skill', got:\n%s", out)
+	}
+	if !strings.Contains(out, "Updated memory-mcp config") {
+		t.Errorf("expected 'Updated memory-mcp config', got:\n%s", out)
+	}
+	if !strings.Contains(out, "→ claude-code:") {
+		t.Errorf("expected '→ claude-code:' rollup line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "→ cursor:") {
+		t.Errorf("expected '→ cursor:' rollup line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "✓ Synced in") {
+		t.Errorf("expected '✓ Synced in', got:\n%s", out)
+	}
+	// Should NOT say "In sync" when there are changes
+	if strings.Contains(out, "In sync") {
+		t.Errorf("unexpected 'In sync' when changes exist, got:\n%s", out)
+	}
+}
+
+func TestRenderSyncBrief_NoChanges(t *testing.T) {
+	plan := &PlanReport{
+		HasChanges: false,
+	}
+	status := &StatusReport{
+		Skills: []SkillEntry{
+			{
+				Source:    "github.com/org/skills",
+				Agent:     "claude-code",
+				Status:    StatusOK,
+				Installed: []string{"code-review", "refactor"},
+			},
+			{
+				Source:    "github.com/org/skills",
+				Agent:     "cursor",
+				Status:    StatusOK,
+				Installed: []string{"code-review", "refactor"},
+			},
+		},
+		MCPs: []MCPEntry{
+			{Name: "memory-mcp", Status: StatusOK, Target: "~/.config/claude/claude_desktop_config.json"},
+		},
+		Agents: []AgentEntry{
+			{Name: "claude-code", Installed: true},
+			{Name: "cursor", Installed: true},
+		},
+	}
+
+	var buf strings.Builder
+	err := RenderSyncBrief(&buf, plan, status, 500*time.Millisecond)
+	if err != nil {
+		t.Fatalf("RenderSyncBrief error: %v", err)
+	}
+	out := buf.String()
+
+	// No change lines expected
+	if strings.Contains(out, "Cloned") {
+		t.Errorf("unexpected 'Cloned' in no-change output, got:\n%s", out)
+	}
+	if strings.Contains(out, "Installed") {
+		t.Errorf("unexpected 'Installed' in no-change output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "→ claude-code:") {
+		t.Errorf("expected '→ claude-code:' rollup line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "→ cursor:") {
+		t.Errorf("expected '→ cursor:' rollup line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "✓ In sync") {
+		t.Errorf("expected '✓ In sync', got:\n%s", out)
+	}
+	// Should NOT say "Synced in" when no changes
+	if strings.Contains(out, "Synced in") {
+		t.Errorf("unexpected 'Synced in' when no changes, got:\n%s", out)
+	}
+}
+
+func TestRenderSyncBrief_NilInputs(t *testing.T) {
+	var buf strings.Builder
+	err := RenderSyncBrief(&buf, nil, nil, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("RenderSyncBrief(nil, nil) error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "✓ In sync") {
+		t.Errorf("expected '✓ In sync' for nil inputs, got:\n%s", out)
+	}
+}

--- a/internal/engine/render/summary_test.go
+++ b/internal/engine/render/summary_test.go
@@ -1,0 +1,172 @@
+package render
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSummaryRenderer_AllHealthy(t *testing.T) {
+	r := &StatusReport{
+		Repositories: []RepoEntry{
+			{Path: "src/a", Status: StatusOK},
+			{Path: "src/b", Status: StatusOK},
+			{Path: "src/c", Status: StatusDirty, Dirty: true},
+		},
+		Skills: []SkillEntry{
+			{
+				Source:    "github.com/org/skills",
+				Agent:     "claude-code",
+				Status:    StatusOK,
+				Installed: []string{"skill-a", "skill-b", "skill-c"},
+				Missing:   []string{},
+			},
+			{
+				Source:    "github.com/org/skills",
+				Agent:     "claude-desktop",
+				Status:    StatusOK,
+				Installed: []string{"skill-a", "skill-b", "skill-d"},
+				Missing:   []string{},
+			},
+		},
+		MCPs: []MCPEntry{
+			{Name: "mcp-a", Status: StatusOK},
+			{Name: "mcp-b", Status: StatusPresent},
+			{Name: "mcp-c", Status: StatusDirty},
+			{Name: "mcp-d", Status: StatusOK},
+		},
+		Agents: []AgentEntry{
+			{Name: "claude-code", Installed: true},
+			{Name: "claude-desktop", Installed: true},
+			{Name: "codex", Installed: true},
+		},
+	}
+
+	var buf strings.Builder
+	sr := &summaryRenderer{}
+	if err := sr.Render(&buf, r); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	out := buf.String()
+
+	// 3 repos, 1 dirty
+	if !strings.Contains(out, "3/3 repos cloned") {
+		t.Errorf("expected '3/3 repos cloned', got:\n%s", out)
+	}
+	if !strings.Contains(out, "(1 dirty)") {
+		t.Errorf("expected '(1 dirty)', got:\n%s", out)
+	}
+	// 4 unique skills across entries (skill-a, skill-b, skill-c, skill-d)
+	if !strings.Contains(out, "4/4 skills installed") {
+		t.Errorf("expected '4/4 skills installed', got:\n%s", out)
+	}
+	// 4 MCPs
+	if !strings.Contains(out, "4/4 MCP servers registered") {
+		t.Errorf("expected '4/4 MCP servers registered', got:\n%s", out)
+	}
+	// 3 agents
+	if !strings.Contains(out, "3 agents configured") {
+		t.Errorf("expected '3 agents configured', got:\n%s", out)
+	}
+	// 0 drift (dirty repo counts as cloned so no drift; dirty MCP still registered)
+	if !strings.Contains(out, "0 drift") {
+		t.Errorf("expected '0 drift', got:\n%s", out)
+	}
+	// All sections use ✓
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "repos") || strings.Contains(line, "skills") ||
+			strings.Contains(line, "MCP") || strings.Contains(line, "agents") {
+			if !strings.HasPrefix(line, "✓") {
+				t.Errorf("expected ✓ prefix on line %q", line)
+			}
+		}
+	}
+}
+
+func TestSummaryRenderer_WithErrors(t *testing.T) {
+	r := &StatusReport{
+		Repositories: []RepoEntry{
+			{Path: "src/a", Status: StatusOK},
+			{Path: "src/b", Status: StatusNotCloned},
+		},
+		Skills: []SkillEntry{
+			{
+				Source:    "github.com/org/skills",
+				Agent:     "claude-code",
+				Status:    StatusPartial,
+				Installed: []string{"skill-a", "skill-b"},
+				Missing:   []string{"skill-c", "skill-d"},
+			},
+			{
+				// Unmanaged entry should be ignored
+				Source: "other",
+				Agent:  "claude-code",
+				Status: StatusUnmanaged,
+			},
+		},
+		MCPs: []MCPEntry{
+			{Name: "mcp-a", Status: StatusOK},
+			{Name: "mcp-b", Status: StatusAbsent},
+			{Name: "mcp-c", Status: StatusUnmanaged},
+		},
+		Agents: []AgentEntry{
+			{Name: "claude-code", Installed: true},
+			{Name: "claude-desktop", Installed: false},
+		},
+	}
+
+	var buf strings.Builder
+	sr := &summaryRenderer{}
+	if err := sr.Render(&buf, r); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	out := buf.String()
+
+	// 1 of 2 repos cloned
+	if !strings.Contains(out, "1/2 repos cloned") {
+		t.Errorf("expected '1/2 repos cloned', got:\n%s", out)
+	}
+	// 2 installed, 4 total unique skills
+	if !strings.Contains(out, "2/4 skills installed") {
+		t.Errorf("expected '2/4 skills installed', got:\n%s", out)
+	}
+	// 1 of 2 non-unmanaged MCPs registered
+	if !strings.Contains(out, "1/2 MCP servers registered") {
+		t.Errorf("expected '1/2 MCP servers registered', got:\n%s", out)
+	}
+	// 1 installed agent
+	if !strings.Contains(out, "1 agents configured") {
+		t.Errorf("expected '1 agents configured', got:\n%s", out)
+	}
+	// Drift > 0
+	if strings.Contains(out, "0 drift") {
+		t.Errorf("expected non-zero drift, got:\n%s", out)
+	}
+	// Sections with issues use !
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "skills") {
+			if !strings.HasPrefix(line, "!") {
+				t.Errorf("expected ! prefix on skills line %q", line)
+			}
+		}
+		if strings.Contains(line, "MCP") {
+			if !strings.HasPrefix(line, "!") {
+				t.Errorf("expected ! prefix on MCP line %q", line)
+			}
+		}
+	}
+}
+
+func TestSummaryRenderer_Empty(t *testing.T) {
+	r := &StatusReport{}
+
+	var buf strings.Builder
+	sr := &summaryRenderer{}
+	if err := sr.Render(&buf, r); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	out := strings.TrimSpace(buf.String())
+	if out != "no managed resources" {
+		t.Errorf("expected 'no managed resources', got %q", out)
+	}
+}

--- a/internal/engine/render/summary_test.go
+++ b/internal/engine/render/summary_test.go
@@ -157,6 +157,26 @@ func TestSummaryRenderer_WithErrors(t *testing.T) {
 	}
 }
 
+func TestNewRenderer_TextReturnsSummary(t *testing.T) {
+	r, err := NewRenderer(FormatText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := r.(*summaryRenderer); !ok {
+		t.Errorf("got %T", r)
+	}
+}
+
+func TestNewRenderer_VerboseReturnsDetailed(t *testing.T) {
+	r, err := NewRenderer(FormatVerbose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := r.(*textRenderer); !ok {
+		t.Errorf("got %T", r)
+	}
+}
+
 func TestSummaryRenderer_Empty(t *testing.T) {
 	r := &StatusReport{}
 

--- a/internal/engine/render/tip.go
+++ b/internal/engine/render/tip.go
@@ -1,0 +1,16 @@
+package render
+
+import (
+	"fmt"
+	"io"
+)
+
+// WriteTip appends a hint about output format options. Call with isTTY=true
+// to actually print; piped output gets no tip.
+func WriteTip(w io.Writer, isTTY bool) {
+	if !isTTY {
+		return
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Tip: use -o table for details, -o json for machine-readable output.")
+}

--- a/internal/engine/render/tip_test.go
+++ b/internal/engine/render/tip_test.go
@@ -1,0 +1,27 @@
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestWriteTip_WhenEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	WriteTip(&buf, true)
+	out := buf.String()
+	if !strings.Contains(out, "-o table") {
+		t.Errorf("missing table hint, got:\n%s", out)
+	}
+	if !strings.Contains(out, "-o json") {
+		t.Errorf("missing json hint, got:\n%s", out)
+	}
+}
+
+func TestWriteTip_WhenDisabled(t *testing.T) {
+	var buf bytes.Buffer
+	WriteTip(&buf, false)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output when disabled, got: %q", buf.String())
+	}
+}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -161,7 +161,6 @@ func (m *Manager) Sync(ctx context.Context) error {
 	return nil
 }
 
-
 func (m *Manager) syncOne(ctx context.Context, mc config.ConfigMcp) error {
 	slog.DebugContext(ctx, "syncing mcp entry", "name", mc.Name, "target", mc.Target)
 	var entry serverEntry


### PR DESCRIPTION
## Summary

Replaces the line-per-resource default `--output text` format with a compact, summary-first layout showing counts and status at a glance. The previous detailed text output is preserved and accessible via `--verbose`.

Closes #105

## What changed

**New summary renderers** (`internal/engine/render/summary*.go`):
- `summaryRenderer` — status: `✓ 11/11 skills installed`, drift count
- `summaryPlanRenderer` — dry-run: changed items listed, unchanged collapsed to counts
- `RenderSyncBrief` — sync: per-agent rollup with "Synced in Xs"
- `summaryAuditRenderer` — audit: "Found N skills across M agents"
- `WriteTip` — TTY-only footer hinting at `-o table` / `-o json`

**Command layer updates** (`cmd/`):
- `doctor.go` — new `renderDoctorSummary` (one line per section)
- `init.go` — prose output replacing pterm boxes when not verbose
- `agents.go` — `Installed: / Available:` one-liner
- `status.go`, `audit.go` — WriteTip footer after summary output
- `sync.go` — `RenderSyncBrief` vs `RenderSyncSummary` based on verbose flag

**Plumbing:**
- `FormatVerbose` output format added; factory functions return summary renderers for `FormatText`
- `effectiveOutputFormat()` helper maps `--verbose` + text → verbose format
- `Options.Verbose` threaded through engine

## Example output

```
$ gaal status
✓ 1/1 repos cloned
✓ 11/11 skills installed
! 2/4 MCP servers registered
✓ 7 agents configured
2 drift

Tip: use -o table for details, -o json for machine-readable output.
```

```
$ gaal audit
Found 126 skills across 2 agents.
Found 0 MCP servers.
2 agents scanned: claude-code, codex
```

```
$ gaal doctor --offline
✓ Config valid
✓ Telemetry configured
✓ 3 sources reachable
! MCP targets valid
✓ 7 agents installed, 0 misconfigured

Checks passed with warnings. Use --verbose for details.
```

## Test plan

- [ ] 859 tests pass (`go test ./...`)
- [ ] `gaal status` shows summary; `gaal status --verbose` shows detailed
- [ ] `gaal sync --dry-run` shows compact plan; `--verbose` shows nested plan
- [ ] `gaal doctor` shows one-line-per-section; `--verbose` shows finding-per-line
- [ ] `gaal audit` shows aggregated counts; `--verbose` shows discovered tree
- [ ] `gaal agents` shows Installed/Available; `--verbose` shows columnar text
- [ ] `gaal init --import-all --scope project` shows prose summary
- [ ] Tip footer appears in TTY, suppressed when piped