### PR TITLE
security: redact URL credentials from logs and error messages

### DIFF
--- a/internal/core/vcs/archive.go
+++ b/internal/core/vcs/archive.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"gaal/internal/urlx"
 )
 
 // VcsArchive implements VCS for tar and zip archives fetched over HTTP(S).
@@ -72,12 +74,13 @@ func fetchURL(ctx context.Context, rawURL string) (io.ReadCloser, error) {
 	}
 
 	resp, err := http.DefaultClient.Do(req)
+	safeURL := urlx.Redact(rawURL)
 	if err != nil {
-		return nil, fmt.Errorf("fetching %s: %w", rawURL, err)
+		return nil, fmt.Errorf("fetching %s: %w", safeURL, err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
-		return nil, fmt.Errorf("fetching %s: HTTP %d", rawURL, resp.StatusCode)
+		return nil, fmt.Errorf("fetching %s: HTTP %d", safeURL, resp.StatusCode)
 	}
 
 	return resp.Body, nil

--- a/internal/core/vcs/bzr.go
+++ b/internal/core/vcs/bzr.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"gaal/internal/runner"
+	"gaal/internal/urlx"
 )
 
 // VcsBazaar implements VCS for Bazaar repositories.
@@ -22,7 +23,7 @@ func (b *VcsBazaar) Clone(ctx context.Context, url, path, version string) error 
 		return fmt.Errorf("creating parent directory: %w", err)
 	}
 
-	slog.DebugContext(ctx, "branching", "url", url, "path", shortPath(path), "version", version)
+	slog.DebugContext(ctx, "branching", "url", urlx.Redact(url), "path", shortPath(path), "version", version)
 
 	args := []string{"branch"}
 	if version != "" {

--- a/internal/core/vcs/git.go
+++ b/internal/core/vcs/git.go
@@ -10,6 +10,8 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+
+	"gaal/internal/urlx"
 )
 
 // VcsGit implements the VCS interface for Git repositories using go-git
@@ -35,7 +37,8 @@ func (g *VcsGit) Clone(ctx context.Context, url, path, version string) error {
 		return fmt.Errorf("creating parent directory: %w", err)
 	}
 
-	slog.DebugContext(ctx, "cloning", "url", url, "path", shortPath(path), "version", version)
+	safeURL := urlx.Redact(url)
+	slog.DebugContext(ctx, "cloning", "url", safeURL, "path", shortPath(path), "version", version)
 
 	r, err := gogit.PlainCloneContext(ctx, path, false, &gogit.CloneOptions{
 		URL:               url,
@@ -44,7 +47,7 @@ func (g *VcsGit) Clone(ctx context.Context, url, path, version string) error {
 		Depth:             g.depth(),
 	})
 	if err != nil {
-		return fmt.Errorf("cloning %s: %w", url, err)
+		return fmt.Errorf("cloning %s: %w", safeURL, err)
 	}
 
 	if version != "" {

--- a/internal/core/vcs/hg.go
+++ b/internal/core/vcs/hg.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"gaal/internal/runner"
+	"gaal/internal/urlx"
 )
 
 // VcsMercurial implements VCS for Mercurial repositories.
@@ -22,7 +23,7 @@ func (m *VcsMercurial) Clone(ctx context.Context, url, path, version string) err
 		return fmt.Errorf("creating parent directory: %w", err)
 	}
 
-	slog.DebugContext(ctx, "cloning", "url", url, "path", shortPath(path), "version", version)
+	slog.DebugContext(ctx, "cloning", "url", urlx.Redact(url), "path", shortPath(path), "version", version)
 
 	args := []string{"clone"}
 	if version != "" {

--- a/internal/core/vcs/svn.go
+++ b/internal/core/vcs/svn.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"gaal/internal/runner"
+	"gaal/internal/urlx"
 )
 
 // VcsSVN implements VCS for Subversion repositories.
@@ -22,7 +23,7 @@ func (s *VcsSVN) Clone(ctx context.Context, url, path, version string) error {
 		return fmt.Errorf("creating parent directory: %w", err)
 	}
 
-	slog.DebugContext(ctx, "checkout", "url", url, "path", shortPath(path), "version", version)
+	slog.DebugContext(ctx, "checkout", "url", urlx.Redact(url), "path", shortPath(path), "version", version)
 
 	args := []string{"checkout"}
 	if version != "" {

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -15,6 +15,7 @@ import (
 	"gaal/internal/config"
 	"gaal/internal/core/agent"
 	"gaal/internal/discover"
+	"gaal/internal/urlx"
 )
 
 // serverEntry mirrors the MCP server JSON structure used by Claude Desktop,
@@ -175,7 +176,7 @@ func (m *Manager) syncOne(ctx context.Context, mc config.ConfigMcp) error {
 		}
 
 	case mc.Source != "":
-		slog.DebugContext(ctx, "mcp remote source", "name", mc.Name, "url", mc.Source)
+		slog.DebugContext(ctx, "mcp remote source", "name", mc.Name, "url", urlx.Redact(mc.Source))
 		var err error
 		entry, err = fetchRemoteEntry(ctx, mc.Source, mc.Name)
 		if err != nil {
@@ -216,7 +217,8 @@ func (m *Manager) writeMCPSnapshot(target string) {
 // If the remote file is a full mcpServers document the matching key is extracted;
 // otherwise the whole document is treated as a single server entry.
 func fetchRemoteEntry(ctx context.Context, rawURL, name string) (serverEntry, error) {
-	slog.DebugContext(ctx, "fetching remote mcp config", "url", rawURL, "name", name)
+	safeURL := urlx.Redact(rawURL)
+	slog.DebugContext(ctx, "fetching remote mcp config", "url", safeURL, "name", name)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return serverEntry{}, fmt.Errorf("building request: %w", err)
@@ -224,12 +226,12 @@ func fetchRemoteEntry(ctx context.Context, rawURL, name string) (serverEntry, er
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return serverEntry{}, fmt.Errorf("fetching %s: %w", rawURL, err)
+		return serverEntry{}, fmt.Errorf("fetching %s: %w", safeURL, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return serverEntry{}, fmt.Errorf("fetching %s: HTTP %d", rawURL, resp.StatusCode)
+		return serverEntry{}, fmt.Errorf("fetching %s: HTTP %d", safeURL, resp.StatusCode)
 	}
 
 	// Try to decode as a full mcpServers document first.
@@ -251,7 +253,7 @@ func fetchRemoteEntry(ctx context.Context, rawURL, name string) (serverEntry, er
 		}
 	}
 
-	return serverEntry{}, fmt.Errorf("no server entry found in %s", rawURL)
+	return serverEntry{}, fmt.Errorf("no server entry found in %s", safeURL)
 }
 
 // mergeIntoTarget reads the target config file (JSON or TOML, picked by

--- a/internal/repo/manager.go
+++ b/internal/repo/manager.go
@@ -8,6 +8,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/core/vcs"
+	"gaal/internal/urlx"
 )
 
 // Status holds the sync state of a single repository.
@@ -74,7 +75,7 @@ func (m *Manager) syncOne(ctx context.Context, path string, cfg config.ConfigRep
 	}
 
 	if !backend.IsCloned(path) {
-		slog.Debug("cloning repository", "path", path, "url", cfg.URL, "version", cfg.Version)
+		slog.Debug("cloning repository", "path", path, "url", urlx.Redact(cfg.URL), "version", cfg.Version)
 		return backend.Clone(ctx, cfg.URL, path, cfg.Version)
 	}
 

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -15,6 +15,7 @@ import (
 	"gaal/internal/config"
 	"gaal/internal/core/vcs"
 	"gaal/internal/discover"
+	"gaal/internal/urlx"
 )
 
 // buildDiscoveryDirs returns the deduplicated list of subdirectories to scan
@@ -247,9 +248,10 @@ func (m *Manager) resolveSource(ctx context.Context, source string) (string, err
 	}
 
 	if !backend.IsCloned(localPath) {
-		slog.Debug("cloning skill source", "url", cloneURL, "path", localPath)
+		safeURL := urlx.Redact(cloneURL)
+		slog.Debug("cloning skill source", "url", safeURL, "path", localPath)
 		if err := backend.Clone(ctx, cloneURL, localPath, ""); err != nil {
-			return "", fmt.Errorf("cloning %s: %w", cloneURL, err)
+			return "", fmt.Errorf("cloning %s: %w", safeURL, err)
 		}
 	} else {
 		slog.Debug("updating skill source", "path", localPath)

--- a/internal/urlx/redact.go
+++ b/internal/urlx/redact.go
@@ -1,0 +1,32 @@
+// Package urlx provides URL utilities, including credential redaction for
+// safe logging and error messages.
+package urlx
+
+import (
+	"log/slog"
+	"net/url"
+)
+
+// Redact returns rawurl with any embedded userinfo (user[:password]) stripped.
+// If rawurl is empty or not a parseable URL, it is returned unchanged.
+//
+// Use this whenever a URL flows into a log line, error message, telemetry
+// payload, or any other persisted/transmitted surface — per the AGENTS.md
+// rule "do not log secrets or credentials."
+func Redact(rawurl string) string {
+	if rawurl == "" {
+		return rawurl
+	}
+	u, err := url.Parse(rawurl)
+	if err != nil || u.User == nil {
+		return rawurl
+	}
+	u.User = nil
+	return u.String()
+}
+
+// SlogURL returns a slog.Attr keyed "url" with the redacted form of rawurl.
+// Convenience wrapper for the common slog.DebugContext(ctx, "...", "url", url) pattern.
+func SlogURL(rawurl string) slog.Attr {
+	return slog.String("url", Redact(rawurl))
+}

--- a/internal/urlx/redact_test.go
+++ b/internal/urlx/redact_test.go
@@ -1,0 +1,40 @@
+package urlx
+
+import "testing"
+
+func TestRedact(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no userinfo", "https://github.com/owner/repo.git", "https://github.com/owner/repo.git"},
+		{"user and password", "https://alice:hunter2@github.com/owner/repo.git", "https://github.com/owner/repo.git"},
+		{"user only", "https://alice@github.com/owner/repo.git", "https://github.com/owner/repo.git"},
+		{"token-as-password", "https://oauth2:ghp_xxxx@github.com/owner/repo.git", "https://github.com/owner/repo.git"},
+		{"ssh with creds", "ssh://user:token@host:22/path", "ssh://host:22/path"},
+		{"http with port and creds", "http://u:p@127.0.0.1:8080/x", "http://127.0.0.1:8080/x"},
+		{"scp-style git (unchanged)", "git@github.com:owner/repo.git", "git@github.com:owner/repo.git"},
+		{"local path (unchanged)", "/home/alice/skills", "/home/alice/skills"},
+		{"unparseable (unchanged)", "://broken", "://broken"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Redact(tt.in)
+			if got != tt.want {
+				t.Errorf("Redact(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlogURL(t *testing.T) {
+	a := SlogURL("https://alice:secret@example.com/x")
+	if a.Key != "url" {
+		t.Errorf("key = %q, want %q", a.Key, "url")
+	}
+	if got := a.Value.String(); got != "https://example.com/x" {
+		t.Errorf("value = %q, want %q", got, "https://example.com/x")
+	}
+}


### PR DESCRIPTION
## Summary
- New \`internal/urlx\` package with \`Redact()\` and \`SlogURL()\` helpers
- Wires the helper into every URL log/error site across vcs (git/hg/svn/bzr/archive), mcp, repo, skill

Per AGENTS.md: \"Do not log secrets or credentials.\" Token-bearing URLs in \`--verbose\` output and \`--log-file\` are now redacted.

Closes #114.

## Test plan
- [x] Unit tests for \`Redact()\` covering empty, no-userinfo, user+password, user-only, SSH, HTTP+port, SCP-style git, local path, unparseable
- [x] \`go test ./internal/urlx/ ./internal/core/vcs/ ./internal/mcp/ ./internal/repo/ ./internal/skill/\`
- [x] \`go build\`
- [ ] Reviewer should confirm no regression in test/e2e CLI verify (assertion strings unchanged for non-credentialed URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)