### PR TITLE
build(e2e): build per-host arch + pass --platform to docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,22 +70,26 @@ test-ci:
 	$(GOBIN)/gotestsum --junitfile report/tests.xml --format github-actions -- -race -count=1 -timeout 5m ./...
 
 ## test-e2e: end-to-end Docker suite (Layer 1 — filesystem assertions only)
-##   Builds gaal for linux/amd64, builds the test image, runs the suite.
+##   Builds gaal for linux/<host-arch> (amd64 on x86_64, arm64 on Apple Silicon),
+##   builds the test image with a matching --platform, runs the suite.
 ##   Requires Docker on the host. Set GAAL_E2E_REBUILD=1 to force a rebuild.
+##   Override the target arch with: make test-e2e GOARCH=amd64
 test-e2e:
 	@mkdir -p test/e2e/fixtures
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) \
 		go build -trimpath -o test/e2e/fixtures/gaal .
-	go test -tags e2e -count=1 -timeout 15m ./test/e2e/...
+	GAAL_E2E_PLATFORM=linux/$(GOARCH) \
+		go test -tags e2e -count=1 -timeout 15m ./test/e2e/...
 
 ## test-e2e-cli: full e2e suite including the heavy CLI verification layer
 ##   Installs claude-code + codex into the image and exercises them
 ##   against the configs gaal wrote. Slower; meant for nightly / release CI.
 test-e2e-cli:
 	@mkdir -p test/e2e/fixtures
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) \
 		go build -trimpath -o test/e2e/fixtures/gaal .
-	GAAL_E2E_CLI=1 go test -tags e2e -count=1 -timeout 30m ./test/e2e/...
+	GAAL_E2E_CLI=1 GAAL_E2E_PLATFORM=linux/$(GOARCH) \
+		go test -tags e2e -count=1 -timeout 30m ./test/e2e/...
 
 ## coverage: run tests with coverage — generates all reports in report/
 ##   report/coverage.html          — standard go tool cover (default)

--- a/test/e2e/container_test.go
+++ b/test/e2e/container_test.go
@@ -28,8 +28,11 @@ type TestContainer struct {
 // it to be running, and returns a handle. The container is started with
 // `--rm` so a dropped suite cleans up automatically.
 func startContainer() (*TestContainer, error) {
-	args := []string{
-		"run", "-d", "--rm",
+	args := []string{"run", "-d", "--rm"}
+	if p := dockerPlatform(); p != "" {
+		args = append(args, "--platform", p)
+	}
+	args = append(args,
 		// Bind-mount the fixtures dir read-only so tests can reference
 		// /fixtures/skills/<name> without docker cp gymnastics.
 		"--mount", fmt.Sprintf("type=bind,source=%s,target=%s,readonly", fixturesPath(), fixturesDir),
@@ -39,7 +42,7 @@ func startContainer() (*TestContainer, error) {
 		// Quiet pterm/term-detection.
 		"-e", "TERM=dumb",
 		imageName,
-	}
+	)
 	cmd := exec.Command("docker", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -137,13 +137,18 @@ func repoRoot() (string, error) {
 
 // ensureImage runs `docker build` with the fixtures directory as context.
 // The build args are derived from envCLI so layer 2 runs install the agent
-// CLIs while layer 1 runs stay slim.
+// CLIs while layer 1 runs stay slim. When GAAL_E2E_PLATFORM is set (e.g.
+// "linux/arm64" on Apple Silicon) it is forwarded to docker as --platform
+// so contributors don't get silently emulated images.
 func ensureImage() error {
 	args := []string{
 		"build",
 		"--quiet",
 		"--tag", imageName,
 		"--build-arg", fmt.Sprintf("INSTALL_AGENT_CLIS=%s", boolToZeroOne(envCLI)),
+	}
+	if p := dockerPlatform(); p != "" {
+		args = append(args, "--platform", p)
 	}
 	args = append(args, fixturesPath())
 
@@ -156,6 +161,16 @@ func ensureImage() error {
 		log.Printf("e2e: image built (%s)", trimmed)
 	}
 	return nil
+}
+
+// dockerPlatform returns the value to pass to docker --platform, or "" when
+// no override is requested. Honored by ensureImage and startContainer so that
+// builds and runs target the host arch by default (Apple Silicon contributors
+// don't get silently-emulated amd64 images, CI on x86_64 runners stays
+// unchanged). Set GAAL_E2E_PLATFORM=linux/<arch> to override; the Makefile
+// derives this from $(GOARCH).
+func dockerPlatform() string {
+	return os.Getenv("GAAL_E2E_PLATFORM")
 }
 
 func boolToZeroOne(b bool) string {


### PR DESCRIPTION
## Summary
- Makefile: drop hardcoded \`GOARCH=amd64\` in \`test-e2e\` / \`test-e2e-cli\`; default to host arch (already used by \`build-cross\`)
- Makefile: export \`GAAL_E2E_PLATFORM=linux/\$(GOARCH)\` to the test process
- Test harness: new \`dockerPlatform()\` helper reads the env var; \`ensureImage\` and \`startContainer\` pass it as \`--platform\` when set

## Why
Apple Silicon contributors running \`make test-e2e\` previously got either an emulated amd64 binary on an arm64 alpine image (or vice versa, depending on Docker defaults) — at best very slow, at worst silently mismatched. CI on x86_64 is unaffected.

Override with \`make test-e2e GOARCH=amd64\`.

Closes #150.

## Test plan
- [x] \`go vet -tags e2e ./test/e2e/...\`
- [x] \`go build\`
- [ ] CI runs \`make test-e2e\` (defaults to host arch == amd64 on the runner)