### PR TITLE
test(e2e): cover TTY vs non-TTY rendering and summary-vs-verbose split

### DIFF
--- a/test/e2e/container_test.go
+++ b/test/e2e/container_test.go
@@ -134,6 +134,39 @@ func (c *TestContainer) MustExec(t *testing.T, env Env, workdir string, argv ...
 	return res
 }
 
+// ExecTTY runs argv inside the container with `docker exec -t`, allocating
+// a pseudo-TTY for the in-container process so isatty(stdout) returns true.
+// pterm and similar TTY-detecting libraries will then emit ANSI escapes.
+//
+// Stdout and stderr are merged into the result's Stdout (the pty conflates
+// them — there is no separate stderr stream over a single pty fd). Used by
+// TTY rendering tests; non-TTY tests should keep using Exec.
+func (c *TestContainer) ExecTTY(t *testing.T, env Env, workdir string, argv ...string) ExecResult {
+	t.Helper()
+	full := []string{"exec", "-t"}
+	for _, e := range env.toSlice() {
+		full = append(full, "-e", e)
+	}
+	if workdir != "" {
+		full = append(full, "-w", workdir)
+	}
+	full = append(full, c.id)
+	full = append(full, argv...)
+
+	cmd := exec.Command("docker", full...)
+	out, err := cmd.CombinedOutput()
+	res := ExecResult{Stdout: string(out)}
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			res.ExitCode = ee.ExitCode()
+		} else {
+			res.ExitCode = -1
+			res.Stderr = err.Error()
+		}
+	}
+	return res
+}
+
 // WriteFile writes content into a file in the container, creating parent
 // directories as needed. Uses `sh -c` with stdin so the body never needs
 // shell-escaping.

--- a/test/e2e/tty_test.go
+++ b/test/e2e/tty_test.go
@@ -1,0 +1,77 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// ansiEscape is the CSI introducer (ESC + '['). Any pterm-emitted color or
+// styling produces a sequence beginning with these two bytes — its presence
+// is the simplest TTY-rendering oracle we have without parsing escape grammar.
+const ansiEscape = "\x1b["
+
+// TestTTY_ColorEnabledUnderPty allocates a pseudo-TTY for the in-container
+// gaal process (`docker exec -t` with TERM=xterm-256color) and asserts that
+// pterm-styled output contains ANSI escape sequences. Regression for #149:
+// the rest of the suite always runs with TERM=dumb and no -t, so a future
+// change that broke pterm's color path under a real TTY would otherwise
+// ship green.
+func TestTTY_ColorEnabledUnderPty(t *testing.T) {
+	env := newTestEnv(t)
+	cfgPath := env.writeProjectConfig(t, newConfig().String())
+	env.mustGaal(t, cfgPath, "sync")
+
+	// `gaal agents` is a heavy pterm consumer (table, colored installed/source
+	// columns) so a TTY-vs-pipe difference is easy to detect.
+	gaalEnv := env.gaalEnv()
+	gaalEnv["TERM"] = "xterm-256color"
+	res := env.c.ExecTTY(t, gaalEnv, env.workdir, "gaal", "-c", cfgPath, "agents")
+	if res.ExitCode != 0 {
+		t.Fatalf("gaal agents under pty failed: exit=%d\n%s",
+			res.ExitCode, res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, ansiEscape) {
+		t.Errorf("expected ANSI escape (%q) in pty-allocated output; got:\n%q",
+			ansiEscape, res.Stdout)
+	}
+}
+
+// TestTTY_ColorDisabledWithoutPty is the inverse: same command, no -t, the
+// suite-default TERM=dumb. Output must NOT contain ANSI escapes — pterm
+// auto-detects the absence of a TTY and falls back to plain text.
+func TestTTY_ColorDisabledWithoutPty(t *testing.T) {
+	env := newTestEnv(t)
+	cfgPath := env.writeProjectConfig(t, newConfig().String())
+	env.mustGaal(t, cfgPath, "sync")
+
+	res := env.mustGaal(t, cfgPath, "agents")
+	if strings.Contains(res.Stdout, ansiEscape) {
+		t.Errorf("expected no ANSI escape (%q) in non-TTY output; got:\n%q",
+			ansiEscape, res.Stdout)
+	}
+}
+
+// TestTTY_VerboseProducesMoreThanSummary validates the summary-first
+// contract from #107: the default text output is more compact than the
+// --verbose flavour. Asserts on byte length to avoid coupling to specific
+// line content.
+func TestTTY_VerboseProducesMoreThanSummary(t *testing.T) {
+	env := newTestEnv(t)
+	cfg := newConfig().
+		AddSkill(localSkillsRoot+"/stub-skill", []string{"claude-code"}, true).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	summary := env.mustGaal(t, cfgPath, "status")
+	verbose := env.mustGaal(t, cfgPath, "-v", "status")
+
+	if len(verbose.Stdout) <= len(summary.Stdout) {
+		t.Errorf("expected verbose status to be longer than summary status\n"+
+			"summary (%d bytes):\n%s\nverbose (%d bytes):\n%s",
+			len(summary.Stdout), summary.Stdout,
+			len(verbose.Stdout), verbose.Stdout)
+	}
+}


### PR DESCRIPTION
## Summary
- New \`TestContainer.ExecTTY\` helper runs \`docker exec -t\` so the in-container process gets a pseudo-TTY (isatty(stdout) == true → pterm emits ANSI)
- New \`test/e2e/tty_test.go\` with three tests:
  - \`TestTTY_ColorEnabledUnderPty\` — \`gaal agents\` under -t + \`TERM=xterm-256color\` contains the CSI introducer (\`ESC [\`)
  - \`TestTTY_ColorDisabledWithoutPty\` — same without -t + default \`TERM=dumb\` does not
  - \`TestTTY_VerboseProducesMoreThanSummary\` — validates the summary-first contract from #107 by byte-length comparison

## Why
The rest of the suite always runs with \`TERM=dumb\` and no -t, so a regression that broke pterm's color path under a real TTY (or the summary-vs-verbose split from #107) would ship green. These three tests pin both contracts.

Closes #149.

## Test plan
- [x] \`go vet -tags e2e ./test/e2e/...\`
- [ ] CI runs \`make test-e2e\` (TTY allocation works on the ubuntu runner — same path the harness already uses)