### PR TITLE
security(vcs): harden archive extraction against tar/zip slip + bombs

### DIFF
--- a/internal/core/vcs/archive.go
+++ b/internal/core/vcs/archive.go
@@ -3,10 +3,13 @@ package vcs
 import (
 	"archive/tar"
 	"archive/zip"
+	"bufio"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -20,6 +23,28 @@ type VcsArchive struct {
 	Format string // "tar" or "zip"
 }
 
+// Resource limits applied during extraction. These defend against zip/tar
+// bombs and malicious archives whose stated entry list dwarfs the user's
+// disk. The values are deliberately generous enough for realistic skill /
+// repo bundles but tight enough to fail fast on adversarial inputs.
+const (
+	// MaxArchiveBytes caps the raw network body we will buffer or stream.
+	MaxArchiveBytes int64 = 1 << 30 // 1 GiB
+
+	// MaxFileBytes caps the decompressed size of any single entry. This is
+	// the primary defense against gzip bombs (a 1 KiB tar.gz that expands
+	// to many GiB of zeros).
+	MaxFileBytes int64 = 256 << 20 // 256 MiB
+
+	// MaxEntryCount caps the number of entries we will process. Defends
+	// against archives that exhaust inodes / process limits with millions
+	// of empty files.
+	MaxEntryCount = 50_000
+)
+
+// errEntryTooLarge is returned when an archive entry exceeds MaxFileBytes.
+var errEntryTooLarge = errors.New("archive entry exceeds per-file size cap")
+
 func (a *VcsArchive) Clone(ctx context.Context, url, path, version string) error {
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return fmt.Errorf("creating target directory: %w", err)
@@ -31,11 +56,15 @@ func (a *VcsArchive) Clone(ctx context.Context, url, path, version string) error
 	}
 	defer data.Close()
 
+	// Cap the raw body up front so that zip-buffer-to-tempfile and tar
+	// streaming both inherit the limit without needing per-format wiring.
+	limited := io.LimitReader(data, MaxArchiveBytes+1)
+
 	switch a.Format {
 	case "tar":
-		return extractTar(data, path, version)
+		return extractTar(limited, path, version)
 	case "zip":
-		return extractZip(data, path, version)
+		return extractZip(limited, path, version)
 	default:
 		return fmt.Errorf("unsupported archive format: %q", a.Format)
 	}
@@ -84,19 +113,23 @@ func fetchURL(ctx context.Context, rawURL string) (io.ReadCloser, error) {
 }
 
 func extractTar(r io.Reader, dest, stripPrefix string) error {
-	gr, err := gzip.NewReader(r)
-	if err != nil {
-		// Try plain tar (no gzip).
-		gr = nil
+	// Detect gzip non-destructively: peek the first two bytes for the magic
+	// (1F 8B) instead of letting gzip.NewReader consume them on a non-gzip
+	// stream (which would leave tar.NewReader with a truncated source).
+	br := bufio.NewReader(r)
+	magic, _ := br.Peek(2)
+	var src io.Reader = br
+	if len(magic) == 2 && magic[0] == 0x1f && magic[1] == 0x8b {
+		gr, err := gzip.NewReader(br)
+		if err != nil {
+			return fmt.Errorf("opening gzip: %w", err)
+		}
+		defer gr.Close()
+		src = gr
 	}
 
-	var tr *tar.Reader
-	if gr != nil {
-		tr = tar.NewReader(gr)
-	} else {
-		tr = tar.NewReader(r)
-	}
-
+	tr := tar.NewReader(src)
+	entries := 0
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -105,8 +138,15 @@ func extractTar(r io.Reader, dest, stripPrefix string) error {
 		if err != nil {
 			return fmt.Errorf("reading tar: %w", err)
 		}
+		entries++
+		if entries > MaxEntryCount {
+			return fmt.Errorf("archive exceeds entry-count cap (%d)", MaxEntryCount)
+		}
 
-		target := archiveEntryPath(hdr.Name, dest, stripPrefix)
+		target, err := archiveEntryPath(hdr.Name, dest, stripPrefix)
+		if err != nil {
+			return err
+		}
 		if target == "" {
 			continue
 		}
@@ -117,16 +157,25 @@ func extractTar(r io.Reader, dest, stripPrefix string) error {
 				return err
 			}
 		case tar.TypeReg:
-			if err := writeFile(tr, target, hdr.FileInfo().Mode()); err != nil {
+			if err := writeFileLimited(tr, target, hdr.FileInfo().Mode(), MaxFileBytes); err != nil {
 				return err
 			}
+		default:
+			// Reject symlinks, hardlinks, devices, FIFOs, sockets and the
+			// PAX-extended types. Allowing TypeSymlink in particular would
+			// re-enable the classic "symlink-then-overwrite-symlink-target"
+			// race; the safer and simpler thing is to drop them with a warn.
+			slog.Warn("archive: skipping entry with disallowed type",
+				"name", hdr.Name, "typeflag", hdr.Typeflag)
 		}
 	}
 	return nil
 }
 
 func extractZip(r io.Reader, dest, stripPrefix string) error {
-	// zip.NewReader needs io.ReaderAt; buffer to a temp file.
+	// zip.NewReader needs io.ReaderAt; buffer to a temp file. The body was
+	// already wrapped in LimitReader(MaxArchiveBytes+1) by the caller; if we
+	// hit that limit, abort.
 	tmp, err := os.CreateTemp("", "gaal-zip-*")
 	if err != nil {
 		return err
@@ -138,15 +187,33 @@ func extractZip(r io.Reader, dest, stripPrefix string) error {
 	if err != nil {
 		return fmt.Errorf("buffering zip: %w", err)
 	}
+	if size > MaxArchiveBytes {
+		return fmt.Errorf("archive exceeds size cap (%d bytes)", MaxArchiveBytes)
+	}
 
 	zr, err := zip.NewReader(tmp, size)
 	if err != nil {
 		return fmt.Errorf("opening zip: %w", err)
 	}
 
+	if len(zr.File) > MaxEntryCount {
+		return fmt.Errorf("archive exceeds entry-count cap (%d)", MaxEntryCount)
+	}
+
 	for _, f := range zr.File {
-		target := archiveEntryPath(f.Name, dest, stripPrefix)
+		target, err := archiveEntryPath(f.Name, dest, stripPrefix)
+		if err != nil {
+			return err
+		}
 		if target == "" {
+			continue
+		}
+
+		// Skip non-regular entries explicitly. Zip's symlinks (encoded via
+		// extra-fields) and devices have no business in a skill bundle.
+		if !f.FileInfo().Mode().IsRegular() && !f.FileInfo().IsDir() {
+			slog.Warn("archive: skipping zip entry with disallowed mode",
+				"name", f.Name, "mode", f.Mode())
 			continue
 		}
 
@@ -161,7 +228,7 @@ func extractZip(r io.Reader, dest, stripPrefix string) error {
 		if err != nil {
 			return err
 		}
-		writeErr := writeFile(rc, target, f.Mode())
+		writeErr := writeFileLimited(rc, target, f.Mode(), MaxFileBytes)
 		rc.Close()
 		if writeErr != nil {
 			return writeErr
@@ -171,37 +238,75 @@ func extractZip(r io.Reader, dest, stripPrefix string) error {
 }
 
 // archiveEntryPath converts an archive entry name to its destination path,
-// optionally stripping stripPrefix.
-func archiveEntryPath(name, dest, stripPrefix string) string {
-	// Prevent path traversal.
-	name = filepath.Clean(name)
-	if strings.HasPrefix(name, "..") {
-		return ""
+// optionally stripping stripPrefix. Returns ("", nil) for benign entries that
+// should be skipped (root, "."), and ("", err) for malicious entries that
+// attempt to escape dest.
+//
+// Containment is enforced via filepath.Rel + HasPrefix, not just a leading
+// "..": that would miss absolute paths and Windows-separator tricks where
+// filepath.Clean only normalises with the OS-native separator.
+func archiveEntryPath(name, dest, stripPrefix string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+	// Reject absolute paths in archive entries (POSIX or Windows-rooted).
+	if filepath.IsAbs(name) || strings.HasPrefix(name, "/") || strings.HasPrefix(name, `\`) {
+		return "", fmt.Errorf("archive entry %q has an absolute path", name)
+	}
+
+	cleaned := filepath.Clean(name)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) ||
+		strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("archive entry %q escapes via ..", name)
 	}
 
 	if stripPrefix != "" {
-		rel, err := filepath.Rel(stripPrefix, name)
+		rel, err := filepath.Rel(stripPrefix, cleaned)
 		if err != nil || strings.HasPrefix(rel, "..") {
-			return ""
+			return "", nil
 		}
-		name = rel
+		cleaned = rel
 	} else {
 		// Strip the first path component (common archive convention).
-		parts := strings.SplitN(name, string(filepath.Separator), 2)
+		parts := strings.SplitN(cleaned, string(filepath.Separator), 2)
 		if len(parts) < 2 {
-			return ""
+			return "", nil
 		}
-		name = parts[1]
+		cleaned = parts[1]
 	}
 
-	if name == "" || name == "." {
-		return ""
+	if cleaned == "" || cleaned == "." {
+		return "", nil
 	}
 
-	return filepath.Join(dest, name)
+	target := filepath.Join(dest, cleaned)
+
+	// Final containment check: target must stay under dest. Defends against
+	// the case where the post-strip name still contains traversal that
+	// filepath.Clean(dest+...) would resolve outside dest.
+	absDest, derr := filepath.Abs(dest)
+	absTgt, terr := filepath.Abs(target)
+	if derr != nil || terr != nil {
+		return "", fmt.Errorf("computing absolute path: dest=%v target=%v", derr, terr)
+	}
+	rel, rerr := filepath.Rel(absDest, absTgt)
+	if rerr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive entry %q escapes destination", name)
+	}
+
+	return target, nil
 }
 
+// writeFile is the unbounded write used by tests that exercise filesystem
+// permission paths only. Production extractors use writeFileLimited.
 func writeFile(r io.Reader, path string, mode os.FileMode) error {
+	return writeFileLimited(r, path, mode, MaxFileBytes)
+}
+
+// writeFileLimited writes at most maxBytes from r to path, returning
+// errEntryTooLarge if the source exceeds the cap. Used by extractTar and
+// extractZip so a single oversize entry cannot fill the disk.
+func writeFileLimited(r io.Reader, path string, mode os.FileMode, maxBytes int64) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
@@ -212,6 +317,13 @@ func writeFile(r io.Reader, path string, mode os.FileMode) error {
 	}
 	defer f.Close()
 
-	_, err = io.Copy(f, r)
-	return err
+	// Copy maxBytes+1 to detect overflow without reading more than needed.
+	n, copyErr := io.CopyN(f, r, maxBytes+1)
+	if copyErr != nil && copyErr != io.EOF {
+		return copyErr
+	}
+	if n > maxBytes {
+		return fmt.Errorf("%w: %s (>= %d bytes)", errEntryTooLarge, path, maxBytes)
+	}
+	return nil
 }

--- a/internal/core/vcs/archive_test.go
+++ b/internal/core/vcs/archive_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -206,16 +207,19 @@ func TestVcsArchive_Clone_WithStripPrefix(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestArchiveEntryPath_PathTraversal(t *testing.T) {
-	// A path starting with ".." should return "".
-	result := archiveEntryPath("../evil/path", "/dest", "")
-	if result != "" {
-		t.Errorf("expected empty result for traversal, got %q", result)
+	// A path starting with ".." is now rejected outright (was: silent skip).
+	_, err := archiveEntryPath("../evil/path", "/dest", "")
+	if err == nil {
+		t.Error("expected error for traversal entry, got nil")
 	}
 }
 
 func TestArchiveEntryPath_RootEntry(t *testing.T) {
 	// Single component (no slash) with no stripPrefix -> skip (returns "").
-	result := archiveEntryPath("single", "/dest", "")
+	result, err := archiveEntryPath("single", "/dest", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if result != "" {
 		t.Errorf("expected empty for single component, got %q", result)
 	}
@@ -223,14 +227,20 @@ func TestArchiveEntryPath_RootEntry(t *testing.T) {
 
 func TestArchiveEntryPath_WithStripPrefix_DotEntry(t *testing.T) {
 	// When stripPrefix is the same as name, rel=="." -> return "".
-	result := archiveEntryPath("prefix", "/dest", "prefix")
+	result, err := archiveEntryPath("prefix", "/dest", "prefix")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if result != "" {
 		t.Errorf("expected empty for dot entry, got %q", result)
 	}
 }
 
 func TestArchiveEntryPath_ValidTwoComponent(t *testing.T) {
-	result := archiveEntryPath("prefix/file.txt", "/dest", "")
+	result, err := archiveEntryPath("prefix/file.txt", "/dest", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if result == "" {
 		t.Error("expected non-empty result for two-component path")
 	}
@@ -436,5 +446,160 @@ func TestWriteFile_MkdirAllFailure(t *testing.T) {
 	err := writeFile(bytes.NewReader([]byte("data")), filepath.Join(parent, "sub", "file.txt"), 0o644)
 	if err == nil {
 		t.Fatal("expected error when parent directory is not writable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Adversarial archive entries (#112)
+// ---------------------------------------------------------------------------
+
+// buildTarRaw lets a test hand-craft tar headers (any Typeflag, any Name).
+func buildTarRaw(t *testing.T, headers []*tar.Header, contents map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, hdr := range headers {
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader: %v", err)
+		}
+		if c, ok := contents[hdr.Name]; ok {
+			tw.Write([]byte(c)) //nolint:errcheck
+		}
+	}
+	tw.Close()
+	return buf.Bytes()
+}
+
+func TestExtractTar_RejectsAbsolutePathEntry(t *testing.T) {
+	data := buildTarRaw(t, []*tar.Header{
+		{Name: "/etc/pwned", Typeflag: tar.TypeReg, Size: 4, Mode: 0o644},
+	}, map[string]string{"/etc/pwned": "evil"})
+
+	dest := t.TempDir()
+	err := extractTar(bytes.NewReader(data), dest, "")
+	if err == nil {
+		t.Fatal("expected error for absolute-path entry, got nil")
+	}
+	if _, statErr := os.Stat("/etc/pwned"); statErr == nil {
+		t.Errorf("absolute-path entry was written to /etc/pwned")
+	}
+}
+
+func TestExtractTar_RejectsParentTraversalEntry(t *testing.T) {
+	data := buildTarRaw(t, []*tar.Header{
+		{Name: "pfx/", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "pfx/../../../tmp/gaal-pwned", Typeflag: tar.TypeReg, Size: 4, Mode: 0o644},
+	}, map[string]string{"pfx/../../../tmp/gaal-pwned": "evil"})
+
+	dest := t.TempDir()
+	err := extractTar(bytes.NewReader(data), dest, "")
+	if err == nil {
+		t.Fatal("expected error for traversal entry, got nil")
+	}
+	if _, statErr := os.Stat("/tmp/gaal-pwned"); statErr == nil {
+		os.Remove("/tmp/gaal-pwned")
+		t.Errorf("traversal entry escaped to /tmp/gaal-pwned")
+	}
+}
+
+func TestExtractTar_SkipsSymlinkEntry(t *testing.T) {
+	// Symlinks are silently skipped (with a warn log) so a malicious archive
+	// cannot redirect a subsequent regular-file write to a sensitive path.
+	data := buildTarRaw(t, []*tar.Header{
+		{Name: "pfx/", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "pfx/link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd", Mode: 0o777},
+	}, nil)
+
+	dest := t.TempDir()
+	if err := extractTar(bytes.NewReader(data), dest, ""); err != nil {
+		t.Fatalf("extractTar: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "link")); err == nil {
+		t.Errorf("symlink entry must not have been created in dest")
+	}
+}
+
+func TestExtractTar_PerEntrySizeCap(t *testing.T) {
+	// Build a tar where one entry's declared body exceeds MaxFileBytes.
+	huge := MaxFileBytes + 1
+	hdr := &tar.Header{Name: "pfx/", Typeflag: tar.TypeDir, Mode: 0o755}
+	hdr2 := &tar.Header{Name: "pfx/big", Typeflag: tar.TypeReg, Mode: 0o644, Size: huge}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.WriteHeader(hdr2); err != nil {
+		t.Fatal(err)
+	}
+	// Stream zero bytes up to the declared size — actual disk impact is
+	// bounded by writeFileLimited copying maxBytes+1 then bailing.
+	zeros := make([]byte, 1<<20) // 1 MiB
+	written := int64(0)
+	for written < huge {
+		n := int64(len(zeros))
+		if rem := huge - written; rem < n {
+			n = rem
+		}
+		if _, err := tw.Write(zeros[:n]); err != nil {
+			t.Fatal(err)
+		}
+		written += n
+	}
+	tw.Close()
+
+	dest := t.TempDir()
+	err := extractTar(bytes.NewReader(buf.Bytes()), dest, "")
+	if err == nil {
+		t.Fatal("expected per-entry size cap error, got nil")
+	}
+}
+
+func TestExtractTar_GzipDetection_NonDestructive(t *testing.T) {
+	// Plain (non-gzip) tar must still extract correctly — the new gzip-magic
+	// peek must not consume the first two bytes of the tar stream.
+	data := buildTar(t, map[string]string{
+		"pfx/hello.txt": "world",
+	}, []string{"pfx/"})
+
+	dest := t.TempDir()
+	if err := extractTar(bytes.NewReader(data), dest, ""); err != nil {
+		t.Fatalf("extractTar: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(dest, "hello.txt"))
+	if err != nil {
+		t.Fatalf("read extracted: %v", err)
+	}
+	if string(body) != "world" {
+		t.Errorf("got %q, want %q", body, "world")
+	}
+}
+
+func TestExtractTar_EntryCountCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipped in -short")
+	}
+	// Build a tar with > MaxEntryCount tiny entries.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for i := 0; i <= MaxEntryCount; i++ {
+		hdr := &tar.Header{
+			Name:     fmt.Sprintf("pfx/file-%d.txt", i),
+			Typeflag: tar.TypeReg,
+			Mode:     0o644,
+			Size:     1,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		tw.Write([]byte("x")) //nolint:errcheck
+	}
+	tw.Close()
+
+	dest := t.TempDir()
+	err := extractTar(bytes.NewReader(buf.Bytes()), dest, "")
+	if err == nil {
+		t.Fatal("expected entry-count cap error, got nil")
 	}
 }


### PR DESCRIPTION
## Summary
\`internal/core/vcs/archive.go\` is rewritten to defend against malicious archives:

- **Path containment**: \`archiveEntryPath\` rejects absolute paths and \`..\` traversal outright; final \`filepath.Rel\` check guards against post-strip escapes
- **Symlink/hardlink/device entries** are explicitly skipped (was: silently passed through) — defends against symlink-then-overwrite races
- **Non-destructive gzip detection** via \`bufio.Reader.Peek(2)\` — plain tar no longer truncated by \`gzip.NewReader\` consuming the magic bytes
- **Size + count caps** (\`MaxArchiveBytes\` 1 GiB, \`MaxFileBytes\` 256 MiB per entry, \`MaxEntryCount\` 50 000)
- \`writeFileLimited\` uses \`io.CopyN(maxBytes+1)\` so an oversize entry is detected without draining the source

## Test plan
- [x] Adversarial unit tests:
  - absolute-path entry (\`/etc/pwned\`) → rejected, no escape
  - \`pfx/../../../tmp/gaal-pwned\` entry → rejected, no escape
  - \`tar.TypeSymlink\` entry → silently skipped (no link in dest)
  - entry exceeding MaxFileBytes → error
  - more than MaxEntryCount entries → error
  - plain (non-gzip) tar still extracts correctly (regression for the gzip-peek)
- [x] Existing \`archiveEntryPath\` tests updated to the new \`(string, error)\` signature
- [x] \`go test ./...\` (all packages green)
- [x] \`go build\`

Closes #112.