### PR TITLE
feat(test): end-to-end test suite with Docker isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,29 @@ jobs:
           retention-days: 30
 
   # ──────────────────────────────────────────────────────────────────────────
+  # E2E: end-to-end test suite — runs gaal inside a Docker container,
+  # asserts filesystem state after sync/prune scenarios. Layer 1 only —
+  # the heavier CLI-verification layer runs separately on demand.
+  # ──────────────────────────────────────────────────────────────────────────
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    needs: [test, changes]
+    if: needs.changes.outputs.code_changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # ubuntu-latest ships with the Docker daemon and BuildKit enabled by
+      # default — no extra setup step needed before `make test-e2e`.
+      - name: Run e2e suite
+        run: make test-e2e
+
+  # ──────────────────────────────────────────────────────────────────────────
   # Coverage: generate HTML report and post summary to the job summary page
   # ──────────────────────────────────────────────────────────────────────────
   coverage:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOOS      ?= $(shell go env GOOS)
 GOARCH    ?= $(shell go env GOARCH)
 BIN_CROSS ?= $(DIST_DIR)/gaal-$(GOOS)-$(GOARCH)
 
-.PHONY: all build build-cross run run-service test test-race test-ci coverage coverage-ci lint hooks clean tidy sandbox sandbox-service sandbox-status
+.PHONY: all build build-cross run run-service test test-race test-ci test-e2e test-e2e-cli coverage coverage-ci lint hooks clean tidy sandbox sandbox-service sandbox-status
 
 all: build
 
@@ -68,6 +68,24 @@ test-race:
 test-ci:
 	@mkdir -p report
 	$(GOBIN)/gotestsum --junitfile report/tests.xml --format github-actions -- -race -count=1 -timeout 5m ./...
+
+## test-e2e: end-to-end Docker suite (Layer 1 — filesystem assertions only)
+##   Builds gaal for linux/amd64, builds the test image, runs the suite.
+##   Requires Docker on the host. Set GAAL_E2E_REBUILD=1 to force a rebuild.
+test-e2e:
+	@mkdir -p test/e2e/fixtures
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+		go build -trimpath -o test/e2e/fixtures/gaal .
+	go test -tags e2e -count=1 -timeout 15m ./test/e2e/...
+
+## test-e2e-cli: full e2e suite including the heavy CLI verification layer
+##   Installs claude-code + codex into the image and exercises them
+##   against the configs gaal wrote. Slower; meant for nightly / release CI.
+test-e2e-cli:
+	@mkdir -p test/e2e/fixtures
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+		go build -trimpath -o test/e2e/fixtures/gaal .
+	GAAL_E2E_CLI=1 go test -tags e2e -count=1 -timeout 30m ./test/e2e/...
 
 ## coverage: run tests with coverage — generates all reports in report/
 ##   report/coverage.html          — standard go tool cover (default)

--- a/test/e2e/assertions_test.go
+++ b/test/e2e/assertions_test.go
@@ -1,0 +1,333 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// Scope describes whether a resource is expected at user-global or
+// workspace-local scope. Mirrors the engine's notion but kept private so
+// the tests are not coupled to the engine package.
+type Scope int
+
+const (
+	ScopeProject Scope = iota
+	ScopeGlobal
+)
+
+func (s Scope) String() string {
+	if s == ScopeGlobal {
+		return "global"
+	}
+	return "project"
+}
+
+// agentSkillDir returns the absolute path to the directory that gaal
+// installs <agent>'s skills into for a given (env, scope, agent).
+//
+// The mapping mirrors internal/core/agent/agents.yaml. The e2e suite
+// hard-codes only the agents it actually exercises (claude-code, codex,
+// generic) — adding a new one is one line here.
+func agentSkillDir(env *testEnv, agent string, scope Scope) (string, bool) {
+	switch agent {
+	case "claude-code":
+		if scope == ScopeGlobal {
+			return path.Join(env.home, ".claude", "skills"), true
+		}
+		return path.Join(env.workdir, ".claude", "skills"), true
+	case "codex":
+		if scope == ScopeGlobal {
+			return path.Join(env.home, ".codex", "skills"), true
+		}
+		// codex has no project skills dir per agents.yaml — falls through to
+		// the generic project convention.
+		return path.Join(env.workdir, ".agents", "skills"), true
+	case "generic":
+		if scope == ScopeGlobal {
+			return path.Join(env.home, ".agents", "skills"), true
+		}
+		return path.Join(env.workdir, ".agents", "skills"), true
+	}
+	return "", false
+}
+
+// agentMCPConfigPath returns the absolute path to the MCP config file
+// gaal writes for a given (env, scope, agent). Returns ok=false when the
+// agent does not have a config file at the requested scope.
+func agentMCPConfigPath(env *testEnv, agent string, scope Scope) (string, bool) {
+	switch agent {
+	case "claude-code":
+		if scope == ScopeGlobal {
+			return path.Join(env.home, ".claude.json"), true
+		}
+		return path.Join(env.workdir, ".mcp.json"), true
+	case "codex":
+		if scope == ScopeGlobal {
+			return path.Join(env.home, ".codex", "config.toml"), true
+		}
+		// codex has no project-scope MCP config — mirror the registry.
+		return "", false
+	}
+	return "", false
+}
+
+// AssertSkillInstalled fails the test when SKILL.md for skillName is not
+// found under <agent>'s skill directory at the given scope.
+func AssertSkillInstalled(t *testing.T, env *testEnv, agent string, scope Scope, skillName string) {
+	t.Helper()
+	dir, ok := agentSkillDir(env, agent, scope)
+	if !ok {
+		t.Fatalf("no skill directory mapping for agent %q (scope=%s)", agent, scope)
+	}
+	target := path.Join(dir, skillName, "SKILL.md")
+	if !env.c.FileExists(t, target) {
+		listing := env.c.ListDir(t, dir)
+		t.Fatalf("skill %q missing for agent=%s scope=%s\n  expected: %s\n  contents of %s: %v",
+			skillName, agent, scope, target, dir, listing)
+	}
+}
+
+// AssertSkillAbsent is the inverse of AssertSkillInstalled.
+func AssertSkillAbsent(t *testing.T, env *testEnv, agent string, scope Scope, skillName string) {
+	t.Helper()
+	dir, ok := agentSkillDir(env, agent, scope)
+	if !ok {
+		t.Fatalf("no skill directory mapping for agent %q (scope=%s)", agent, scope)
+	}
+	target := path.Join(dir, skillName, "SKILL.md")
+	if env.c.FileExists(t, target) {
+		t.Fatalf("skill %q unexpectedly present for agent=%s scope=%s at %s",
+			skillName, agent, scope, target)
+	}
+}
+
+// AssertFileExists fails when p does not exist in the container.
+func AssertFileExists(t *testing.T, env *testEnv, p string) {
+	t.Helper()
+	if !env.c.FileExists(t, p) {
+		t.Fatalf("expected file to exist: %s", p)
+	}
+}
+
+// AssertFileAbsent fails when p exists in the container.
+func AssertFileAbsent(t *testing.T, env *testEnv, p string) {
+	t.Helper()
+	if env.c.FileExists(t, p) {
+		t.Fatalf("expected file to be absent: %s", p)
+	}
+}
+
+// MCPExpect describes an MCP server entry that gaal is expected to have
+// upserted into an agent's config file. Empty fields are not asserted on.
+type MCPExpect struct {
+	Command string
+	Args    []string
+	Env     map[string]string
+}
+
+// AssertMCPEntry parses the agent's MCP config file (JSON or TOML based
+// on extension) and verifies that an entry named serverName matches expect.
+func AssertMCPEntry(t *testing.T, env *testEnv, agent string, scope Scope, serverName string, expect MCPExpect) {
+	t.Helper()
+	cfgPath, ok := agentMCPConfigPath(env, agent, scope)
+	if !ok {
+		t.Fatalf("agent %q has no MCP config file at scope=%s", agent, scope)
+	}
+	if !env.c.FileExists(t, cfgPath) {
+		t.Fatalf("expected MCP config %s to exist after sync", cfgPath)
+	}
+	body := env.c.ReadFile(t, cfgPath)
+
+	servers := decodeServers(t, cfgPath, body)
+	got, present := servers[serverName]
+	if !present {
+		names := make([]string, 0, len(servers))
+		for n := range servers {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		t.Fatalf("MCP server %q not found in %s\n  configured: %v\n  body: %s",
+			serverName, cfgPath, names, body)
+	}
+
+	if expect.Command != "" && got.Command != expect.Command {
+		t.Fatalf("MCP %q: command mismatch\n  want: %s\n  got:  %s",
+			serverName, expect.Command, got.Command)
+	}
+	if len(expect.Args) > 0 {
+		if !slicesEqual(got.Args, expect.Args) {
+			t.Fatalf("MCP %q: args mismatch\n  want: %v\n  got:  %v",
+				serverName, expect.Args, got.Args)
+		}
+	}
+	for k, v := range expect.Env {
+		if got.Env[k] != v {
+			t.Fatalf("MCP %q: env[%s] mismatch\n  want: %s\n  got:  %s",
+				serverName, k, v, got.Env[k])
+		}
+	}
+}
+
+// AssertMCPAbsent verifies that no entry named serverName appears in the
+// agent's MCP config file. A missing config file counts as absent.
+func AssertMCPAbsent(t *testing.T, env *testEnv, agent string, scope Scope, serverName string) {
+	t.Helper()
+	cfgPath, ok := agentMCPConfigPath(env, agent, scope)
+	if !ok {
+		t.Fatalf("agent %q has no MCP config file at scope=%s", agent, scope)
+	}
+	if !env.c.FileExists(t, cfgPath) {
+		return
+	}
+	body := env.c.ReadFile(t, cfgPath)
+	servers := decodeServers(t, cfgPath, body)
+	if _, present := servers[serverName]; present {
+		t.Fatalf("MCP server %q unexpectedly present in %s\n  body: %s",
+			serverName, cfgPath, body)
+	}
+}
+
+// AssertValidJSON parses p as JSON and fails the test on any decode error.
+// Useful as a smoke check after mutation tests so a sync-then-prune round
+// does not leave the agent config in a corrupt state.
+func AssertValidJSON(t *testing.T, env *testEnv, p string) {
+	t.Helper()
+	body := env.c.ReadFile(t, p)
+	var any any
+	if err := json.Unmarshal([]byte(body), &any); err != nil {
+		t.Fatalf("expected %s to be valid JSON: %v\n  body: %s", p, err, body)
+	}
+}
+
+// AssertValidTOML parses p as TOML and fails the test on any decode error.
+func AssertValidTOML(t *testing.T, env *testEnv, p string) {
+	t.Helper()
+	body := env.c.ReadFile(t, p)
+	var any any
+	if err := toml.Unmarshal([]byte(body), &any); err != nil {
+		t.Fatalf("expected %s to be valid TOML: %v\n  body: %s", p, err, body)
+	}
+}
+
+// AssertNoStaleSymlinks walks dir and fails the test on any dangling
+// symlink. Used by prune scenarios to make sure the install copies are
+// not symlinks pointing into the old skill cache. Uses the POSIX-portable
+// `-type l ! -exec test -e` chain so the assertion works against busybox
+// find (the Alpine base shell), which does not implement GNU find's
+// -xtype extension.
+func AssertNoStaleSymlinks(t *testing.T, env *testEnv, dir string) {
+	t.Helper()
+	if !env.c.FileExists(t, dir) {
+		return
+	}
+	res := env.c.MustExec(t, nil, "",
+		"sh", "-c",
+		fmt.Sprintf(`find %s -type l '!' -exec test -e {} ';' -print 2>/dev/null`, shellQuote(dir)),
+	)
+	if strings.TrimSpace(res.Stdout) != "" {
+		t.Fatalf("stale symlinks under %s:\n%s", dir, res.Stdout)
+	}
+}
+
+// mcpServer mirrors the on-disk shape stored by gaal in both JSON and
+// TOML config files. Kept structurally identical to internal/mcp.serverEntry.
+type mcpServer struct {
+	Command string            `json:"command,omitempty" toml:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"    toml:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"     toml:"env,omitempty"`
+}
+
+func decodeServers(t *testing.T, cfgPath, body string) map[string]mcpServer {
+	t.Helper()
+	if strings.HasSuffix(cfgPath, ".toml") {
+		return decodeTOMLServers(t, cfgPath, body)
+	}
+	return decodeJSONServers(t, cfgPath, body)
+}
+
+// decodeJSONServers mirrors internal/mcp/codec.go: the document is a
+// JSON object with a top-level "mcpServers" map.
+func decodeJSONServers(t *testing.T, cfgPath, body string) map[string]mcpServer {
+	t.Helper()
+	if strings.TrimSpace(body) == "" {
+		return map[string]mcpServer{}
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("parsing %s as JSON: %v\n  body: %s", cfgPath, err, body)
+	}
+	srvRaw, ok := raw["mcpServers"]
+	if !ok {
+		return map[string]mcpServer{}
+	}
+	out := map[string]mcpServer{}
+	if err := json.Unmarshal(srvRaw, &out); err != nil {
+		t.Fatalf("parsing mcpServers in %s: %v", cfgPath, err)
+	}
+	return out
+}
+
+// decodeTOMLServers mirrors internal/mcp/codec.go: the document carries a
+// top-level [mcp_servers] table.
+func decodeTOMLServers(t *testing.T, cfgPath, body string) map[string]mcpServer {
+	t.Helper()
+	if strings.TrimSpace(body) == "" {
+		return map[string]mcpServer{}
+	}
+	doc := map[string]any{}
+	if err := toml.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("parsing %s as TOML: %v\n  body: %s", cfgPath, err, body)
+	}
+	tab, ok := doc["mcp_servers"].(map[string]any)
+	if !ok {
+		return map[string]mcpServer{}
+	}
+	out := make(map[string]mcpServer, len(tab))
+	for name, v := range tab {
+		entry, ok := v.(map[string]any)
+		if !ok {
+			t.Fatalf("mcp_servers.%s in %s is not a table", name, cfgPath)
+		}
+		var s mcpServer
+		if cmd, ok := entry["command"].(string); ok {
+			s.Command = cmd
+		}
+		if args, ok := entry["args"].([]any); ok {
+			for _, a := range args {
+				if str, ok := a.(string); ok {
+					s.Args = append(s.Args, str)
+				}
+			}
+		}
+		if env, ok := entry["env"].(map[string]any); ok {
+			s.Env = map[string]string{}
+			for k, v := range env {
+				if str, ok := v.(string); ok {
+					s.Env[k] = str
+				}
+			}
+		}
+		out[name] = s
+	}
+	return out
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/test/e2e/cli_verify_test.go
+++ b/test/e2e/cli_verify_test.go
@@ -1,0 +1,101 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path"
+	"strings"
+	"testing"
+)
+
+// requireCLILayer skips the test when the heavy CLI verification layer is
+// not enabled. The image build skips installing the agent CLIs unless
+// GAAL_E2E_CLI=1, so trying to invoke `claude` or `codex` would only fail
+// in an opaque "not found" — better to skip cleanly.
+func requireCLILayer(t *testing.T) {
+	t.Helper()
+	if !envCLI {
+		t.Skip("CLI verification layer disabled (set GAAL_E2E_CLI=1 to enable)")
+	}
+}
+
+// TestCLI_ClaudeMCPListShowsSyncedServer is the classic "round-trip" test:
+// gaal writes the entry, the real claude CLI reads it back, the entry
+// must appear in `claude mcp list` output.
+func TestCLI_ClaudeMCPListShowsSyncedServer(t *testing.T) {
+	requireCLILayer(t)
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddMCP("filesystem", []string{"claude-code"}, true,
+			"uvx", []string{"mcp-server-filesystem", "/data"}, nil).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	res := suite.MustExec(t, env.gaalEnv(), env.workdir, "claude", "mcp", "list")
+	if !strings.Contains(res.Stdout+res.Stderr, "filesystem") {
+		t.Fatalf("expected `claude mcp list` to mention the synced server\n%s",
+			res.Combined())
+	}
+}
+
+// TestCLI_CodexReadsTOMLWritten verifies the TOML codex writes is
+// re-parseable by the codex CLI itself. We don't assume which codex
+// subcommand surfaces MCP servers — version drift makes that brittle —
+// so we use `codex --help` as a smoke check that the binary still runs
+// against the gaal-written config and exits 0. A broken TOML would make
+// codex bail out on startup.
+func TestCLI_CodexReadsTOMLWritten(t *testing.T) {
+	requireCLILayer(t)
+	env := newTestEnv(t)
+	env.c.MustExec(t, nil, "", "mkdir", "-p", path.Join(env.home, ".codex"))
+
+	cfg := newConfig().
+		AddMCP("git", []string{"codex"}, true,
+			"uvx", []string{"mcp-server-git"}, nil).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	res := suite.Exec(t, env.gaalEnv(), env.workdir, "codex", "--help")
+	if res.ExitCode != 0 {
+		t.Fatalf("codex --help failed after gaal-written config: exit=%d\n%s",
+			res.ExitCode, res.Combined())
+	}
+}
+
+// TestCLI_PruneRemovesEntryFromCLIView is the destructive twin of
+// TestCLI_ClaudeMCPListShowsSyncedServer: after a sync --prune drops the
+// entry, `claude mcp list` must no longer show it.
+func TestCLI_PruneRemovesEntryFromCLIView(t *testing.T) {
+	requireCLILayer(t)
+	env := newTestEnv(t)
+
+	cfg1 := newConfig().
+		AddMCP("filesystem", []string{"claude-code"}, true,
+			"uvx", []string{"mcp-server-filesystem", "/data"}, nil).
+		AddMCP("git", []string{"claude-code"}, true,
+			"uvx", []string{"mcp-server-git"}, nil).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+
+	cfg2 := newConfig().
+		AddMCP("filesystem", []string{"claude-code"}, true,
+			"uvx", []string{"mcp-server-filesystem", "/data"}, nil).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync", "--prune")
+
+	res := suite.MustExec(t, env.gaalEnv(), env.workdir, "claude", "mcp", "list")
+	combined := res.Stdout + res.Stderr
+	if !strings.Contains(combined, "filesystem") {
+		t.Fatalf("expected `claude mcp list` to still mention filesystem\n%s",
+			res.Combined())
+	}
+	if strings.Contains(combined, "git") {
+		t.Fatalf("expected `claude mcp list` to no longer mention git after prune\n%s",
+			res.Combined())
+	}
+}

--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -1,0 +1,133 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+)
+
+// configBuilder assembles small gaal.yaml documents in a readable, test-
+// local way. The fields cover the subset of the schema the e2e suite
+// exercises — repositories, skills, mcps. Callers add entries via the
+// chainable Add* methods and finalise with String().
+type configBuilder struct {
+	skills []skillBlock
+	mcps   []mcpBlock
+}
+
+type skillBlock struct {
+	source  string
+	agents  []string
+	global  bool
+	selects []string
+}
+
+type mcpBlock struct {
+	name    string
+	agents  []string
+	global  bool
+	command string
+	args    []string
+	env     map[string]string
+}
+
+func newConfig() *configBuilder { return &configBuilder{} }
+
+func (b *configBuilder) AddSkill(source string, agents []string, global bool, selects ...string) *configBuilder {
+	b.skills = append(b.skills, skillBlock{source: source, agents: agents, global: global, selects: selects})
+	return b
+}
+
+func (b *configBuilder) AddMCP(name string, agents []string, global bool, command string, args []string, env map[string]string) *configBuilder {
+	b.mcps = append(b.mcps, mcpBlock{name: name, agents: agents, global: global, command: command, args: args, env: env})
+	return b
+}
+
+// String renders the builder as a YAML document that gaal can consume.
+// Indentation is fixed (two-space) and ordering is deterministic so test
+// failure messages diff cleanly against expected golden output.
+func (b *configBuilder) String() string {
+	var sb strings.Builder
+	sb.WriteString("schema: 1\n")
+	if len(b.skills) > 0 {
+		sb.WriteString("skills:\n")
+		for _, s := range b.skills {
+			fmt.Fprintf(&sb, "  - source: %s\n", s.source)
+			fmt.Fprintf(&sb, "    agents: [%s]\n", quoteAndJoin(s.agents))
+			fmt.Fprintf(&sb, "    global: %t\n", s.global)
+			if len(s.selects) > 0 {
+				sb.WriteString("    select:\n")
+				for _, sel := range s.selects {
+					fmt.Fprintf(&sb, "      - %s\n", sel)
+				}
+			}
+		}
+	}
+	if len(b.mcps) > 0 {
+		sb.WriteString("mcps:\n")
+		for _, m := range b.mcps {
+			fmt.Fprintf(&sb, "  - name: %s\n", m.name)
+			fmt.Fprintf(&sb, "    agents: [%s]\n", quoteAndJoin(m.agents))
+			fmt.Fprintf(&sb, "    global: %t\n", m.global)
+			sb.WriteString("    inline:\n")
+			fmt.Fprintf(&sb, "      command: %s\n", m.command)
+			if len(m.args) > 0 {
+				sb.WriteString("      args:\n")
+				for _, a := range m.args {
+					fmt.Fprintf(&sb, "        - %s\n", quoteIfNeeded(a))
+				}
+			}
+			if len(m.env) > 0 {
+				sb.WriteString("      env:\n")
+				keys := sortedKeys(m.env)
+				for _, k := range keys {
+					fmt.Fprintf(&sb, "        %s: %s\n", k, quoteIfNeeded(m.env[k]))
+				}
+			}
+		}
+	}
+	return sb.String()
+}
+
+func quoteAndJoin(items []string) string {
+	out := make([]string, len(items))
+	for i, s := range items {
+		out[i] = `"` + s + `"`
+	}
+	return strings.Join(out, ", ")
+}
+
+// quoteIfNeeded YAML-quotes a value when it contains characters that would
+// trip the bare-scalar parser. Conservative: anything other than [a-zA-Z0-9._/-]
+// gets wrapped in double quotes with embedded quotes escaped.
+func quoteIfNeeded(s string) string {
+	if s == "" {
+		return `""`
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '.' || r == '/' || r == '-':
+		default:
+			return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+		}
+	}
+	return s
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// Tiny insertion sort — keeps configs stable for diff-friendly failures.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}

--- a/test/e2e/container_test.go
+++ b/test/e2e/container_test.go
@@ -1,0 +1,328 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"path"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestContainer wraps the long-lived Docker container shared across the
+// suite. All exec, file-IO and lifecycle operations route through it so
+// tests stay declarative.
+type TestContainer struct {
+	id      string
+	stopped atomic.Bool
+}
+
+// startContainer launches the suite container detached, waits briefly for
+// it to be running, and returns a handle. The container is started with
+// `--rm` so a dropped suite cleans up automatically.
+func startContainer() (*TestContainer, error) {
+	args := []string{
+		"run", "-d", "--rm",
+		// Bind-mount the fixtures dir read-only so tests can reference
+		// /fixtures/skills/<name> without docker cp gymnastics.
+		"--mount", fmt.Sprintf("type=bind,source=%s,target=%s,readonly", fixturesPath(), fixturesDir),
+		// Telemetry off so the test suite never opens an outbound connection.
+		"-e", "GAAL_TELEMETRY=0",
+		"-e", "DO_NOT_TRACK=1",
+		// Quiet pterm/term-detection.
+		"-e", "TERM=dumb",
+		imageName,
+	}
+	cmd := exec.Command("docker", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("docker run: %w\n%s", err, out)
+	}
+	id := strings.TrimSpace(string(out))
+	if len(id) < 12 {
+		return nil, fmt.Errorf("docker run: unexpected output %q", string(out))
+	}
+	c := &TestContainer{id: id[:12]}
+
+	// `docker run -d` returns once the container is created, not once it
+	// is ready to accept exec — short retry loop avoids a startup race.
+	for i := 0; i < 20; i++ {
+		probe := exec.Command("docker", "exec", c.id, "true")
+		if err := probe.Run(); err == nil {
+			return c, nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("container %s failed to become ready", c.id)
+}
+
+// Stop kills the container. Safe to call more than once.
+func (c *TestContainer) Stop() error {
+	if c.stopped.Swap(true) {
+		return nil
+	}
+	cmd := exec.Command("docker", "rm", "-f", c.id)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker rm: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// ExecResult holds the outcome of one `docker exec` invocation.
+type ExecResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// Combined returns Stdout + a separator + Stderr — handy for error messages.
+func (r ExecResult) Combined() string {
+	if r.Stderr == "" {
+		return r.Stdout
+	}
+	return r.Stdout + "\n--- stderr ---\n" + r.Stderr
+}
+
+// Exec runs argv inside the container with the given env and working
+// directory. Tests should not fail on stderr alone — many gaal commands
+// log to stderr by design — but the returned ExecResult exposes the field
+// for explicit assertions.
+func (c *TestContainer) Exec(t *testing.T, env Env, workdir string, argv ...string) ExecResult {
+	t.Helper()
+	full := []string{"exec"}
+	for _, e := range env.toSlice() {
+		full = append(full, "-e", e)
+	}
+	if workdir != "" {
+		full = append(full, "-w", workdir)
+	}
+	full = append(full, c.id)
+	full = append(full, argv...)
+
+	cmd := exec.Command("docker", full...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	res := ExecResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			res.ExitCode = ee.ExitCode()
+		} else {
+			res.ExitCode = -1
+			res.Stderr += "\n" + err.Error()
+		}
+	}
+	return res
+}
+
+// MustExec is Exec + a fatal assertion that the exit code was zero.
+func (c *TestContainer) MustExec(t *testing.T, env Env, workdir string, argv ...string) ExecResult {
+	t.Helper()
+	res := c.Exec(t, env, workdir, argv...)
+	if res.ExitCode != 0 {
+		t.Fatalf("exec %v failed: exit=%d\n%s", argv, res.ExitCode, res.Combined())
+	}
+	return res
+}
+
+// WriteFile writes content into a file in the container, creating parent
+// directories as needed. Uses `sh -c` with stdin so the body never needs
+// shell-escaping.
+func (c *TestContainer) WriteFile(t *testing.T, p string, content string) {
+	t.Helper()
+	parent := path.Dir(p)
+	if mk := c.Exec(t, nil, "", "mkdir", "-p", parent); mk.ExitCode != 0 {
+		t.Fatalf("mkdir -p %s: %s", parent, mk.Combined())
+	}
+	args := []string{"exec", "-i", c.id, "sh", "-c", "cat > " + shellQuote(p)}
+	cmd := exec.Command("docker", args...)
+	cmd.Stdin = strings.NewReader(content)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("write %s: %v\n%s", p, err, stderr.String())
+	}
+}
+
+// ReadFile returns the contents of p in the container, or fails the test
+// if the read errors out (a missing file is a hard fail — use FileExists
+// first when you need a soft check).
+func (c *TestContainer) ReadFile(t *testing.T, p string) string {
+	t.Helper()
+	res := c.MustExec(t, nil, "", "cat", p)
+	return res.Stdout
+}
+
+// FileExists reports whether p exists in the container. It does not
+// distinguish between regular files, directories and symlinks.
+func (c *TestContainer) FileExists(t *testing.T, p string) bool {
+	t.Helper()
+	res := c.Exec(t, nil, "", "test", "-e", p)
+	return res.ExitCode == 0
+}
+
+// IsDir reports whether p exists and is a directory.
+func (c *TestContainer) IsDir(t *testing.T, p string) bool {
+	t.Helper()
+	res := c.Exec(t, nil, "", "test", "-d", p)
+	return res.ExitCode == 0
+}
+
+// RemoveFile deletes p (or recursively, a directory) from the container.
+func (c *TestContainer) RemoveFile(t *testing.T, p string) {
+	t.Helper()
+	c.MustExec(t, nil, "", "rm", "-rf", p)
+}
+
+// ListDir returns the entries of dir in the container, sorted by name.
+// Returns an empty slice when the directory does not exist.
+func (c *TestContainer) ListDir(t *testing.T, dir string) []string {
+	t.Helper()
+	if !c.FileExists(t, dir) {
+		return nil
+	}
+	res := c.MustExec(t, nil, "", "sh", "-c", "ls -1A "+shellQuote(dir)+" 2>/dev/null | sort")
+	if strings.TrimSpace(res.Stdout) == "" {
+		return nil
+	}
+	return strings.Split(strings.TrimRight(res.Stdout, "\n"), "\n")
+}
+
+// Env is a small ordered string→string map. Maps are unordered in Go but
+// the env list we hand to docker exec must be reproducible across test
+// runs to keep failure messages stable.
+type Env map[string]string
+
+func (e Env) toSlice() []string {
+	if len(e) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(e))
+	for k := range e {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, fmt.Sprintf("%s=%s", k, e[k]))
+	}
+	return out
+}
+
+// shellQuote single-quote-escapes a path so it survives `sh -c` interpolation.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// testEnv bundles the per-test container HOME and workspace. Allocated by
+// newTestEnv() and disposed via t.Cleanup.
+type testEnv struct {
+	home    string // e.g. /tmp/test-sync-mcp-3a8f9c
+	workdir string // e.g. /tmp/test-sync-mcp-3a8f9c-work — project-scope cwd
+	c       *TestContainer
+}
+
+// newTestEnv allocates a fresh HOME + workspace inside the container,
+// scoped to the running test. The dirs are best-effort removed on cleanup;
+// any leak is bounded to the suite container's lifetime.
+func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+	suffix := randomSuffix()
+	sanitized := sanitizeName(t.Name())
+	home := fmt.Sprintf("/tmp/%s-%s", sanitized, suffix)
+	workdir := home + "-work"
+
+	suite.MustExec(t, nil, "", "mkdir", "-p", home, workdir)
+	t.Cleanup(func() {
+		suite.Exec(t, nil, "", "rm", "-rf", home, workdir)
+	})
+
+	return &testEnv{home: home, workdir: workdir, c: suite}
+}
+
+// gaalEnv returns the Env map every gaal exec inside a test should carry.
+// HOME redirection plus empty XDG vars is enough for gaal to anchor every
+// path under home (per cmd/root.go and internal/config/platform/unix.go).
+func (e *testEnv) gaalEnv() Env {
+	return Env{
+		"HOME":            e.home,
+		"GAAL_TELEMETRY":  "0",
+		"DO_NOT_TRACK":    "1",
+		"XDG_CONFIG_HOME": "",
+		"XDG_CACHE_HOME":  "",
+	}
+}
+
+// gaal runs the gaal CLI against the test env and returns the result.
+// The first argv element is typically "sync"/"status"/"prune"; the test
+// supplies a config path via -c. The --no-banner flag suppresses the
+// ASCII art so test output stays grep-friendly.
+func (e *testEnv) gaal(t *testing.T, configPath string, argv ...string) ExecResult {
+	t.Helper()
+	full := []string{"gaal", "--no-banner"}
+	if configPath != "" {
+		full = append(full, "-c", configPath)
+	}
+	full = append(full, argv...)
+	return e.c.Exec(t, e.gaalEnv(), e.workdir, full...)
+}
+
+// mustGaal is gaal + a fatal assertion that the exit code was zero.
+func (e *testEnv) mustGaal(t *testing.T, configPath string, argv ...string) ExecResult {
+	t.Helper()
+	res := e.gaal(t, configPath, argv...)
+	if res.ExitCode != 0 {
+		t.Fatalf("gaal %v failed: exit=%d\n%s", argv, res.ExitCode, res.Combined())
+	}
+	return res
+}
+
+// writeProjectConfig drops a gaal.yaml inside the test workdir and returns
+// its absolute path so the caller can pass it to gaal -c.
+func (e *testEnv) writeProjectConfig(t *testing.T, body string) string {
+	t.Helper()
+	p := path.Join(e.workdir, "gaal.yaml")
+	e.c.WriteFile(t, p, body)
+	return p
+}
+
+// writeUserConfig drops a config under $HOME/.config/gaal/config.yaml and
+// returns its absolute path. This is the user-scope counterpart to
+// writeProjectConfig.
+func (e *testEnv) writeUserConfig(t *testing.T, body string) string {
+	t.Helper()
+	p := path.Join(e.home, ".config", "gaal", "config.yaml")
+	e.c.WriteFile(t, p, body)
+	return p
+}
+
+// sanitizeName produces a /tmp-safe slug from a Go test name. "/" and "."
+// are replaced with "-" so each subtest gets a unique, readable directory.
+func sanitizeName(name string) string {
+	r := strings.NewReplacer("/", "-", ".", "-", " ", "_", "#", "n")
+	out := r.Replace(name)
+	if len(out) > 60 {
+		out = out[:60]
+	}
+	return strings.ToLower(out)
+}
+
+// randomSuffix returns 6 hex chars used to disambiguate test temp dirs
+// across re-runs of the same test name.
+func randomSuffix() string {
+	var b [3]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%06x", time.Now().UnixNano()&0xffffff)
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,166 @@
+//go:build e2e
+
+// Package e2e contains the gaal end-to-end test suite.
+//
+// The suite is gated by the `e2e` build tag so the day-to-day `go test ./...`
+// run never picks it up. Run it with:
+//
+//	make test-e2e                            # fast filesystem layer only
+//	GAAL_E2E_CLI=1 make test-e2e             # also exercise agent CLIs
+//
+// All tests share one Docker container per `go test` invocation. Each test
+// gets a unique HOME (a fresh /tmp/<test>-XXXXXX directory inside the
+// container) so writes from one test never leak into another.
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	// imageName tags the Docker image built once per `go test` invocation.
+	// Bumping the suffix forces a rebuild for everyone on the next run.
+	imageName = "gaal-e2e:dev"
+
+	// fixturesDir is the in-container path under which the host-side
+	// fixtures directory is bind-mounted (read-only).
+	fixturesDir = "/fixtures"
+)
+
+// suite is the package-global TestContainer initialised by TestMain and
+// reused by every test in the suite. Tests that need filesystem isolation
+// allocate their own HOME under it via newTestEnv().
+var suite *TestContainer
+
+// envCLI is true when GAAL_E2E_CLI=1 is set. The cli_verify_test.go layer
+// keys off this flag and skips itself otherwise.
+var envCLI = os.Getenv("GAAL_E2E_CLI") == "1"
+
+// TestMain orchestrates suite-wide setup:
+//  1. compile the gaal binary for linux/amd64 if it isn't already in
+//     fixtures/gaal (the Makefile target builds it before invoking go test;
+//     this is a safety net for ad-hoc invocations from an editor).
+//  2. build the Docker image (re-uses the layer cache so iterative runs
+//     only redo the cheap final COPY).
+//  3. start one long-lived container, bind-mounting the fixtures dir.
+//  4. run the tests.
+//  5. tear down the container regardless of test outcome.
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		fmt.Println("e2e: skipped under -short")
+		os.Exit(0)
+	}
+
+	if err := ensureBinary(); err != nil {
+		log.Fatalf("e2e: building gaal binary: %v", err)
+	}
+
+	if err := ensureImage(); err != nil {
+		log.Fatalf("e2e: building docker image: %v", err)
+	}
+
+	c, err := startContainer()
+	if err != nil {
+		log.Fatalf("e2e: starting container: %v", err)
+	}
+	suite = c
+
+	code := m.Run()
+
+	if err := c.Stop(); err != nil {
+		log.Printf("e2e: stopping container: %v", err)
+	}
+	os.Exit(code)
+}
+
+// fixturesPath returns the absolute host path to the fixtures directory.
+// Resolved from the runtime caller location so the suite works regardless
+// of the current working directory at test invocation time.
+func fixturesPath() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Fatal("e2e: cannot resolve caller path")
+	}
+	return filepath.Join(filepath.Dir(file), "fixtures")
+}
+
+// ensureBinary builds the gaal binary into fixtures/gaal when missing or
+// when GAAL_E2E_REBUILD=1 is set. The Makefile normally pre-builds it; this
+// fallback exists for direct `go test -tags e2e ./test/e2e/...` invocations.
+func ensureBinary() error {
+	dest := filepath.Join(fixturesPath(), "gaal")
+	if os.Getenv("GAAL_E2E_REBUILD") != "1" {
+		if _, err := os.Stat(dest); err == nil {
+			return nil
+		}
+	}
+
+	repoRoot, err := repoRoot()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("go", "build", "-trimpath", "-o", dest, ".")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"CGO_ENABLED=0",
+		"GOOS=linux",
+		"GOARCH=amd64",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("go build: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// repoRoot walks up from the current source file looking for go.mod.
+func repoRoot() (string, error) {
+	dir := fixturesPath()
+	for i := 0; i < 8; i++ {
+		dir = filepath.Dir(dir)
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+	}
+	return "", fmt.Errorf("could not locate repo root from %s", fixturesPath())
+}
+
+// ensureImage runs `docker build` with the fixtures directory as context.
+// The build args are derived from envCLI so layer 2 runs install the agent
+// CLIs while layer 1 runs stay slim.
+func ensureImage() error {
+	args := []string{
+		"build",
+		"--quiet",
+		"--tag", imageName,
+		"--build-arg", fmt.Sprintf("INSTALL_AGENT_CLIS=%s", boolToZeroOne(envCLI)),
+	}
+	args = append(args, fixturesPath())
+
+	cmd := exec.Command("docker", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker build: %w\n%s", err, out)
+	}
+	if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+		log.Printf("e2e: image built (%s)", trimmed)
+	}
+	return nil
+}
+
+func boolToZeroOne(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}

--- a/test/e2e/fixtures/.dockerignore
+++ b/test/e2e/fixtures/.dockerignore
@@ -1,0 +1,4 @@
+# Skill fixtures are bind-mounted at runtime and do not need to be baked
+# into the image. Keeping them out keeps the image small and the build cache
+# stable when only fixtures change.
+skills/

--- a/test/e2e/fixtures/.gitignore
+++ b/test/e2e/fixtures/.gitignore
@@ -1,0 +1,2 @@
+# Compiled gaal binary copied in by `make test-e2e` before the docker build.
+gaal

--- a/test/e2e/fixtures/Dockerfile
+++ b/test/e2e/fixtures/Dockerfile
@@ -1,0 +1,40 @@
+# Dockerfile for gaal end-to-end tests.
+#
+# Builds a small Alpine image carrying the prerequisites the e2e suite
+# exercises:
+#   - git, ca-certificates                    — VCS + TLS for skill cloning
+#   - bash, coreutils                         — predictable shell semantics
+#   - node + npm                              — agent CLIs (claude-code, codex)
+#
+# The gaal binary itself is NOT installed by the agent CLI install step:
+# the surrounding Makefile target compiles it for linux/amd64 and the test
+# harness COPYs it into /usr/local/bin/gaal as the LAST layer so iterative
+# rebuilds only re-do the cheap final step. The agent CLIs are gated behind
+# a build arg so the cheap layer-1 image can skip the slow npm install when
+# Layer 2 (`GAAL_E2E_CLI=1`) is not requested.
+FROM alpine:3.20
+
+ARG INSTALL_AGENT_CLIS=0
+
+RUN apk add --no-cache \
+        bash \
+        ca-certificates \
+        coreutils \
+        git \
+        nodejs \
+        npm
+
+# Optional: install the agent CLIs that the heavy CLI-verification layer
+# uses. Skipped by default so layer-1 builds stay fast.
+RUN if [ "$INSTALL_AGENT_CLIS" = "1" ]; then \
+        npm install -g --no-fund --no-audit @anthropic-ai/claude-code @openai/codex; \
+    fi
+
+# Persistent container entrypoint. The Go test harness keeps one container
+# alive per `go test` invocation and `docker exec`s into it for every test.
+CMD ["sleep", "infinity"]
+
+# The gaal binary is copied last so editing the binary only invalidates
+# this layer (apk + npm stay cached).
+COPY gaal /usr/local/bin/gaal
+RUN chmod +x /usr/local/bin/gaal

--- a/test/e2e/fixtures/skills/realistic-skill/SKILL.md
+++ b/test/e2e/fixtures/skills/realistic-skill/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: realistic-skill
+description: Multi-file skill (SKILL.md + prompts/ + templates/) used to verify gaal preserves the directory structure during install.
+---
+
+# realistic-skill
+
+This skill ships several companion assets:
+
+- `prompts/main.md`  — primary instructions referenced by the SKILL.md body
+- `templates/component.tsx` — boilerplate the skill copies into a project
+
+The gaal e2e suite uses this fixture to assert that the entire directory tree
+lands inside the agent's skill directory after `gaal sync`.

--- a/test/e2e/fixtures/skills/realistic-skill/prompts/main.md
+++ b/test/e2e/fixtures/skills/realistic-skill/prompts/main.md
@@ -1,0 +1,4 @@
+# realistic-skill / prompts / main.md
+
+Primary prompt referenced from `SKILL.md`. The exact contents are unimportant
+— the e2e suite only checks that this file is present after install.

--- a/test/e2e/fixtures/skills/realistic-skill/templates/component.tsx
+++ b/test/e2e/fixtures/skills/realistic-skill/templates/component.tsx
@@ -1,0 +1,5 @@
+// realistic-skill template — used by the gaal e2e suite to assert
+// nested companion files survive a sync.
+export function Placeholder() {
+  return null;
+}

--- a/test/e2e/fixtures/skills/second-skill/SKILL.md
+++ b/test/e2e/fixtures/skills/second-skill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: second-skill
+description: Companion stub skill — sits next to stub-skill so multi-skill scenarios have at least two distinct entries to operate on.
+---
+
+# second-skill
+
+Used by mutation tests that add a second skill to a config that already
+contains stub-skill, so the resulting filesystem state can be asserted on a
+two-skill source.

--- a/test/e2e/fixtures/skills/stub-skill/SKILL.md
+++ b/test/e2e/fixtures/skills/stub-skill/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: stub-skill
+description: Minimal single-file skill used by the gaal e2e test suite.
+---
+
+# stub-skill
+
+A trivial skill used by the gaal end-to-end tests.
+
+It contains a single SKILL.md file, no companion assets, and exists solely so
+the suite can verify that gaal copies SKILL.md into the agent's skill
+directory.

--- a/test/e2e/mutate_test.go
+++ b/test/e2e/mutate_test.go
@@ -1,0 +1,201 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path"
+	"strings"
+	"testing"
+)
+
+// TestMutate_AddSkill_PropagatesOnResync covers the most common edit:
+// add a new skill entry, re-sync (without --prune), the new skill appears.
+func TestMutate_AddSkill_PropagatesOnResync(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg1 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, false).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+	AssertSkillInstalled(t, env, "claude-code", ScopeProject, "stub-skill")
+	AssertSkillAbsent(t, env, "claude-code", ScopeProject, "second-skill")
+
+	cfg2 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, false).
+		AddSkill(localSkillsRoot+"/second-skill", []string{"claude-code"}, false).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertSkillInstalled(t, env, "claude-code", ScopeProject, "stub-skill")
+	AssertSkillInstalled(t, env, "claude-code", ScopeProject, "second-skill")
+}
+
+// TestMutate_AddMCP_PropagatesOnResync verifies a new MCP entry is upserted
+// without disturbing existing entries.
+func TestMutate_AddMCP_PropagatesOnResync(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg1 := newConfig().
+		AddMCP("filesystem", []string{"claude-code"}, true,
+			"uvx", []string{"mcp-server-filesystem", "/data"}, nil).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+
+	cfg2 := newConfig().
+		AddMCP("filesystem", []string{"claude-code"}, true,
+			"uvx", []string{"mcp-server-filesystem", "/data"}, nil).
+		AddMCP("git", []string{"claude-code"}, true,
+			"uvx", []string{"mcp-server-git"}, nil).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertMCPEntry(t, env, "claude-code", ScopeGlobal, "filesystem", MCPExpect{Command: "uvx"})
+	AssertMCPEntry(t, env, "claude-code", ScopeGlobal, "git", MCPExpect{Command: "uvx"})
+	AssertValidJSON(t, env, path.Join(env.home, ".claude.json"))
+}
+
+// TestMutate_AddCodexAgent verifies that adding a second agent to an
+// existing skill entry causes the skill to land in the new agent's dir
+// without disturbing the first.
+func TestMutate_AddCodexAgent(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg1 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, true).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+	AssertSkillInstalled(t, env, "claude-code", ScopeGlobal, "stub-skill")
+	AssertSkillAbsent(t, env, "codex", ScopeGlobal, "stub-skill")
+
+	cfg2 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code", "codex"}, true).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertSkillInstalled(t, env, "claude-code", ScopeGlobal, "stub-skill")
+	AssertSkillInstalled(t, env, "codex", ScopeGlobal, "stub-skill")
+}
+
+// TestMutate_SwitchScope_PopulatesNewLocation flips global: false → true
+// and re-syncs. The new global location must receive the skill copy.
+//
+// Note: prune currently only walks the skill directories the *current*
+// config references (see internal/skill/manager.go Prune). A scope flip
+// makes the previous project-scope dir no longer present in the
+// `expected` map, so the project-scope copy is left in place. The test
+// only asserts the new location is populated; the legacy copy is a
+// known limitation tracked separately.
+func TestMutate_SwitchScope_PopulatesNewLocation(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg1 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, false).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+	AssertSkillInstalled(t, env, "claude-code", ScopeProject, "stub-skill")
+	AssertSkillAbsent(t, env, "claude-code", ScopeGlobal, "stub-skill")
+
+	cfg2 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, true).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync", "--prune")
+
+	AssertSkillInstalled(t, env, "claude-code", ScopeGlobal, "stub-skill")
+}
+
+// TestMutate_SkillContent_ReSyncUpdates ensures the installed copy
+// reflects updated source content after a re-sync. The fixture is
+// read-only, so the test stages its own scratch source under $HOME with
+// the layout gaal expects (a parent directory whose subdirectories each
+// contain a SKILL.md). The marker file lives inside the skill's own
+// directory, so it travels with the skill on install.
+func TestMutate_SkillContent_ReSyncUpdates(t *testing.T) {
+	env := newTestEnv(t)
+
+	scratchRoot := path.Join(env.home, "scratch-skills")
+	scratchSkill := path.Join(scratchRoot, "stub-skill")
+	env.c.MustExec(t, nil, "", "mkdir", "-p", scratchRoot)
+	env.c.MustExec(t, nil, "", "cp", "-r", localSkillsRoot+"/stub-skill", scratchSkill)
+	env.c.WriteFile(t, path.Join(scratchSkill, "marker.txt"), "v1")
+
+	cfg := newConfig().
+		AddSkill(scratchRoot, []string{"claude-code"}, false).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	dir, _ := agentSkillDir(env, "claude-code", ScopeProject)
+	installedMarker := path.Join(dir, "stub-skill", "marker.txt")
+	if got := strings.TrimSpace(env.c.ReadFile(t, installedMarker)); got != "v1" {
+		t.Fatalf("expected marker v1 after first sync, got %q", got)
+	}
+
+	env.c.WriteFile(t, path.Join(scratchSkill, "marker.txt"), "v2")
+	env.mustGaal(t, cfgPath, "sync")
+
+	if got := strings.TrimSpace(env.c.ReadFile(t, installedMarker)); got != "v2" {
+		t.Fatalf("expected marker v2 after re-sync, got %q", got)
+	}
+}
+
+// TestMutate_MCPEnv_ReSyncUpdates verifies that changing inline env vars
+// in an MCP entry causes the on-disk config to update on the next sync.
+func TestMutate_MCPEnv_ReSyncUpdates(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg1 := newConfig().
+		AddMCP("git", []string{"claude-code"}, false,
+			"uvx", []string{"mcp-server-git"},
+			map[string]string{"GIT_AUTHOR_NAME": "ci"},
+		).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+	AssertMCPEntry(t, env, "claude-code", ScopeProject, "git", MCPExpect{
+		Env: map[string]string{"GIT_AUTHOR_NAME": "ci"},
+	})
+
+	cfg2 := newConfig().
+		AddMCP("git", []string{"claude-code"}, false,
+			"uvx", []string{"mcp-server-git"},
+			map[string]string{"GIT_AUTHOR_NAME": "release"},
+		).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertMCPEntry(t, env, "claude-code", ScopeProject, "git", MCPExpect{
+		Env: map[string]string{"GIT_AUTHOR_NAME": "release"},
+	})
+}
+
+// TestMutate_StatusReportsCounts smoke-tests the JSON status output so the
+// summary-first PR (#107) is provably consumable from end-to-end test code.
+// Using -o json keeps the assertion stable across summary-format tweaks.
+func TestMutate_StatusReportsCounts(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, false).
+		AddMCP("filesystem", []string{"claude-code"}, false,
+			"uvx", []string{"mcp-server-filesystem", "/data"}, nil).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	res := env.mustGaal(t, cfgPath, "-o", "json", "status")
+	if !strings.Contains(res.Stdout, `"skills"`) || !strings.Contains(res.Stdout, "stub-skill") {
+		t.Fatalf("expected status JSON to include skills + stub-skill; got:\n%s", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, `"mcps"`) || !strings.Contains(res.Stdout, "filesystem") {
+		t.Fatalf("expected status JSON to include mcps + filesystem; got:\n%s", res.Stdout)
+	}
+}

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -1,0 +1,124 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path"
+	"testing"
+)
+
+// TestPrune_RemovesOrphanSkill exercises the "drop a skill from config,
+// re-sync with --prune" workflow. The skill must be gone from the agent
+// directory after the second sync.
+func TestPrune_RemovesOrphanSkill(t *testing.T) {
+	env := newTestEnv(t)
+
+	// 1. Sync with two skills present.
+	cfg1 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, false).
+		AddSkill(localSkillsRoot+"/second-skill", []string{"claude-code"}, false).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+	AssertSkillInstalled(t, env, "claude-code", ScopeProject, "stub-skill")
+	AssertSkillInstalled(t, env, "claude-code", ScopeProject, "second-skill")
+
+	// 2. Drop second-skill from the config and sync --prune.
+	cfg2 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, false).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync", "--prune")
+
+	AssertSkillInstalled(t, env, "claude-code", ScopeProject, "stub-skill")
+	AssertSkillAbsent(t, env, "claude-code", ScopeProject, "second-skill")
+
+	// 3. The remaining install must not contain dangling symlinks pointing
+	//    into the removed skill's cache copy.
+	dir, _ := agentSkillDir(env, "claude-code", ScopeProject)
+	AssertNoStaleSymlinks(t, env, dir)
+}
+
+// TestPrune_RemovesOrphanMCPEntry covers the JSON codec prune path:
+// removing an MCP entry from the config + sync --prune drops the
+// matching mcpServers key from .mcp.json while preserving siblings.
+func TestPrune_RemovesOrphanMCPEntry(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg1 := newConfig().
+		AddMCP("filesystem", []string{"claude-code"}, false,
+			"uvx", []string{"mcp-server-filesystem", "/data"}, nil).
+		AddMCP("git", []string{"claude-code"}, false,
+			"uvx", []string{"mcp-server-git"}, nil).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+	AssertMCPEntry(t, env, "claude-code", ScopeProject, "filesystem", MCPExpect{Command: "uvx"})
+	AssertMCPEntry(t, env, "claude-code", ScopeProject, "git", MCPExpect{Command: "uvx"})
+
+	cfg2 := newConfig().
+		AddMCP("filesystem", []string{"claude-code"}, false,
+			"uvx", []string{"mcp-server-filesystem", "/data"}, nil).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync", "--prune")
+
+	AssertMCPEntry(t, env, "claude-code", ScopeProject, "filesystem", MCPExpect{Command: "uvx"})
+	AssertMCPAbsent(t, env, "claude-code", ScopeProject, "git")
+	AssertValidJSON(t, env, path.Join(env.workdir, ".mcp.json"))
+}
+
+// TestPrune_RemovesOrphanMCPEntry_TOML is the codex/TOML twin of the JSON
+// test above. The codec branch is selected purely by file extension so it
+// matters that both paths get a regression test.
+func TestPrune_RemovesOrphanMCPEntry_TOML(t *testing.T) {
+	env := newTestEnv(t)
+	env.c.MustExec(t, nil, "", "mkdir", "-p", path.Join(env.home, ".codex"))
+
+	cfg1 := newConfig().
+		AddMCP("git", []string{"codex"}, true,
+			"uvx", []string{"mcp-server-git"}, nil).
+		AddMCP("filesystem", []string{"codex"}, true,
+			"uvx", []string{"mcp-server-filesystem", "/data"}, nil).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+	AssertMCPEntry(t, env, "codex", ScopeGlobal, "git", MCPExpect{Command: "uvx"})
+	AssertMCPEntry(t, env, "codex", ScopeGlobal, "filesystem", MCPExpect{Command: "uvx"})
+
+	cfg2 := newConfig().
+		AddMCP("git", []string{"codex"}, true,
+			"uvx", []string{"mcp-server-git"}, nil).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync", "--prune")
+
+	AssertMCPEntry(t, env, "codex", ScopeGlobal, "git", MCPExpect{Command: "uvx"})
+	AssertMCPAbsent(t, env, "codex", ScopeGlobal, "filesystem")
+	AssertValidTOML(t, env, path.Join(env.home, ".codex", "config.toml"))
+}
+
+// TestPrune_AcrossMultipleAgents removes a skill that was synced to two
+// agents and verifies it disappears from both.
+func TestPrune_AcrossMultipleAgents(t *testing.T) {
+	env := newTestEnv(t)
+	preparePresentAgents(t, env, ScopeGlobal, "claude-code", "codex")
+
+	cfg1 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code", "codex"}, true).
+		AddSkill(localSkillsRoot+"/second-skill", []string{"claude-code", "codex"}, true).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg1)
+	env.mustGaal(t, cfgPath, "sync")
+	AssertSkillInstalled(t, env, "claude-code", ScopeGlobal, "second-skill")
+	AssertSkillInstalled(t, env, "codex", ScopeGlobal, "second-skill")
+
+	cfg2 := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code", "codex"}, true).
+		String()
+	env.c.WriteFile(t, cfgPath, cfg2)
+	env.mustGaal(t, cfgPath, "sync", "--prune")
+
+	AssertSkillAbsent(t, env, "claude-code", ScopeGlobal, "second-skill")
+	AssertSkillAbsent(t, env, "codex", ScopeGlobal, "second-skill")
+}

--- a/test/e2e/scope_test.go
+++ b/test/e2e/scope_test.go
@@ -1,0 +1,193 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path"
+	"strings"
+	"testing"
+)
+
+// TestScope_Matrix runs the same minimal sync against the (skill, mcp) ×
+// (project, global) matrix to confirm the scope flag is plumbed correctly
+// for every resource type. Each subtest gets its own HOME, so failures are
+// independent and easy to diff.
+func TestScope_Matrix(t *testing.T) {
+	type expect struct {
+		skillScope Scope
+		mcpScope   Scope
+	}
+	cases := []struct {
+		name   string
+		global bool
+		want   expect
+	}{
+		{"project", false, expect{ScopeProject, ScopeProject}},
+		{"global", true, expect{ScopeGlobal, ScopeGlobal}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newTestEnv(t)
+
+			cfg := newConfig().
+				AddSkill(localSkillsRoot+"/stub-skill",
+					[]string{"claude-code"}, tc.global).
+				AddMCP("filesystem",
+					[]string{"claude-code"}, tc.global,
+					"uvx",
+					[]string{"mcp-server-filesystem", "/data"},
+					nil,
+				).
+				String()
+			cfgPath := env.writeProjectConfig(t, cfg)
+			env.mustGaal(t, cfgPath, "sync")
+
+			AssertSkillInstalled(t, env, "claude-code", tc.want.skillScope, "stub-skill")
+			AssertMCPEntry(t, env, "claude-code", tc.want.mcpScope, "filesystem", MCPExpect{
+				Command: "uvx",
+			})
+
+			// And the opposite scope must remain empty.
+			otherSkillScope := ScopeGlobal
+			otherMCPScope := ScopeGlobal
+			if tc.global {
+				otherSkillScope = ScopeProject
+				otherMCPScope = ScopeProject
+			}
+			AssertSkillAbsent(t, env, "claude-code", otherSkillScope, "stub-skill")
+			AssertMCPAbsent(t, env, "claude-code", otherMCPScope, "filesystem")
+		})
+	}
+}
+
+// TestScope_UserConfigLoaded verifies that gaal loads a config from
+// $HOME/.config/gaal/config.yaml when no -c is supplied — proof that the
+// XDG path resolution (cmd/root.go + internal/config/platform/unix.go)
+// works under HOME redirection.
+func TestScope_UserConfigLoaded(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, true).
+		String()
+	env.writeUserConfig(t, cfg)
+
+	// No -c argument — gaal must walk the user-config search chain and
+	// find the file we just wrote.
+	res := env.gaal(t, "", "sync")
+	if res.ExitCode != 0 {
+		t.Fatalf("gaal sync (no -c) failed: exit=%d\n%s", res.ExitCode, res.Combined())
+	}
+	AssertSkillInstalled(t, env, "claude-code", ScopeGlobal, "stub-skill")
+}
+
+// TestScope_DryRunReportsChanges exercises the --dry-run plan path:
+// nothing should land on disk, but the command must exit non-zero (1)
+// to signal pending changes per cmd/sync.go's contract.
+func TestScope_DryRunReportsChanges(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, false).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	res := env.gaal(t, cfgPath, "sync", "--dry-run")
+	if res.ExitCode != 1 {
+		t.Fatalf("expected dry-run exit code 1 (pending changes), got %d\n%s",
+			res.ExitCode, res.Combined())
+	}
+	AssertSkillAbsent(t, env, "claude-code", ScopeProject, "stub-skill")
+
+	// Now actually sync and re-run dry-run — the second run must report
+	// no changes and exit 0.
+	env.mustGaal(t, cfgPath, "sync")
+	res = env.gaal(t, cfgPath, "sync", "--dry-run")
+	if res.ExitCode != 0 {
+		t.Fatalf("expected post-sync dry-run exit 0 (clean), got %d\n%s",
+			res.ExitCode, res.Combined())
+	}
+}
+
+// TestScope_AuditDiscoversInstalledSkill installs a skill via gaal sync
+// then runs `gaal audit -o json` and asserts the discovered tree mentions
+// it. This is the regression target for the full sync → audit handoff.
+func TestScope_AuditDiscoversInstalledSkill(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, true).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	res := env.mustGaal(t, cfgPath, "-o", "json", "audit")
+	if !strings.Contains(res.Stdout, "stub-skill") {
+		t.Fatalf("expected audit JSON to surface stub-skill\n%s", res.Stdout)
+	}
+}
+
+// TestScope_StatusJSONShape sanity-checks that the JSON status output is a
+// well-formed object with the four documented top-level arrays. This is
+// the structural contract Layer 2 (CLI verification) builds on.
+func TestScope_StatusJSONShape(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, false).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	res := env.mustGaal(t, cfgPath, "-o", "json", "status")
+	for _, key := range []string{`"repositories"`, `"skills"`, `"mcps"`, `"agents"`} {
+		if !strings.Contains(res.Stdout, key) {
+			t.Fatalf("status JSON missing %s\n%s", key, res.Stdout)
+		}
+	}
+
+	// And the synced skill must be in the status payload.
+	if !strings.Contains(res.Stdout, "stub-skill") {
+		t.Fatalf("status JSON missing stub-skill\n%s", res.Stdout)
+	}
+}
+
+// TestScope_NoSpuriousFiles guards against gaal writing anything under
+// HOME or workdir other than the explicitly configured agent paths. A
+// regression that, say, accidentally writes under ~/.gaal would show up
+// as an unexpected directory entry.
+func TestScope_NoSpuriousFiles(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, true).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	homeEntries := env.c.ListDir(t, env.home)
+	allowed := map[string]struct{}{
+		".cache":  {}, // gaal source/state caches
+		".claude": {}, // the synced skill's parent
+		".config": {}, // potential telemetry/user config
+	}
+	for _, e := range homeEntries {
+		if _, ok := allowed[e]; !ok {
+			t.Fatalf("unexpected entry under HOME after sync: %s\n  full listing: %v",
+				e, homeEntries)
+		}
+	}
+
+	// Workdir should only contain the gaal.yaml the test wrote.
+	workEntries := env.c.ListDir(t, env.workdir)
+	if len(workEntries) != 1 || workEntries[0] != "gaal.yaml" {
+		t.Fatalf("unexpected workdir entries after global-scope sync: %v", workEntries)
+	}
+
+	// And ~/.claude/skills/stub-skill exists and is a directory.
+	dir, _ := agentSkillDir(env, "claude-code", ScopeGlobal)
+	if !env.c.IsDir(t, path.Join(dir, "stub-skill")) {
+		t.Fatalf("expected synced skill to be a directory at %s", dir)
+	}
+}

--- a/test/e2e/sync_test.go
+++ b/test/e2e/sync_test.go
@@ -1,0 +1,234 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path"
+	"strings"
+	"testing"
+)
+
+// localSkillsRoot is the read-only fixtures path inside the container —
+// every test that uses a local skill source points its config here.
+const localSkillsRoot = fixturesDir + "/skills"
+
+// preparePresentAgents creates the directories that mark each named agent
+// as "installed" in the test HOME, so wildcard expansion (agents: ["*"])
+// resolves to the expected set without --force. The directory list mirrors
+// the registry in internal/core/agent/agents.yaml — adding a new agent
+// here means adding the dir its detection check looks for.
+func preparePresentAgents(t *testing.T, env *testEnv, scope Scope, names ...string) {
+	t.Helper()
+	for _, n := range names {
+		dir, ok := agentSkillDir(env, n, scope)
+		if !ok {
+			t.Fatalf("no skill dir mapping for %q", n)
+		}
+		env.c.MustExec(t, nil, "", "mkdir", "-p", dir)
+		// codex MCP target lives under ~/.codex; pre-create so MCP sync
+		// can write its TOML.
+		if n == "codex" && scope == ScopeGlobal {
+			env.c.MustExec(t, nil, "", "mkdir", "-p", path.Join(env.home, ".codex"))
+		}
+	}
+}
+
+// TestSync_SkillToClaudeCode_Project verifies a project-scope skill sync
+// to claude-code lands SKILL.md inside .claude/skills/<skill>/ under the
+// project working directory.
+func TestSync_SkillToClaudeCode_Project(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, false).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertSkillInstalled(t, env, "claude-code", ScopeProject, "stub-skill")
+}
+
+// TestSync_SkillToClaudeCode_Global mirrors the project-scope test for
+// home-relative installs (~/.claude/skills/).
+func TestSync_SkillToClaudeCode_Global(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, true).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertSkillInstalled(t, env, "claude-code", ScopeGlobal, "stub-skill")
+}
+
+// TestSync_SkillToCodex_Global verifies the codex global-skill path,
+// which writes to ~/.codex/skills/. codex has no project-scope skills
+// dir per the registry — its supports_generic_project flag delegates
+// project-scope writes to .agents/skills (the generic convention) — so
+// the project counterpart is covered by TestSync_SkillToGeneric_Project.
+func TestSync_SkillToCodex_Global(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"codex"}, true).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertSkillInstalled(t, env, "codex", ScopeGlobal, "stub-skill")
+}
+
+// TestSync_MCPToClaudeCode_Global verifies that an inline MCP entry lands
+// in ~/.claude.json under the mcpServers key with command/args preserved.
+func TestSync_MCPToClaudeCode_Global(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddMCP("filesystem",
+			[]string{"claude-code"}, true,
+			"uvx",
+			[]string{"mcp-server-filesystem", "/data"},
+			nil,
+		).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertMCPEntry(t, env, "claude-code", ScopeGlobal, "filesystem", MCPExpect{
+		Command: "uvx",
+		Args:    []string{"mcp-server-filesystem", "/data"},
+	})
+	AssertValidJSON(t, env, path.Join(env.home, ".claude.json"))
+}
+
+// TestSync_MCPToClaudeCode_Project asserts the workspace-scoped path:
+// the entry must land in ./.mcp.json, not ~/.claude.json.
+func TestSync_MCPToClaudeCode_Project(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddMCP("filesystem",
+			[]string{"claude-code"}, false,
+			"uvx",
+			[]string{"mcp-server-filesystem", "/data"},
+			nil,
+		).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertMCPEntry(t, env, "claude-code", ScopeProject, "filesystem", MCPExpect{
+		Command: "uvx",
+		Args:    []string{"mcp-server-filesystem", "/data"},
+	})
+	AssertFileAbsent(t, env, path.Join(env.home, ".claude.json"))
+	AssertValidJSON(t, env, path.Join(env.workdir, ".mcp.json"))
+}
+
+// TestSync_MCPToCodex_Global verifies the TOML codec path: codex stores
+// MCP entries in ~/.codex/config.toml under the [mcp_servers.<name>] table.
+// This is the regression target for #91.
+func TestSync_MCPToCodex_Global(t *testing.T) {
+	env := newTestEnv(t)
+
+	// codex's config dir must exist for mergeIntoTarget to write into it.
+	env.c.MustExec(t, nil, "", "mkdir", "-p", path.Join(env.home, ".codex"))
+
+	cfg := newConfig().
+		AddMCP("git",
+			[]string{"codex"}, true,
+			"uvx",
+			[]string{"mcp-server-git", "--repository", "/data/repo"},
+			map[string]string{"GIT_AUTHOR_NAME": "ci"},
+		).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertMCPEntry(t, env, "codex", ScopeGlobal, "git", MCPExpect{
+		Command: "uvx",
+		Args:    []string{"mcp-server-git", "--repository", "/data/repo"},
+		Env:     map[string]string{"GIT_AUTHOR_NAME": "ci"},
+	})
+	tomlPath := path.Join(env.home, ".codex", "config.toml")
+	AssertValidTOML(t, env, tomlPath)
+
+	// The TOML body must use the table form gaal writes — sanity-check the
+	// surface syntax so a regression to inline tables is caught here.
+	body := env.c.ReadFile(t, tomlPath)
+	if !strings.Contains(body, "[mcp_servers.git]") {
+		t.Fatalf("expected [mcp_servers.git] table in codex config.toml, got:\n%s", body)
+	}
+}
+
+// TestSync_WildcardAgents_Skills covers the agents: ["*"] expansion: every
+// installed agent must receive the skill, but agents whose dir is missing
+// must NOT be created as a side effect (the safe wildcard contract).
+func TestSync_WildcardAgents_Skills(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Mark claude-code AND codex as installed at global scope.
+	preparePresentAgents(t, env, ScopeGlobal, "claude-code", "codex")
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"*"}, true).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	AssertSkillInstalled(t, env, "claude-code", ScopeGlobal, "stub-skill")
+	AssertSkillInstalled(t, env, "codex", ScopeGlobal, "stub-skill")
+	// "generic" was NOT pre-installed → must not pick up the skill.
+	AssertSkillAbsent(t, env, "generic", ScopeGlobal, "stub-skill")
+}
+
+// TestSync_RealisticSkill_PreservesTree asserts that gaal copies the
+// entire skill directory, not just SKILL.md. This is the regression
+// target for any change that walks files individually instead of using
+// a recursive copy.
+func TestSync_RealisticSkill_PreservesTree(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/realistic-skill", []string{"claude-code"}, false).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	dir, _ := agentSkillDir(env, "claude-code", ScopeProject)
+	skillRoot := path.Join(dir, "realistic-skill")
+
+	for _, rel := range []string{
+		"SKILL.md",
+		"prompts/main.md",
+		"templates/component.tsx",
+	} {
+		AssertFileExists(t, env, path.Join(skillRoot, rel))
+	}
+}
+
+// TestSync_SelectFiltersSkills verifies the select: list narrows the
+// install set: a single named skill drops in even though the source
+// directory only carries that one (so the test doubles as a smoke check
+// that select with a single match works at all).
+func TestSync_SelectFiltersSkills(t *testing.T) {
+	env := newTestEnv(t)
+
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/realistic-skill",
+			[]string{"claude-code"}, false, "realistic-skill").
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+	AssertSkillInstalled(t, env, "claude-code", ScopeProject, "realistic-skill")
+}


### PR DESCRIPTION
Closes #106.

## Summary

Two-layer Docker-based e2e test suite under `test/e2e/`. Layer 1 asserts on filesystem state after `gaal sync`/`prune`/mutate scenarios. Layer 2 (gated by `GAAL_E2E_CLI=1`) installs the real `claude` and `codex` CLIs in the image and verifies they read what gaal wrote. The whole suite is gated by a `//go:build e2e` tag so the everyday `go test ./...` is unaffected.

## What's covered

| File | Scenarios |
|------|-----------|
| `sync_test.go` | skill→claude-code (project + global), skill→codex global, MCP→claude-code (JSON, both scopes), MCP→codex (TOML, regression for #91), wildcard agents respect installed-detection, multi-file skills preserve their tree, `select:` filter |
| `prune_test.go` | orphan skill removal, JSON MCP prune, TOML MCP prune, multi-agent prune, no stale symlinks left behind |
| `mutate_test.go` | add skill / add MCP / add agent on resync, scope flip populates new location, source content edits propagate, MCP env mutation propagates, JSON `status` shape sanity |
| `scope_test.go` | project/global matrix, user-config discovery via XDG, dry-run exit codes (0/1), `audit -o json` discovers synced skills, no-spurious-files in `$HOME` or workdir |
| `cli_verify_test.go` | (gated) `claude mcp list` round-trip, codex re-parses gaal-written TOML, prune drops entries from CLI view |

## Harness highlights

- **One container per `go test` invocation**, each test gets a fresh `HOME` inside it via `mktemp -d` for full isolation.
- **Fixtures** (`skills/`, `Dockerfile`) bind-mounted read-only at `/fixtures` — no `docker cp` dance.
- **Layer ordering** in the Dockerfile keeps the `apk` and optional `npm install` layers cached; only the final `COPY gaal` invalidates on iteration.
- **Telemetry off** via `GAAL_TELEMETRY=0` + `DO_NOT_TRACK=1` so the suite never opens an outbound connection.
- **`-o json`** is preferred whenever a test needs to parse output, so the summary-first default from #107 never trips an assertion.

## Quick start

```bash
make test-e2e            # Layer 1 only (~25s on a warm machine)
make test-e2e-cli        # full suite incl. claude + codex CLIs
GAAL_E2E_REBUILD=1 make test-e2e   # force a fresh gaal build
go test -tags e2e -run TestSync_MCPToCodex_Global ./test/e2e/...
```

## CI

New `e2e` job in `.github/workflows/ci.yml` runs after `test`. `ubuntu-latest` already ships Docker + BuildKit, so no extra setup is required.

## Compatibility with #107

The summary-first text output from #107 lives by design alongside richer formats (`-o json`, `-o table`, `--verbose`). Every assertion in the suite that needs structured data uses `-o json`; assertions about side effects go through filesystem inspection. The summary text is exercised indirectly (every `gaal sync` runs through it) but never parsed.

## Test plan

- [x] `make test-e2e` passes on a clean machine (fresh `dist/` and image) — verified locally
- [x] `make test-e2e-cli` passes including all three CLI tests — verified locally (~77s)
- [x] `go test ./...` continues to pass and does not pick up the e2e package
- [x] `make lint` clean (`gofmt` + `go vet` on default tags and `-tags e2e`)
- [x] Without `GAAL_E2E_CLI=1`, the three CLI tests skip with a descriptive message