### PR TITLE
security: enforce URL scheme allowlist for VCS clones and HTTP fetches

### DIFF
--- a/internal/core/vcs/archive.go
+++ b/internal/core/vcs/archive.go
@@ -68,6 +68,9 @@ func (a *VcsArchive) HasChanges(_ context.Context, _ string) (bool, error) {
 
 // fetchURL performs a GET request and returns the response body.
 func fetchURL(ctx context.Context, rawURL string) (io.ReadCloser, error) {
+	if err := urlx.ValidateRemoteFetchURL(rawURL); err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("building request: %w", err)

--- a/internal/core/vcs/bzr.go
+++ b/internal/core/vcs/bzr.go
@@ -19,6 +19,9 @@ func (b *VcsBazaar) Clone(ctx context.Context, url, path, version string) error 
 	if err := requireBinary("bzr"); err != nil {
 		return err
 	}
+	if err := urlx.ValidateRepoURL(url); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("creating parent directory: %w", err)
 	}

--- a/internal/core/vcs/bzr_test.go
+++ b/internal/core/vcs/bzr_test.go
@@ -67,7 +67,7 @@ func TestVcsBazaar_Clone_FakeBin(t *testing.T) {
 	t.Setenv("PATH", binDir)
 	b := &VcsBazaar{}
 	dest := filepath.Join(t.TempDir(), "repo")
-	if err := b.Clone(context.Background(), "http://fake/repo", dest, ""); err != nil {
+	if err := b.Clone(context.Background(), "https://fake.example/repo", dest, ""); err != nil {
 		t.Fatalf("Clone with fake bzr: %v", err)
 	}
 }
@@ -77,7 +77,7 @@ func TestVcsBazaar_Clone_FakeBin_WithVersion(t *testing.T) {
 	t.Setenv("PATH", binDir)
 	b := &VcsBazaar{}
 	dest := filepath.Join(t.TempDir(), "repo")
-	if err := b.Clone(context.Background(), "http://fake/repo", dest, "1"); err != nil {
+	if err := b.Clone(context.Background(), "https://fake.example/repo", dest, "1"); err != nil {
 		t.Fatalf("Clone with fake bzr + version: %v", err)
 	}
 }

--- a/internal/core/vcs/git.go
+++ b/internal/core/vcs/git.go
@@ -33,6 +33,9 @@ func (g *VcsGit) depth() int {
 }
 
 func (g *VcsGit) Clone(ctx context.Context, url, path, version string) error {
+	if err := urlx.ValidateRepoURL(url); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("creating parent directory: %w", err)
 	}

--- a/internal/core/vcs/hg.go
+++ b/internal/core/vcs/hg.go
@@ -19,6 +19,9 @@ func (m *VcsMercurial) Clone(ctx context.Context, url, path, version string) err
 	if err := requireBinary("hg"); err != nil {
 		return err
 	}
+	if err := urlx.ValidateRepoURL(url); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("creating parent directory: %w", err)
 	}

--- a/internal/core/vcs/hg_test.go
+++ b/internal/core/vcs/hg_test.go
@@ -67,7 +67,7 @@ func TestVcsMercurial_Clone_FakeBin(t *testing.T) {
 	t.Setenv("PATH", binDir)
 	m := &VcsMercurial{}
 	dest := filepath.Join(t.TempDir(), "repo")
-	if err := m.Clone(context.Background(), "http://fake/repo", dest, ""); err != nil {
+	if err := m.Clone(context.Background(), "https://fake.example/repo", dest, ""); err != nil {
 		t.Fatalf("Clone with fake hg: %v", err)
 	}
 }
@@ -77,7 +77,7 @@ func TestVcsMercurial_Clone_FakeBin_WithVersion(t *testing.T) {
 	t.Setenv("PATH", binDir)
 	m := &VcsMercurial{}
 	dest := filepath.Join(t.TempDir(), "repo")
-	if err := m.Clone(context.Background(), "http://fake/repo", dest, "tip"); err != nil {
+	if err := m.Clone(context.Background(), "https://fake.example/repo", dest, "tip"); err != nil {
 		t.Fatalf("Clone with fake hg + version: %v", err)
 	}
 }

--- a/internal/core/vcs/svn.go
+++ b/internal/core/vcs/svn.go
@@ -19,6 +19,9 @@ func (s *VcsSVN) Clone(ctx context.Context, url, path, version string) error {
 	if err := requireBinary("svn"); err != nil {
 		return err
 	}
+	if err := urlx.ValidateRepoURL(url); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("creating parent directory: %w", err)
 	}

--- a/internal/core/vcs/svn_test.go
+++ b/internal/core/vcs/svn_test.go
@@ -67,7 +67,7 @@ func TestVcsSVN_Clone_FakeBin(t *testing.T) {
 	t.Setenv("PATH", binDir)
 	s := &VcsSVN{}
 	dest := filepath.Join(t.TempDir(), "repo")
-	if err := s.Clone(context.Background(), "http://fake/repo", dest, ""); err != nil {
+	if err := s.Clone(context.Background(), "https://fake.example/repo", dest, ""); err != nil {
 		t.Fatalf("Clone with fake svn: %v", err)
 	}
 }
@@ -77,7 +77,7 @@ func TestVcsSVN_Clone_FakeBin_WithVersion(t *testing.T) {
 	t.Setenv("PATH", binDir)
 	s := &VcsSVN{}
 	dest := filepath.Join(t.TempDir(), "repo")
-	if err := s.Clone(context.Background(), "http://fake/repo", dest, "HEAD"); err != nil {
+	if err := s.Clone(context.Background(), "https://fake.example/repo", dest, "HEAD"); err != nil {
 		t.Fatalf("Clone with fake svn + version: %v", err)
 	}
 }

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -217,6 +217,9 @@ func (m *Manager) writeMCPSnapshot(target string) {
 // If the remote file is a full mcpServers document the matching key is extracted;
 // otherwise the whole document is treated as a single server entry.
 func fetchRemoteEntry(ctx context.Context, rawURL, name string) (serverEntry, error) {
+	if err := urlx.ValidateRemoteFetchURL(rawURL); err != nil {
+		return serverEntry{}, err
+	}
 	safeURL := urlx.Redact(rawURL)
 	slog.DebugContext(ctx, "fetching remote mcp config", "url", safeURL, "name", name)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)

--- a/internal/urlx/scheme.go
+++ b/internal/urlx/scheme.go
@@ -1,0 +1,124 @@
+package urlx
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ValidateRemoteFetchURL rejects any URL that gaal should not follow over
+// HTTP — used by the MCP and archive fetchers. Allowed schemes are https://
+// for any host, and http:// only when the host is a loopback address (so
+// fixture servers in CI / e2e still work). Plain paths (no scheme) are
+// rejected; this function is for *remote* fetches only.
+//
+// Defends against:
+//   - file:// — exfil / arbitrary local read
+//   - gopher://, dict://, ftp://, etc. — unintended protocols routed through
+//     a permissive transport
+//   - http:// to internal hosts (RFC 1918 / link-local) — SSRF; e.g. AWS IMDS
+//     at 169.254.169.254
+func ValidateRemoteFetchURL(rawurl string) error {
+	if rawurl == "" {
+		return fmt.Errorf("empty url")
+	}
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return fmt.Errorf("parsing url: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHost(u.Host) {
+			return nil
+		}
+		return fmt.Errorf("scheme http:// is only allowed for loopback hosts (got host %q)", u.Host)
+	case "":
+		return fmt.Errorf("url %q is missing a scheme", rawurl)
+	default:
+		return fmt.Errorf("scheme %q is not allowed for remote fetches (allowed: https, http+loopback)", u.Scheme)
+	}
+}
+
+// ValidateRepoURL rejects URLs that VCS clone backends should not follow.
+// It is laxer than ValidateRemoteFetchURL because cloning legitimately uses
+// ssh:// and git:// transports.
+//
+// Allowed:
+//   - https://... (any host)
+//   - ssh://... (any host)
+//   - git://... (any host; deprecated transport but still in use)
+//   - http://... only for loopback hosts (CI fixtures)
+//   - SCP-style git URLs (user@host:path) — common for git remotes
+//   - empty scheme — treated as a local filesystem path (containment is the
+//     responsibility of the caller; see issue #118)
+//
+// Rejected: file://, gopher://, ftp://, dict://, anything else.
+func ValidateRepoURL(rawurl string) error {
+	if rawurl == "" {
+		return fmt.Errorf("empty url")
+	}
+	if isSCPStyleGitURL(rawurl) {
+		return nil
+	}
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return fmt.Errorf("parsing url: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https", "ssh", "git":
+		return nil
+	case "http":
+		if isLoopbackHost(u.Host) {
+			return nil
+		}
+		return fmt.Errorf("scheme http:// is only allowed for loopback hosts (got host %q)", u.Host)
+	case "":
+		// Treated as a local path; #118 enforces workspace containment.
+		return nil
+	default:
+		return fmt.Errorf("scheme %q is not allowed (allowed: https, ssh, git, http+loopback)", u.Scheme)
+	}
+}
+
+// isLoopbackHost reports whether host (without trailing :port) is a loopback
+// address. Accepts "localhost", "127.0.0.0/8", "::1", and bracketed IPv6.
+func isLoopbackHost(hostport string) bool {
+	host := hostport
+	// Strip port if present.
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// isSCPStyleGitURL detects the user@host:path syntax that git accepts in
+// addition to URL forms. It is *not* a URL — net/url misparses it — so we
+// match it heuristically: a single ":" with no "/" before it, and the part
+// before "@" is non-empty.
+func isSCPStyleGitURL(s string) bool {
+	at := strings.Index(s, "@")
+	if at <= 0 {
+		return false
+	}
+	rest := s[at+1:]
+	colon := strings.Index(rest, ":")
+	if colon <= 0 {
+		return false
+	}
+	// Reject if the colon comes after a slash (that's a URL like
+	// "user@example.com/path:other", not SCP form).
+	if strings.Contains(rest[:colon], "/") {
+		return false
+	}
+	return true
+}

--- a/internal/urlx/scheme_test.go
+++ b/internal/urlx/scheme_test.go
@@ -1,0 +1,91 @@
+package urlx
+
+import "testing"
+
+func TestValidateRemoteFetchURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"empty rejected", "", true},
+		{"https ok", "https://github.com/owner/repo.json", false},
+		{"https with creds ok", "https://u:p@github.com/repo.json", false},
+		{"http loopback ok", "http://127.0.0.1:8080/x", false},
+		{"http localhost ok", "http://localhost/x", false},
+		{"http ipv6 loopback ok", "http://[::1]:9000/x", false},
+		{"http public rejected", "http://example.com/x", true},
+		{"http imds rejected (SSRF)", "http://169.254.169.254/latest/meta-data/", true},
+		{"file rejected", "file:///etc/passwd", true},
+		{"gopher rejected", "gopher://example.com/", true},
+		{"dict rejected", "dict://example.com/", true},
+		{"ssh rejected for fetch", "ssh://host/repo", true},
+		{"missing scheme rejected", "github.com/owner/repo", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRemoteFetchURL(tt.in)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %q, got nil", tt.in)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.in, err)
+			}
+		})
+	}
+}
+
+func TestValidateRepoURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"empty rejected", "", true},
+		{"https ok", "https://github.com/owner/repo.git", false},
+		{"ssh ok", "ssh://git@github.com:22/owner/repo.git", false},
+		{"git ok", "git://github.com/owner/repo.git", false},
+		{"http loopback ok", "http://127.0.0.1/repo.git", false},
+		{"http public rejected", "http://example.com/repo.git", true},
+		{"file rejected", "file:///srv/repo.git", true},
+		{"ftp rejected", "ftp://example.com/repo.git", true},
+		{"scp-style git ok", "git@github.com:owner/repo.git", false},
+		{"scp-style with user ok", "alice@host.example:foo/bar", false},
+		{"plain local path ok", "/srv/local/repo", false},
+		{"plain relative path ok", "./local/repo", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRepoURL(tt.in)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %q, got nil", tt.in)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.in, err)
+			}
+		})
+	}
+}
+
+func TestIsSCPStyleGitURL(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"git@github.com:owner/repo.git", true},
+		{"alice@host:path", true},
+		{"https://github.com/owner/repo.git", false},
+		{"ssh://git@host/repo", false},
+		{"@host:path", false},
+		{"host:path", false},
+		{"user@host", false},
+		{"user@host.com/foo:bar", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := isSCPStyleGitURL(tt.in); got != tt.want {
+				t.Errorf("isSCPStyleGitURL(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- New \`internal/urlx\` validators:
  - \`ValidateRepoURL\` — accepts \`https\`, \`ssh\`, \`git\`, \`http\` (loopback only), SCP-style \`git@host:path\`, plain local paths
  - \`ValidateRemoteFetchURL\` — stricter: \`https\` only (\`http\` allowed for loopback)
- Wires \`ValidateRepoURL\` into git/hg/svn/bzr Clone
- Wires \`ValidateRemoteFetchURL\` into archive fetchURL and MCP fetchRemoteEntry
- Updates fake-binary test URLs from \`http://fake/repo\` to \`https://fake.example/repo\` so they survive the new gate

## Why
A YAML config like \`source: file:///root/.ssh\` previously had go-git happily clone arbitrary local paths. \`http://169.254.169.254/...\` (AWS IMDS) and other RFC 1918 / link-local hosts were a classic SSRF vector for the MCP remote fetch path. SCP-style git URLs (\`git@host:path\`) need explicit handling because \`net/url\` misparses them.

Note: redirect-policy hardening (block redirects to internal hosts) is tracked separately under #123 since it's part of the broader HTTP client overhaul (timeouts, body caps, scheme enforcement on redirect targets).

Closes #117.

## Test plan
- [x] Unit tests for both validators (12 + 12 cases) covering empty, https, ssh, git, http loopback/public, file, gopher, dict, ftp, scp-style, plain paths, SSRF (169.254.169.254)
- [x] \`go test ./...\` (all packages green)
- [x] \`go build\`