### PR TITLE
fix(cmd): replace os.Exit with ExitCodeError so PostRun cleanup runs

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -77,7 +77,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	}
 
 	if report.ExitCode != 0 {
-		os.Exit(report.ExitCode)
+		return &ExitCodeError{Code: report.ExitCode}
 	}
 	return nil
 }
@@ -364,7 +364,7 @@ func renderDoctorJSON(report *ops.DoctorReport, showUpsell bool) error {
 		return err
 	}
 	if report.ExitCode != 0 {
-		os.Exit(report.ExitCode)
+		return &ExitCodeError{Code: report.ExitCode}
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +17,26 @@ import (
 	"gaal/internal/logger"
 	"gaal/internal/telemetry"
 )
+
+// ExitCodeError carries a process exit code separate from the error's
+// human-readable message. RunE handlers return one of these when a command
+// needs an exit code other than the cobra default (0 on nil, 1 on any error).
+//
+// Returning an error skips PersistentPostRunE (cobra design), so cleanup that
+// must happen on every code path lives in Execute() instead.
+type ExitCodeError struct {
+	Code  int
+	Cause error
+}
+
+func (e *ExitCodeError) Error() string {
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return fmt.Sprintf("exit %d", e.Code)
+}
+
+func (e *ExitCodeError) Unwrap() error { return e.Cause }
 
 var (
 	cfgFile      string
@@ -45,6 +66,10 @@ configurations.
 
 Run once (one-shot mode) or continuously as a service with --service.`,
 	SilenceUsage: true,
+	// Silence cobra's own "Error:" print so that ExitCodeError without a Cause
+	// (used purely to set the process exit code) does not leak "Error: exit N"
+	// onto stderr. Execute() prints the error itself when a Cause is present.
+	SilenceErrors: true,
 	// PersistentPreRunE runs before every sub-command (sync, status, …) and
 	// before RunE on the root command itself. It is the single place where the
 	// logger, banner and sandbox are initialised so no sub-command needs to repeat it.
@@ -115,11 +140,30 @@ Run once (one-shot mode) or continuously as a service with --service.`,
 }
 
 // Execute is the entry-point called by main.
+//
+// Cobra's PersistentPostRunE is skipped when RunE returns an error, so the
+// telemetry consent/shutdown cleanup happens here unconditionally to avoid
+// dropping in-flight events or losing freshly-granted consent.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		telemetry.Shutdown()
-		os.Exit(1)
+	err := rootCmd.Execute()
+	if flushErr := telemetry.FlushConsent(); flushErr != nil {
+		slog.Warn("failed to persist telemetry consent", "err", flushErr)
 	}
+	telemetry.Shutdown()
+	if err == nil {
+		return
+	}
+	var exitErr *ExitCodeError
+	if errors.As(err, &exitErr) {
+		// Only print when there's a real underlying cause; bare exit-code
+		// errors are control-flow only.
+		if exitErr.Cause != nil {
+			fmt.Fprintln(os.Stderr, "Error:", exitErr.Cause.Error())
+		}
+		os.Exit(exitErr.Code)
+	}
+	fmt.Fprintln(os.Stderr, "Error:", err.Error())
+	os.Exit(1)
 }
 
 func init() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -138,3 +138,23 @@ func TestSkipTelemetry(t *testing.T) {
 		})
 	}
 }
+
+// TestExitCodeError_ErrorString covers both shapes: with a Cause it returns the
+// cause's message; bare it returns "exit N" (used purely as control flow).
+func TestExitCodeError_ErrorString(t *testing.T) {
+	bare := &ExitCodeError{Code: 2}
+	if got := bare.Error(); got != "exit 2" {
+		t.Errorf("bare Error() = %q, want %q", got, "exit 2")
+	}
+	wrapped := &ExitCodeError{Code: 2, Cause: errStub("underlying")}
+	if got := wrapped.Error(); got != "underlying" {
+		t.Errorf("wrapped Error() = %q, want %q", got, "underlying")
+	}
+	if wrapped.Unwrap() == nil {
+		t.Error("Unwrap() = nil, want non-nil")
+	}
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -73,16 +73,16 @@ func runSync(_ *cobra.Command, _ []string) error {
 		plan, err := eng.DryRun(ctx, format)
 		if err != nil {
 			telemetry.TrackError("sync", err)
-			os.Exit(2)
+			return &ExitCodeError{Code: 2, Cause: err}
 		}
 		telemetry.Track("sync-dry-run")
 		if plan.HasErrors {
-			os.Exit(2)
+			return &ExitCodeError{Code: 2}
 		}
 		if plan.HasChanges {
-			os.Exit(1)
+			return &ExitCodeError{Code: 1}
 		}
-		os.Exit(0)
+		return nil
 	}
 
 	if service {


### PR DESCRIPTION
## Summary
- New \`cmd.ExitCodeError\` (Code + optional Cause + Unwrap)
- \`cmd/sync.go\` dry-run path returns \`ExitCodeError\` instead of \`os.Exit(0|1|2)\`
- \`cmd/doctor.go\` (text + JSON renderers) returns \`ExitCodeError\` instead of \`os.Exit(report.ExitCode)\`
- \`Execute()\` runs telemetry \`FlushConsent\` + \`Shutdown\` unconditionally and translates \`ExitCodeError\` to the right exit code
- Root command gets \`SilenceErrors: true\` so bare ExitCodeError control-flow values don't leak \"Error: exit N\" to stderr; \`Execute()\` handles error printing itself when a Cause is present

## Why
Cobra skips \`PersistentPostRunE\` when \`RunE\` returns an error or when the command calls \`os.Exit\` directly. The previous code lost telemetry consent that was granted in the same invocation (next run re-prompted) and dropped in-flight Plausible \`Track\` goroutines mid-request.

Closes #109.

## Test plan
- [x] New \`TestExitCodeError_ErrorString\` covers bare-vs-wrapped Error() output and Unwrap
- [x] \`go test ./...\` (all packages green)
- [x] \`go build\`
- [ ] Reviewer: confirm \`gaal sync --dry-run\` exit codes still match the documented contract (0 clean, 1 changes, 2 errors)