### PR TITLE
ci: timeouts, e2e diagnostics on failure, nightly Layer 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [lint, changes]
     if: needs.changes.outputs.code_changed == 'true'
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +129,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [build, changes]
     if: needs.changes.outputs.code_changed == 'true'
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -242,6 +244,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, changes]
     if: needs.changes.outputs.code_changed == 'true'
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -255,6 +258,31 @@ jobs:
       - name: Run e2e suite
         run: make test-e2e
 
+      # On failure, capture the suite container's logs and any stray gaal
+      # state under /tmp inside it. The harness uses `docker run --rm`
+      # so without this step every signal disappears with the container.
+      - name: Capture e2e diagnostics on failure
+        if: failure()
+        run: |
+          mkdir -p e2e-diagnostics
+          # Find any container started from the suite image (running or exited).
+          for cid in $(docker ps -a --filter "ancestor=gaal-e2e:dev" --format '{{.ID}}'); do
+            echo "--- docker inspect $cid ---" > "e2e-diagnostics/$cid.inspect"
+            docker inspect "$cid" >> "e2e-diagnostics/$cid.inspect" 2>&1 || true
+            docker logs "$cid" > "e2e-diagnostics/$cid.log" 2>&1 || true
+          done
+          # Save the test binary's stderr if it landed somewhere conventional.
+          cp -r test/e2e/fixtures e2e-diagnostics/fixtures 2>/dev/null || true
+          ls -la e2e-diagnostics/
+
+      - name: Upload e2e diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-diagnostics
+          path: e2e-diagnostics/
+          retention-days: 7
+
   # ──────────────────────────────────────────────────────────────────────────
   # Coverage: generate HTML report and post summary to the job summary page
   # ──────────────────────────────────────────────────────────────────────────
@@ -263,6 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, changes]
     if: needs.changes.outputs.code_changed == 'true'
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/nightly-e2e-cli.yml
+++ b/.github/workflows/nightly-e2e-cli.yml
@@ -1,0 +1,49 @@
+name: Nightly E2E (Layer 2 — agent CLIs)
+
+# Layer 2 of the e2e suite installs the actual agent CLIs (claude-code,
+# codex) and verifies that the configs gaal writes are accepted by them.
+# That's the entire point of the tool, so it MUST run somewhere — but it
+# is too slow for every PR (heavy npm install). Schedule daily and expose
+# manual dispatch so a release manager can kick it off on demand.
+on:
+  schedule:
+    - cron: '17 4 * * *'  # 04:17 UTC daily — off-peak for both US/EU runners
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  layer2:
+    name: E2E Layer 2 (CLI verify)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run Layer 2 e2e suite
+        run: make test-e2e-cli
+
+      - name: Capture e2e diagnostics on failure
+        if: failure()
+        run: |
+          mkdir -p e2e-diagnostics
+          for cid in $(docker ps -a --filter "ancestor=gaal-e2e:dev" --format '{{.ID}}'); do
+            echo "--- docker inspect $cid ---" > "e2e-diagnostics/$cid.inspect"
+            docker inspect "$cid" >> "e2e-diagnostics/$cid.inspect" 2>&1 || true
+            docker logs "$cid" > "e2e-diagnostics/$cid.log" 2>&1 || true
+          done
+          ls -la e2e-diagnostics/
+
+      - name: Upload e2e diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: layer2-diagnostics
+          path: e2e-diagnostics/
+          retention-days: 14


### PR DESCRIPTION
## Summary
1. **\`timeout-minutes\`** added to every long-running job: build 10, test 15, e2e 20, coverage 15. Replaces GitHub's 6h default for hung runs.
2. **e2e diagnostics on failure**: capture \`docker inspect\` + \`docker logs\` for any container started from \`gaal-e2e:dev\`, plus a fixtures snapshot. Uploaded as \`e2e-diagnostics\` artifact (7-day retention).
3. **Nightly Layer 2 workflow** (\`.github/workflows/nightly-e2e-cli.yml\`): runs \`make test-e2e-cli\` daily at 04:17 UTC + manual dispatch. Same diagnostics pattern (14-day retention since this catches escapes that PR CI can't).

## Why
Without diagnostics, a failed e2e run on PR CI gives the reviewer only the inline \`go test\` output — and the \`--rm\` container is gone by the time anyone looks. Without the nightly Layer 2, nobody is actually verifying that the configs gaal writes are accepted by claude-code / codex themselves.

\`--network none\` is intentionally left for later — #143 will add a hermetic VCS server inside the container that needs loopback connectivity.

Closes #148.

## Test plan
- [ ] CI runs the new e2e step (no-op on green PR; failure path will be exercised when something actually fails)
- [ ] Reviewer: confirm the cron schedule is sensible and that \`workflow_dispatch\` works after merge