### PR TITLE
security: reject repo paths that escape workspace root

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -133,8 +133,23 @@ func UserConfigFilePath() string {
 // Load reads and validates a single gaal configuration file.
 // Duplicate skill sources and MCP names within the file are silently
 // deduplicated, keeping the first occurrence.
+//
+// Repository keys are NOT containment-checked here; callers loading a
+// project-scope config should use LoadStrict instead so that a shared YAML
+// cannot clone over arbitrary user-writable paths (~/.ssh, etc.).
 func Load(path string) (*Config, error) {
-	slog.Debug("loading config file", "path", path)
+	return loadOne(path, false)
+}
+
+// LoadStrict is like Load but additionally enforces that every repository
+// path is contained under the config file's directory (i.e. the workspace
+// root). Used for project-scope configs in LoadChain.
+func LoadStrict(path string) (*Config, error) {
+	return loadOne(path, true)
+}
+
+func loadOne(path string, enforceContainment bool) (*Config, error) {
+	slog.Debug("loading config file", "path", path, "enforceContainment", enforceContainment)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
@@ -151,6 +166,12 @@ func Load(path string) (*Config, error) {
 
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	if enforceContainment {
+		if err := cfg.validateRepositoryContainment(); err != nil {
+			return nil, fmt.Errorf("invalid config %s: %w", path, err)
+		}
 	}
 
 	cfg.expandPaths(filepath.Dir(path))
@@ -186,7 +207,15 @@ func LoadChain(workspacePath string) (*ResolvedConfig, error) {
 	loaded := 0
 
 	for _, c := range candidates {
-		cfg, err := Load(c.path)
+		var (
+			cfg *Config
+			err error
+		)
+		if c.scope == ScopeWorkspace {
+			cfg, err = LoadStrict(c.path)
+		} else {
+			cfg, err = Load(c.path)
+		}
 		if errors.Is(err, os.ErrNotExist) {
 			slog.Debug("config file not found, skipping", "path", c.path)
 			continue

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -406,6 +406,9 @@ func TestLoadChain_OnlyWorkspace(t *testing.T) {
 	empty := t.TempDir()
 	t.Setenv("HOME", empty)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(empty, "xdg"))
+	// Use absolute path; bypass containment so this exercise of LoadChain
+	// is independent of the new project-scope strict check.
+	t.Setenv("GAAL_ALLOW_ABSOLUTE_PATHS", "1")
 
 	repoPath := filepath.ToSlash(filepath.Join(t.TempDir(), "testrepo"))
 	p := writeYAML(t, fmt.Sprintf(`
@@ -420,6 +423,23 @@ repositories:
 	}
 	if _, ok := cfg.Repositories[repoPath]; !ok {
 		t.Errorf("expected %q in merged config, got: %v", repoPath, repoKeys(cfg.Config))
+	}
+}
+
+func TestLoadChain_WorkspaceRejectsAbsoluteRepoPath(t *testing.T) {
+	empty := t.TempDir()
+	t.Setenv("HOME", empty)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(empty, "xdg"))
+	t.Setenv("GAAL_ALLOW_ABSOLUTE_PATHS", "")
+
+	p := writeYAML(t, `
+repositories:
+  /home/victim/.ssh:
+    type: git
+    url: https://example.com/evil.git
+`)
+	if _, err := LoadChain(p); err == nil {
+		t.Fatal("expected LoadChain to reject absolute repo path in workspace config, got nil")
 	}
 }
 

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,6 +54,41 @@ func isGitHubShorthand(s string) bool {
 		return false
 	}
 	return len(strings.Split(s, "/")) == 2
+}
+
+// validateRepositoryContainment rejects repository keys that escape the
+// workspace root via an absolute path, "..", or "~/" prefix. This prevents a
+// shared / public gaal.yaml from clobbering arbitrary user-writable paths
+// (e.g. ~/.ssh) on first sync. Only applied to project-scope configs
+// (LoadStrict); global/user configs legitimately use absolute paths.
+//
+// Set GAAL_ALLOW_ABSOLUTE_PATHS=1 to bypass when needed.
+func (c *Config) validateRepositoryContainment() error {
+	if os.Getenv("GAAL_ALLOW_ABSOLUTE_PATHS") == "1" {
+		return nil
+	}
+	for key := range c.Repositories {
+		if err := checkRepoPathContained(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkRepoPathContained rejects keys that look like an attempt to escape the
+// workspace dir. Returns nil on safe keys.
+func checkRepoPathContained(key string) error {
+	if filepath.IsAbs(key) || strings.HasPrefix(key, "/") {
+		return fmt.Errorf("repository path %q is absolute; refusing to clone outside the workspace (set GAAL_ALLOW_ABSOLUTE_PATHS=1 to bypass)", key)
+	}
+	if strings.HasPrefix(key, "~/") || strings.HasPrefix(key, `~\`) {
+		return fmt.Errorf("repository path %q starts with ~ (home directory); refusing to clone outside the workspace (set GAAL_ALLOW_ABSOLUTE_PATHS=1 to bypass)", key)
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(key))
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return fmt.Errorf("repository path %q escapes the workspace via '..'; refusing (set GAAL_ALLOW_ABSOLUTE_PATHS=1 to bypass)", key)
+	}
+	return nil
 }
 
 // expandPaths expands ~ and relative paths in c, while leaving remote URLs and

--- a/internal/config/utils_test.go
+++ b/internal/config/utils_test.go
@@ -242,3 +242,52 @@ func TestIsGitHubShorthand(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// validateRepositoryContainment / checkRepoPathContained
+// ---------------------------------------------------------------------------
+
+func TestCheckRepoPathContained(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{"plain relative", "src/myrepo", false},
+		{"dot relative", "./src/myrepo", false},
+		{"nested relative", "a/b/c", false},
+		{"absolute unix", "/home/victim/.ssh", true},
+		{"home tilde posix", "~/.ssh", true},
+		{"home tilde windows", `~\Users`, true},
+		{"parent traversal", "../../etc", true},
+		{"parent only", "..", true},
+		{"parent inside is fine", "src/../sibling", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkRepoPathContained(tt.key)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %q, got nil", tt.key)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.key, err)
+			}
+		})
+	}
+}
+
+func TestValidateRepositoryContainment_EnvBypass(t *testing.T) {
+	c := &Config{Repositories: map[string]ConfigRepo{"/abs/path": {Type: "git", URL: "https://x"}}}
+	t.Setenv("GAAL_ALLOW_ABSOLUTE_PATHS", "1")
+	if err := c.validateRepositoryContainment(); err != nil {
+		t.Errorf("expected bypass via env, got %v", err)
+	}
+}
+
+func TestValidateRepositoryContainment_RejectsByDefault(t *testing.T) {
+	c := &Config{Repositories: map[string]ConfigRepo{"/home/victim/.ssh": {Type: "git", URL: "https://x"}}}
+	t.Setenv("GAAL_ALLOW_ABSOLUTE_PATHS", "")
+	if err := c.validateRepositoryContainment(); err == nil {
+		t.Error("expected containment error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- New \`LoadStrict\` entry point wraps \`Load\` and additionally enforces \`validateRepositoryContainment\`
- \`LoadChain\` calls \`LoadStrict\` only for the workspace-scope file; global/user configs continue to use lax \`Load\`
- Rejected repo key shapes: absolute paths, \`..\` traversal, \`~/\` and \`~\\\` home-anchored
- \`GAAL_ALLOW_ABSOLUTE_PATHS=1\` bypasses for power users

## Why
A shared / public \`gaal.yaml\` could previously do:

\`\`\`yaml
repositories:
  /home/victim/.ssh:
    type: git
    url: https://attacker.example/evil.git
\`\`\`

and \`gaal sync\` would clone over \`~/.ssh\` on first run. Now this is rejected at config-load time with an actionable error.

Note: MCP \`target:\` paths legitimately point to \`~/.claude.json\` etc and are not constrained — they go through \`expandPaths\`. The threat model is repo paths under user-shared workspace YAML.

Closes #118.

## Test plan
- [x] Unit tests for \`checkRepoPathContained\` (plain rel, ./, nested, /abs, ~/.ssh, ~\\, ../../, .., src/../sibling)
- [x] \`TestValidateRepositoryContainment_EnvBypass\` and \`TestValidateRepositoryContainment_RejectsByDefault\`
- [x] New \`TestLoadChain_WorkspaceRejectsAbsoluteRepoPath\`
- [x] Existing \`TestLoadChain_OnlyWorkspace\` updated to opt-in via env (preserved as smoke for legitimate-bypass case)
- [x] \`go test ./...\` — all packages green