### PR TITLE
fix(sync): aggregate per-entry errors instead of aborting on the first

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -151,7 +152,7 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 
 	if len(errs) > 0 {
 		slog.Error("sync completed with errors", "errors", len(errs))
-		return fmt.Errorf("sync errors: %v", errs)
+		return errors.Join(errs...)
 	}
 
 	slog.Debug("sync completed successfully")
@@ -197,10 +198,7 @@ func (e *Engine) Prune(ctx context.Context) error {
 	if err := e.mcps.Prune(ctx); err != nil {
 		errs = append(errs, fmt.Errorf("mcps prune: %w", err))
 	}
-	if len(errs) > 0 {
-		return fmt.Errorf("prune errors: %v", errs)
-	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // Collect gathers the current status of all resources without side effects.

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -151,14 +152,18 @@ func (m *Manager) warnLegacyClaudeDesktopJSON() {
 		"hint", "Claude Code now writes ~/.claude.json; Claude Desktop uses ~/Library/Application Support/Claude/")
 }
 
-// Sync applies every MCP configuration entry.
+// Sync applies every MCP configuration entry. A failure on one entry does not
+// abort the rest — every entry is attempted, and the per-entry errors are
+// joined via errors.Join so callers can inspect each underlying cause via
+// errors.As / errors.Is.
 func (m *Manager) Sync(ctx context.Context) error {
+	var errs []error
 	for _, mc := range m.resolvedMCPs() {
 		if err := m.syncOne(ctx, mc); err != nil {
-			return fmt.Errorf("mcp %q: %w", mc.Name, err)
+			errs = append(errs, fmt.Errorf("mcp %q: %w", mc.Name, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (m *Manager) syncOne(ctx context.Context, mc config.ConfigMcp) error {

--- a/internal/repo/manager.go
+++ b/internal/repo/manager.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -60,10 +61,7 @@ func (m *Manager) Sync(ctx context.Context) error {
 		errs = append(errs, err)
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("%d repository error(s): %v", len(errs), errs)
-	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (m *Manager) syncOne(ctx context.Context, path string, cfg config.ConfigRepo) error {

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -122,15 +122,19 @@ func (m *Manager) SourcePaths() []string {
 	return out
 }
 
-// Sync installs or updates every skill in the configuration.
+// Sync installs or updates every skill in the configuration. A failure on one
+// source does not abort the rest — every entry is attempted, and the
+// per-entry errors are joined via errors.Join so callers can inspect each
+// underlying cause via errors.As / errors.Is.
 func (m *Manager) Sync(ctx context.Context) error {
 	m.emitConfigWarnings()
+	var errs []error
 	for _, sc := range m.skills {
 		if err := m.syncOne(ctx, sc); err != nil {
-			return fmt.Errorf("skill %q: %w", sc.Source, err)
+			errs = append(errs, fmt.Errorf("skill %q: %w", sc.Source, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // emitConfigWarnings surfaces issues that depend on the user's skill config
@@ -185,7 +189,10 @@ func (m *Manager) syncOne(ctx context.Context, sc config.ConfigSkill) error {
 	agents := m.syncAgents(sc)
 	slog.DebugContext(ctx, "resolved sync agents", "source", sc.Source, "agents", agents)
 
-	// 5. Install each skill to each agent.
+	// 5. Install each skill to each agent. Per-agent and per-skill errors are
+	//    accumulated so a single failure (e.g. one agent's dir is read-only)
+	//    does not skip every later install.
+	var errs []error
 	for _, agent := range agents {
 		skillsDir, ok := SkillDir(agent, sc.Global, m.home)
 		if !ok {
@@ -200,20 +207,22 @@ func (m *Manager) syncOne(ctx context.Context, sc config.ConfigSkill) error {
 
 		// Create the skills directory if it does not exist yet.
 		if err := os.MkdirAll(skillsDir, 0o755); err != nil {
-			return fmt.Errorf("creating skills dir for agent %q: %w", agent, err)
+			errs = append(errs, fmt.Errorf("creating skills dir for agent %q: %w", agent, err))
+			continue
 		}
 
 		for _, sk := range selected {
 			dest := filepath.Join(skillsDir, filepath.Base(sk.Dir))
 			if err := installSkill(sk.Dir, dest); err != nil {
-				return fmt.Errorf("installing skill %q to agent %q: %w", sk.Name, agent, err)
+				errs = append(errs, fmt.Errorf("installing skill %q to agent %q: %w", sk.Name, agent, err))
+				continue
 			}
 			slog.Debug("installed skill", "name", sk.Name, "agent", agent, "dest", dest)
 			m.writeSkillSnapshot(dest)
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // resolveSource ensures the source is available locally and returns its path.

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -995,3 +995,52 @@ func TestEmitConfigWarnings_FiresOncePerManager(t *testing.T) {
 		t.Errorf("expected warning to fire exactly once, fired %d times", count)
 	}
 }
+
+// TestManager_Sync_AggregatesErrorsAcrossSources is a regression for #110:
+// before the fix, the first failing source aborted the loop; later sources
+// were silently skipped. Now, per-source failures are accumulated via
+// errors.Join and every source is attempted.
+//
+// Setup: workDir points at a regular file, so any MkdirAll for a
+// project-scope skills dir fails. Two sources each carry a valid skill that
+// targets the "claude-code" agent. Both should fail the same way; the
+// aggregated error must mention both source paths to prove the loop did not
+// bail after the first failure.
+func TestManager_Sync_AggregatesErrorsAcrossSources(t *testing.T) {
+	tmp := t.TempDir()
+	workDirAsFile := filepath.Join(tmp, "not-a-dir")
+	if err := os.WriteFile(workDirAsFile, []byte("file"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	mkSource := func(name string) string {
+		root := filepath.Join(tmp, name)
+		skillDir := filepath.Join(root, name)
+		os.MkdirAll(skillDir, 0o755)
+		os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+			[]byte("---\nname: "+name+"\n---\n"), 0o644)
+		return root
+	}
+	sourceA := mkSource("source-a")
+	sourceB := mkSource("source-b")
+
+	// Force the project-scope MkdirAll path: agents:["claude-code"] with
+	// global=false uses workDir/<.claude/skills>. The "force" flag at the
+	// end bypasses the IsAgentInstalled gate.
+	skills := []config.ConfigSkill{
+		{Source: sourceA, Agents: []string{"claude-code"}},
+		{Source: sourceB, Agents: []string{"claude-code"}},
+	}
+	m := NewManager(skills, t.TempDir(), tmp, workDirAsFile, "", true)
+
+	err := m.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected aggregated error from MkdirAll failure on both sources, got nil")
+	}
+	if !strings.Contains(err.Error(), sourceA) {
+		t.Errorf("aggregated error must reference source A; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), sourceB) {
+		t.Errorf("aggregated error must reference source B (proves loop continued past A); got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- \`skill.Manager.Sync\` iterates all sources; per-source errors collected via \`errors.Join\`
- \`skill.Manager.syncOne\` accumulates per-agent + per-skill errors instead of returning on the first
- \`mcp.Manager.Sync\` iterates all entries; per-entry errors collected via \`errors.Join\`
- \`engine.Engine.RunOnce\` and \`engine.Engine.Prune\` use \`errors.Join\` (replacing \`fmt.Errorf(\"...: %v\", errs)\`)
- \`repo.Manager.Sync\` uses \`errors.Join\` (was already iterating fully via goroutines)

## Why
A single typo or transient network failure on an early skill / MCP entry previously masked every later entry. Combined with non-atomic skill installs (#121) and non-atomic MCP writes (#120), partial state could persist across runs without any signal to the user. The new behavior preserves \`errors.Is\` / \`errors.As\` so callers can inspect each underlying cause.

Closes #110.

## Test plan
- [x] New \`TestManager_Sync_AggregatesErrorsAcrossSources\`: two sources both targeting a workDir-rooted MkdirAll path that fails (workDir is a regular file). Asserts both source paths appear in the joined error string, proving the loop continued past the first failure.
- [x] \`go test ./...\` (all packages green)
- [x] \`go build\`