### PR TITLE
build(e2e): pin Dockerfile base + agent CLI versions

### DIFF
--- a/test/e2e/fixtures/Dockerfile
+++ b/test/e2e/fixtures/Dockerfile
@@ -12,9 +12,15 @@
 # rebuilds only re-do the cheap final step. The agent CLIs are gated behind
 # a build arg so the cheap layer-1 image can skip the slow npm install when
 # Layer 2 (`GAAL_E2E_CLI=1`) is not requested.
-FROM alpine:3.20
+#
+# Versions are pinned to specific patches so an upstream publish cannot
+# break CI overnight. Bump these deliberately (and re-run `make test-e2e`)
+# rather than letting the floating tags drift.
+FROM alpine:3.20.3
 
 ARG INSTALL_AGENT_CLIS=0
+ARG CLAUDE_CODE_VERSION=2.1.126
+ARG CODEX_VERSION=0.128.0
 
 RUN apk add --no-cache \
         bash \
@@ -27,7 +33,9 @@ RUN apk add --no-cache \
 # Optional: install the agent CLIs that the heavy CLI-verification layer
 # uses. Skipped by default so layer-1 builds stay fast.
 RUN if [ "$INSTALL_AGENT_CLIS" = "1" ]; then \
-        npm install -g --no-fund --no-audit @anthropic-ai/claude-code @openai/codex; \
+        npm install -g --no-fund --no-audit \
+            "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+            "@openai/codex@${CODEX_VERSION}"; \
     fi
 
 # Persistent container entrypoint. The Go test harness keeps one container


### PR DESCRIPTION
## Summary
- \`alpine:3.20\` → \`alpine:3.20.3\` (patch-pinned)
- \`@anthropic-ai/claude-code\` latest → \`@2.1.126\` (current dist-tag latest)
- \`@openai/codex\` latest → \`@0.128.0\` (current dist-tag latest)
- Versions exposed as ARGs (\`CLAUDE_CODE_VERSION\`, \`CODEX_VERSION\`) so maintainers can override on the docker build command line

## Why
Floating tags meant an upstream publish could break CI overnight. Now bumps are deliberate.

Digest pinning (\`alpine:3.20.3@sha256:...\`) is left for follow-up once a Renovate/Dependabot config exists to bump the digests automatically.

Closes #147.

## Test plan
- [ ] \`make test-e2e\` (CI runs this on the PR)
- [ ] Reviewer: confirm the chosen npm versions are still on dist-tag latest