### PR TITLE
security(skill): do not dereference symlinks during install or drift compare

### DIFF
--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -474,6 +474,12 @@ var vcsMetaDirs = map[string]struct{}{
 // installSkill copies the skill directory content from src to dst.
 // VCS metadata directories at the top level of src are skipped — see
 // [vcsMetaDirs] for the rationale.
+//
+// Symlinks (and other non-regular entries: devices, FIFOs, sockets) are
+// explicitly skipped instead of being dereferenced. Without this guard, a
+// malicious skill source containing e.g. `secret.md -> /etc/passwd` would
+// have copyFile read /etc/passwd and write its contents into the agent
+// skill directory under the gaal-managed name. See #113.
 func installSkill(src, dst string) error {
 	slog.Debug("installing skill", "src", src, "dst", dst)
 	if err := os.MkdirAll(dst, 0o755); err != nil {
@@ -496,11 +502,26 @@ func installSkill(src, dst string) error {
 			return os.MkdirAll(target, 0o755)
 		}
 
+		// Skip symlinks (and other non-regular entries) — see func docstring.
+		if d.Type()&fs.ModeSymlink != 0 {
+			slog.Warn("skill: skipping symlink in source",
+				"path", path, "rel", rel,
+				"reason", "symlinks are not dereferenced — would leak the link target's content into the install dir")
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			slog.Warn("skill: skipping non-regular file in source",
+				"path", path, "rel", rel, "mode", d.Type().String())
+			return nil
+		}
+
 		return copyFile(path, target)
 	})
 }
 
-// copyFile copies a single file from src to dst.
+// copyFile copies a single file from src to dst. Callers must have already
+// filtered out symlinks (see installSkill) — copyFile uses os.ReadFile which
+// follows them.
 func copyFile(src, dst string) error {
 	data, err := os.ReadFile(src)
 	if err != nil {
@@ -525,6 +546,11 @@ func skillDirModified(src, dst string) bool {
 	slog.Debug("comparing skill directories", "src", src, "dst", dst)
 	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
+			return nil
+		}
+		// Symlinks are not installed (see installSkill), so skip them here too
+		// — otherwise we'd dereference into the link target via os.ReadFile.
+		if d.Type()&fs.ModeSymlink != 0 || !d.Type().IsRegular() {
 			return nil
 		}
 		rel, _ := filepath.Rel(src, path)

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -1044,3 +1044,48 @@ func TestManager_Sync_AggregatesErrorsAcrossSources(t *testing.T) {
 		t.Errorf("aggregated error must reference source B (proves loop continued past A); got: %v", err)
 	}
 }
+
+// TestInstallSkill_DoesNotDereferenceSymlink is the regression for #113:
+// a malicious skill source containing a symlink pointing at /etc/passwd
+// previously had copyFile read the link target and write its contents into
+// the install dir under the gaal-managed name. The new behavior skips
+// symlinks (and other non-regular entries) with a warn.
+func TestInstallSkill_DoesNotDereferenceSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	src := t.TempDir()
+	// A regular file that should be installed normally.
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A "secret" target outside src that the malicious symlink would expose.
+	secretDir := t.TempDir()
+	secretPath := filepath.Join(secretDir, "secret.txt")
+	if err := os.WriteFile(secretPath, []byte("PRIVATE-DATA"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The malicious symlink inside src.
+	if err := os.Symlink(secretPath, filepath.Join(src, "leak.txt")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "installed")
+	if err := installSkill(src, dst); err != nil {
+		t.Fatalf("installSkill: %v", err)
+	}
+
+	// SKILL.md must be installed.
+	if _, err := os.Stat(filepath.Join(dst, "SKILL.md")); err != nil {
+		t.Errorf("expected SKILL.md in dst: %v", err)
+	}
+	// leak.txt must NOT exist in dst (neither as a copy of secret content nor
+	// as a recreated symlink).
+	leakDst := filepath.Join(dst, "leak.txt")
+	if data, err := os.ReadFile(leakDst); err == nil {
+		t.Errorf("symlink leak: dst contains leak.txt with content %q (should not exist)", data)
+	}
+	if _, err := os.Lstat(leakDst); err == nil {
+		t.Errorf("symlink leak: dst contains leak.txt entry (should not exist)")
+	}
+}


### PR DESCRIPTION
## Summary
- \`installSkill\` now explicitly skips symlinks (and non-regular entries: devices, FIFOs, sockets) with a warn log
- \`skillDirModified\` applies the same filter so the drift comparator doesn't fall through to \`os.ReadFile\` on a symlink

## Why
\`filepath.WalkDir\` uses \`Lstat\`, so a symlink in the source appears as a non-directory entry. The previous code handed it straight to \`copyFile\` → \`os.ReadFile\`, which DOES follow symlinks. A malicious (or merely careless) skill source with \`secret.md -> /etc/passwd\` had its target's content written into \`~/.cursor/skills/<bundle>/secret.md\` under the gaal-managed name — bounded only by the user's UID. See #113.

## Scope note
The other half of #113 (discover walks following symlinked dirs into cycles) is **not** materially exploitable today because the codebase uses \`filepath.WalkDir\` exclusively, which by Go design does not recurse into symlinked directories. Adding defensive symlink-dir skips to those walks is left out of this PR to keep it focused; a future caller switching to \`filepath.Walk\` (which does recurse) would re-introduce the risk and should be caught by review.

Closes #113.

## Test plan
- [x] New \`TestInstallSkill_DoesNotDereferenceSymlink\` builds a source with a symlink → secret file outside src; asserts secret content does NOT appear in dst, and the symlink is not recreated either
- [x] Skipped on Windows (symlink semantics differ)
- [x] \`go test ./...\` (all green)
- [x] \`go build\`