### PR TITLE
security: tighten file mode of MCP configs and log files to 0o600

### DIFF
--- a/internal/engine/ops/init.go
+++ b/internal/engine/ops/init.go
@@ -12,6 +12,7 @@ import (
 
 	"gaal/internal/config"
 	configtemplate "gaal/internal/config/template"
+	"gaal/internal/secfile"
 )
 
 // Init writes the documented gaal.yaml skeleton to dest.
@@ -33,7 +34,7 @@ func Init(dest string, force bool) error {
 		return err
 	}
 
-	if err := os.WriteFile(dest, tmpl, 0o644); err != nil {
+	if err := secfile.Write(dest, tmpl); err != nil {
 		return fmt.Errorf("writing %s: %w", dest, err)
 	}
 
@@ -63,7 +64,7 @@ func InitFromPlan(dest string, plan Plan, force bool) error {
 		return err
 	}
 
-	if err := os.WriteFile(dest, content, 0o644); err != nil {
+	if err := secfile.Write(dest, content); err != nil {
 		return fmt.Errorf("writing %s: %w", dest, err)
 	}
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+
+	"gaal/internal/secfile"
 )
 
 // Setup initialises the global slog logger.
@@ -23,7 +25,7 @@ func Setup(level slog.Level, logFile string) (func(), error) {
 	noop := func() {}
 
 	if logFile != "" {
-		f, err := os.OpenFile(logFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644) //nolint:gosec
+		f, err := secfile.OpenAppend(logFile)
 		if err != nil {
 			return noop, fmt.Errorf("opening log file %q: %w", logFile, err)
 		}

--- a/internal/mcp/codec.go
+++ b/internal/mcp/codec.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
+
+	"gaal/internal/secfile"
 )
 
 // mcpCodec abstracts reading and writing the MCP-server table inside an
@@ -90,7 +92,7 @@ func (jsonCodec) WriteServers(path string, servers map[string]serverEntry) error
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, out, 0o644) //nolint:gosec
+	return secfile.Write(path, out)
 }
 
 // ── TOML ────────────────────────────────────────────────────────────────────
@@ -154,7 +156,7 @@ func (tomlCodec) WriteServers(path string, servers map[string]serverEntry) error
 	if err != nil {
 		return fmt.Errorf("encoding %s: %w", path, err)
 	}
-	return os.WriteFile(path, out, 0o644) //nolint:gosec
+	return secfile.Write(path, out)
 }
 
 // decodeTOMLEntry converts a parsed TOML table into a serverEntry, normalising

--- a/internal/secfile/secfile.go
+++ b/internal/secfile/secfile.go
@@ -1,0 +1,40 @@
+// Package secfile writes files with mode 0o600 and tightens existing files
+// that were created with looser permissions. Use this for any file that may
+// hold secrets — MCP env tokens, telemetry state, log records, gaal config.
+package secfile
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Mode is the permission bits applied to all secret files.
+const Mode os.FileMode = 0o600
+
+// Write writes data to path with mode 0o600. If path already exists with
+// looser permissions, it is tightened via Chmod after the write — os.WriteFile
+// only honours the mode argument on file creation, so an existing 0o644 file
+// would otherwise stay world-readable.
+func Write(path string, data []byte) error {
+	if err := os.WriteFile(path, data, Mode); err != nil {
+		return err
+	}
+	if err := os.Chmod(path, Mode); err != nil {
+		slog.Warn("secfile: chmod failed", "path", path, "err", err)
+	}
+	return nil
+}
+
+// OpenAppend opens path for append-write with mode 0o600, creating it if
+// missing. If the file already exists with looser permissions, it is
+// tightened. The caller owns the returned *os.File and must Close it.
+func OpenAppend(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, Mode)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, Mode); err != nil {
+		slog.Warn("secfile: chmod failed", "path", path, "err", err)
+	}
+	return f, nil
+}

--- a/internal/secfile/secfile_test.go
+++ b/internal/secfile/secfile_test.go
@@ -1,0 +1,70 @@
+package secfile
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWrite_NewFileIs0o600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.json")
+	if err := Write(path, []byte(`{"k":1}`)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != Mode {
+		t.Errorf("mode = %o, want %o", got, Mode)
+	}
+}
+
+func TestWrite_TightensExistingLooseFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.json")
+	if err := os.WriteFile(path, []byte("orig"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := Write(path, []byte("new")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != Mode {
+		t.Errorf("mode = %o, want %o (loose file should be tightened)", got, Mode)
+	}
+}
+
+func TestOpenAppend_TightensExistingLooseFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log")
+	if err := os.WriteFile(path, []byte("orig\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	f, err := OpenAppend(path)
+	if err != nil {
+		t.Fatalf("OpenAppend: %v", err)
+	}
+	defer f.Close()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != Mode {
+		t.Errorf("mode = %o, want %o", got, Mode)
+	}
+}

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -12,6 +12,7 @@ import (
 
 	"gaal/internal/config"
 	configtemplate "gaal/internal/config/template"
+	"gaal/internal/secfile"
 )
 
 // consentState represents the resolved telemetry consent.
@@ -150,5 +151,5 @@ func persistConsent(cfgPath string, enabled bool) error {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
 
-	return os.WriteFile(cfgPath, out, 0o644)
+	return secfile.Write(cfgPath, out)
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -13,6 +13,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/core/agent"
+	"gaal/internal/secfile"
 	"gaal/internal/skill"
 )
 
@@ -311,7 +312,7 @@ func saveMilestoneState(path string, ms milestoneState) {
 		slog.Warn("failed to create milestone state directory", "err", err)
 		return
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := secfile.Write(path, data); err != nil {
 		slog.Warn("failed to write milestone state", "err", err)
 	}
 }


### PR DESCRIPTION
## Summary
- New \`internal/secfile\` package with \`Write\` (write + chmod 0o600) and \`OpenAppend\` (open append + chmod 0o600)
- Replaces every 0o644 write/open in: MCP json+toml codecs, telemetry consent persistence, telemetry milestone state, --log-file open, gaal.yaml init writes

## Why
On a shared host any local user could previously read MCP env tokens (\`GITHUB_TOKEN\`, \`ANTHROPIC_API_KEY\`), token-bearing URLs persisted to --log-file, and the user's gaal.yaml. \`os.WriteFile\` does not modify perms on existing files, so a one-time tightening pass also runs via the helper's Chmod.

Closes #115.

## Test plan
- [x] Unit tests: new file 0o600, existing loose file tightened (Write + OpenAppend variants), Windows skip
- [x] \`go test ./internal/secfile/ ./internal/mcp/ ./internal/telemetry/ ./internal/logger/ ./internal/engine/...\`
- [x] \`go build\`
- [ ] Reviewer: confirm gaal.yaml at 0o600 is acceptable for the workspace-scope case (user can chmod 644 if they want to commit it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)