### PR TITLE
security: defend hg/svn/bzr against argv-flag injection

### DIFF
--- a/internal/core/vcs/bzr.go
+++ b/internal/core/vcs/bzr.go
@@ -19,6 +19,12 @@ func (b *VcsBazaar) Clone(ctx context.Context, url, path, version string) error 
 	if err := requireBinary("bzr"); err != nil {
 		return err
 	}
+	if err := validateVCSOperand("url", url); err != nil {
+		return err
+	}
+	if err := validateVCSOperand("version", version); err != nil {
+		return err
+	}
 	if err := urlx.ValidateRepoURL(url); err != nil {
 		return err
 	}
@@ -32,13 +38,16 @@ func (b *VcsBazaar) Clone(ctx context.Context, url, path, version string) error 
 	if version != "" {
 		args = append(args, "-r", "tag:"+version)
 	}
-	args = append(args, url, path)
+	args = append(args, "--", url, path)
 
 	return runner.Run(ctx, "branching "+shortPath(path), "", "bzr", args...)
 }
 
 func (b *VcsBazaar) Update(ctx context.Context, path, version string) error {
 	if err := requireBinary("bzr"); err != nil {
+		return err
+	}
+	if err := validateVCSOperand("version", version); err != nil {
 		return err
 	}
 	slog.DebugContext(ctx, "pulling", "path", shortPath(path), "version", version)

--- a/internal/core/vcs/hg.go
+++ b/internal/core/vcs/hg.go
@@ -19,6 +19,12 @@ func (m *VcsMercurial) Clone(ctx context.Context, url, path, version string) err
 	if err := requireBinary("hg"); err != nil {
 		return err
 	}
+	if err := validateVCSOperand("url", url); err != nil {
+		return err
+	}
+	if err := validateVCSOperand("version", version); err != nil {
+		return err
+	}
 	if err := urlx.ValidateRepoURL(url); err != nil {
 		return err
 	}
@@ -32,13 +38,16 @@ func (m *VcsMercurial) Clone(ctx context.Context, url, path, version string) err
 	if version != "" {
 		args = append(args, "-r", version)
 	}
-	args = append(args, url, path)
+	args = append(args, "--", url, path)
 
 	return runner.Run(ctx, "cloning "+shortPath(path), "", "hg", args...)
 }
 
 func (m *VcsMercurial) Update(ctx context.Context, path, version string) error {
 	if err := requireBinary("hg"); err != nil {
+		return err
+	}
+	if err := validateVCSOperand("version", version); err != nil {
 		return err
 	}
 	slog.DebugContext(ctx, "pulling", "path", shortPath(path))

--- a/internal/core/vcs/svn.go
+++ b/internal/core/vcs/svn.go
@@ -19,6 +19,12 @@ func (s *VcsSVN) Clone(ctx context.Context, url, path, version string) error {
 	if err := requireBinary("svn"); err != nil {
 		return err
 	}
+	if err := validateVCSOperand("url", url); err != nil {
+		return err
+	}
+	if err := validateVCSOperand("version", version); err != nil {
+		return err
+	}
 	if err := urlx.ValidateRepoURL(url); err != nil {
 		return err
 	}
@@ -32,13 +38,16 @@ func (s *VcsSVN) Clone(ctx context.Context, url, path, version string) error {
 	if version != "" {
 		args = append(args, "-r", version)
 	}
-	args = append(args, url, path)
+	args = append(args, "--", url, path)
 
 	return runner.Run(ctx, "checkout "+shortPath(path), "", "svn", args...)
 }
 
 func (s *VcsSVN) Update(ctx context.Context, path, version string) error {
 	if err := requireBinary("svn"); err != nil {
+		return err
+	}
+	if err := validateVCSOperand("version", version); err != nil {
 		return err
 	}
 	slog.DebugContext(ctx, "updating", "path", shortPath(path), "version", version)

--- a/internal/core/vcs/util.go
+++ b/internal/core/vcs/util.go
@@ -33,3 +33,22 @@ func shortPath(p string) string {
 	}
 	return strings.Join(parts[len(parts)-2:], "/")
 }
+
+// validateVCSOperand rejects user-controlled subprocess operands (URL, version
+// pin) that begin with "-", which would be parsed as a CLI flag by hg/svn/bzr.
+// Combined with the "--" end-of-options separator on the argv, this defends
+// against flag-injection attacks like:
+//
+//	version: "--config=hooks.preupdate=touch /tmp/pwned"   (hg)
+//	version: "--config-dir=/tmp/evil"                       (svn)
+//
+// kind is used for the error message ("url", "version", etc).
+func validateVCSOperand(kind, value string) error {
+	if value == "" {
+		return nil
+	}
+	if strings.HasPrefix(value, "-") {
+		return fmt.Errorf("%s %q must not start with '-' (would be parsed as a flag)", kind, value)
+	}
+	return nil
+}

--- a/internal/core/vcs/util_test.go
+++ b/internal/core/vcs/util_test.go
@@ -2,8 +2,41 @@ package vcs
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
+
+func TestValidateVCSOperand(t *testing.T) {
+	tests := []struct {
+		name    string
+		kind    string
+		value   string
+		wantErr bool
+	}{
+		{"empty allowed", "version", "", false},
+		{"normal tag", "version", "v1.2.3", false},
+		{"branch with slash", "version", "release/2026", false},
+		{"https url", "url", "https://github.com/owner/repo", false},
+		{"ssh url", "url", "ssh://git@host:22/repo", false},
+		{"flag injection version", "version", "--config=hooks.preupdate=touch /tmp/x", true},
+		{"single dash flag", "version", "-r", true},
+		{"flag injection url", "url", "--config-dir=/tmp/evil", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVCSOperand(tt.kind, tt.value)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), tt.kind) {
+				t.Errorf("error %q should mention kind %q", err.Error(), tt.kind)
+			}
+		})
+	}
+}
 
 func TestRequireBinary_Found(t *testing.T) {
 	if err := requireBinary("go"); err != nil {


### PR DESCRIPTION
## Summary
- New \`validateVCSOperand(kind, value)\` helper in \`internal/core/vcs/util.go\` rejecting any URL/version that starts with \`-\`
- \`hg\` / \`svn\` / \`bzr\` Clone now insert \`--\` between gaal-supplied flags and the user-controlled url/path operands
- \`hg\` / \`svn\` / \`bzr\` Update validates the version

## Why
A YAML config like:

\`\`\`yaml
repositories:
  foo:
    type: hg
    url: https://example.com/r
    version: \"--config=hooks.preupdate=touch /tmp/pwned\"
\`\`\`

previously had hg interpret \`version\` as a config flag, giving arbitrary code execution under the user's UID. Same vector applies to svn (\`--config-dir=\`) and bzr.

Closes #116.

## Test plan
- [x] Table-driven \`TestValidateVCSOperand\`: empty, normal tag, branch with slash, https/ssh URLs, flag-injection version, single-dash flag, flag-injection URL
- [x] \`go test ./internal/core/vcs/\`
- [x] \`go build\`