### PR TITLE
security: doctor honors engine WorkDir (no os.Getwd leak under --sandbox)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -274,5 +274,8 @@ func (e *Engine) Migrate(target, url string, dryRun bool) (*ops.MigrateResult, e
 
 // Doctor runs sanity checks and returns a diagnostic report.
 func (e *Engine) Doctor(opts ops.DoctorOptions) *ops.DoctorReport {
+	if opts.WorkDir == "" {
+		opts.WorkDir = e.workDir
+	}
 	return ops.RunDoctor(e.cfg, opts)
 }

--- a/internal/engine/ops/doctor.go
+++ b/internal/engine/ops/doctor.go
@@ -55,20 +55,30 @@ type DoctorReport struct {
 type DoctorOptions struct {
 	Offline bool
 	Levels  config.LevelConfigs // individual config levels before merging
+	// WorkDir is the workspace root used for project-scope agent detection.
+	// Required so --sandbox redirection is honored — caller must pass
+	// engine.Engine.workDir; falling back to os.Getwd() would leak the
+	// real shell cwd through the sandbox.
+	WorkDir string
 }
 
 // RunDoctor executes all sanity checks against the given config and returns
 // a structured report. Exit code: 0 = clean, 1 = warnings only, 2 = any errors.
 func RunDoctor(cfg *config.Config, opts DoctorOptions) *DoctorReport {
-	slog.Debug("running doctor checks", "offline", opts.Offline)
+	slog.Debug("running doctor checks", "offline", opts.Offline, "workDir", opts.WorkDir)
+
+	if opts.WorkDir == "" {
+		// Defensive default for direct callers (tests). Engine always sets it.
+		opts.WorkDir, _ = os.Getwd()
+	}
 
 	var findings []Finding
 	findings = append(findings, checkSchema(opts.Levels, cfg.Schema)...)
 	findings = append(findings, checkTelemetry(cfg)...)
-	findings = append(findings, checkSkillSources(cfg, opts.Offline)...)
+	findings = append(findings, checkSkillSources(cfg, opts.Offline, opts.WorkDir)...)
 	findings = append(findings, checkMCPTargets(cfg)...)
 	findings = append(findings, checkTools(cfg)...)
-	findings = append(findings, checkAgents()...)
+	findings = append(findings, checkAgents(opts.WorkDir)...)
 
 	exitCode := 0
 	for _, f := range findings {
@@ -169,7 +179,7 @@ func checkTelemetry(cfg *config.Config) []Finding {
 }
 
 // checkSkillSources validates each configured skill source.
-func checkSkillSources(cfg *config.Config, offline bool) []Finding {
+func checkSkillSources(cfg *config.Config, offline bool, workDir string) []Finding {
 	var findings []Finding
 
 	// Check for duplicate sources.
@@ -190,7 +200,7 @@ func checkSkillSources(cfg *config.Config, offline bool) []Finding {
 	for _, sk := range cfg.Skills {
 		// Warn on agents:["*"] with zero detected agents.
 		if len(sk.Agents) == 1 && sk.Agents[0] == "*" {
-			if countInstalledAgents() == 0 {
+			if countInstalledAgents(workDir) == 0 {
 				findings = append(findings, Finding{
 					Section:  "skills",
 					Severity: SeverityWarning,
@@ -281,8 +291,8 @@ func checkMCPTargets(cfg *config.Config) []Finding {
 }
 
 // checkAgents counts installed agents and reports as info.
-func checkAgents() []Finding {
-	count := countInstalledAgents()
+func checkAgents(workDir string) []Finding {
+	count := countInstalledAgents(workDir)
 	return []Finding{
 		{Section: "agents", Severity: SeverityInfo, Message: fmt.Sprintf("%d agent(s) detected", count)},
 	}
@@ -346,15 +356,16 @@ func checkRemoteReachable(url string) error {
 }
 
 // countInstalledAgents returns the number of agents currently installed on this
-// machine, using agent.Names() and skill.IsAgentInstalled().
-func countInstalledAgents() int {
+// machine, using agent.Names() and skill.IsAgentInstalled(). workDir is the
+// workspace root used for project-scope detection (must be the engine's
+// configured WorkDir so --sandbox redirection is honored).
+func countInstalledAgents(workDir string) int {
 	home, _ := os.UserHomeDir()
-	wd, _ := os.Getwd()
 
 	count := 0
 	for _, name := range agent.Names() {
-		if skill.IsAgentInstalled(name, true, home, wd) ||
-			skill.IsAgentInstalled(name, false, home, wd) {
+		if skill.IsAgentInstalled(name, true, home, workDir) ||
+			skill.IsAgentInstalled(name, false, home, workDir) {
 			count++
 		}
 	}

--- a/internal/engine/ops/doctor_test.go
+++ b/internal/engine/ops/doctor_test.go
@@ -551,3 +551,35 @@ func TestDoctorTools_PerSkillAttribution(t *testing.T) {
 		t.Errorf("message lacks skill attribution: %q", got[0].Message)
 	}
 }
+
+// TestCountInstalledAgents_HonorsWorkDir asserts that countInstalledAgents
+// uses the workDir argument and not os.Getwd, so --sandbox redirection is
+// effective. Regression for #119: the old implementation called os.Getwd
+// internally, leaking the real shell cwd through a sandboxed doctor run.
+func TestCountInstalledAgents_HonorsWorkDir(t *testing.T) {
+	// Isolate HOME so global-installed agents don't pollute the count.
+	isolatedHome := t.TempDir()
+	t.Setenv("HOME", isolatedHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(isolatedHome, ".config"))
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", isolatedHome)
+		t.Setenv("APPDATA", filepath.Join(isolatedHome, "AppData"))
+		t.Setenv("LOCALAPPDATA", filepath.Join(isolatedHome, "AppData", "Local"))
+	}
+
+	emptyWork := t.TempDir()
+	emptyCount := countInstalledAgents(emptyWork)
+
+	populatedWork := t.TempDir()
+	// Create the parent dir of claude-code's project skill dir
+	// (.claude/skills → check is for .claude existing).
+	if err := os.MkdirAll(filepath.Join(populatedWork, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	populatedCount := countInstalledAgents(populatedWork)
+
+	if populatedCount <= emptyCount {
+		t.Errorf("workDir with .claude/ should detect more agents than empty workDir; got empty=%d populated=%d (workDir not honored?)",
+			emptyCount, populatedCount)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds \`WorkDir\` field to \`ops.DoctorOptions\`
- Threads it through \`checkSkillSources\`, \`checkAgents\`, \`countInstalledAgents\`
- \`Engine.Doctor\` populates \`opts.WorkDir = e.workDir\` so existing callers don't need to change
- Replaces the in-line \`os.Getwd()\` call inside \`countInstalledAgents\`

## Why
\`countInstalledAgents\` previously called \`os.Getwd()\` internally. Under \`gaal --sandbox /tmp/sb doctor\`, that returns the shell's actual cwd (the real workspace), so agents detected via the user's real \`~/work/...\` leaked into the sandboxed agent count.

## Test plan
- [x] New \`TestCountInstalledAgents_HonorsWorkDir\` proves the workDir argument is actually used: empty workDir A and a workDir B containing \`.claude/\` produce different agent counts. Isolates HOME so global agents don't pollute the count.
- [x] \`go test ./...\` (all green)
- [x] \`go build\`

## Scope note
The other two gaps from #119 (go-git config files reading from sandboxed \$HOME, \`os.UserCacheDir\` behavior on macOS) require an end-to-end sandbox test in \`test/e2e/\` — tracked separately by #145. This PR closes the \`os.Getwd\` leak only.