### PR TITLE
test(e2e): hermetic git VCS coverage

### DIFF
--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -12,8 +12,16 @@ import (
 // exercises — repositories, skills, mcps. Callers add entries via the
 // chainable Add* methods and finalise with String().
 type configBuilder struct {
+	repos  []repoBlock
 	skills []skillBlock
 	mcps   []mcpBlock
+}
+
+type repoBlock struct {
+	path    string // workspace-relative checkout path (the YAML map key)
+	typ     string // "git", "hg", "tar", etc.
+	url     string // clone source — local path or URL
+	version string // optional tag / branch / commit
 }
 
 type skillBlock struct {
@@ -34,6 +42,15 @@ type mcpBlock struct {
 
 func newConfig() *configBuilder { return &configBuilder{} }
 
+// AddRepository registers a repository entry. path is the workspace-relative
+// checkout location (the YAML map key); typ is "git", "hg", "tar", etc.;
+// url is the clone source — a local filesystem path is acceptable for
+// hermetic test backends.
+func (b *configBuilder) AddRepository(path, typ, url, version string) *configBuilder {
+	b.repos = append(b.repos, repoBlock{path: path, typ: typ, url: url, version: version})
+	return b
+}
+
 func (b *configBuilder) AddSkill(source string, agents []string, global bool, selects ...string) *configBuilder {
 	b.skills = append(b.skills, skillBlock{source: source, agents: agents, global: global, selects: selects})
 	return b
@@ -50,6 +67,17 @@ func (b *configBuilder) AddMCP(name string, agents []string, global bool, comman
 func (b *configBuilder) String() string {
 	var sb strings.Builder
 	sb.WriteString("schema: 1\n")
+	if len(b.repos) > 0 {
+		sb.WriteString("repositories:\n")
+		for _, r := range b.repos {
+			fmt.Fprintf(&sb, "  %s:\n", r.path)
+			fmt.Fprintf(&sb, "    type: %s\n", r.typ)
+			fmt.Fprintf(&sb, "    url: %s\n", quoteIfNeeded(r.url))
+			if r.version != "" {
+				fmt.Fprintf(&sb, "    version: %s\n", quoteIfNeeded(r.version))
+			}
+		}
+	}
 	if len(b.skills) > 0 {
 		sb.WriteString("skills:\n")
 		for _, s := range b.skills {

--- a/test/e2e/vcs_git_test.go
+++ b/test/e2e/vcs_git_test.go
@@ -1,0 +1,166 @@
+//go:build e2e
+
+// Hermetic VCS coverage — issue #143.
+//
+// Until this file landed the e2e suite never exercised the actual VCS
+// backends (git via go-git, hg/svn/bzr/tar/zip via subprocess). Every
+// `repositories:` entry the suite ever wrote was a no-op because nothing
+// in the test configs used one. A regression in internal/core/vcs/git.go
+// (broken ref resolution, wrong checksum, partial clone recovery) would
+// ship green.
+//
+// This file covers the **git** backend hermetically: it bootstraps a bare
+// repo inside the container, clones from it via the gaal git backend, and
+// verifies update-after-upstream-change. The hg/svn/bzr/tar/zip backends
+// require additional packages and a HTTP fileserver; tracked as follow-up
+// scope under #143.
+package e2e
+
+import (
+	"path"
+	"testing"
+)
+
+// gitConfigEnv returns the env vars needed to make `git commit` work in a
+// fresh container — git complains without a configured user.
+var gitConfigEnv = Env{
+	"GIT_AUTHOR_NAME":     "gaal-e2e",
+	"GIT_AUTHOR_EMAIL":    "e2e@example.test",
+	"GIT_COMMITTER_NAME":  "gaal-e2e",
+	"GIT_COMMITTER_EMAIL": "e2e@example.test",
+}
+
+// initBareGitRepo creates a bare git repo at <root>/<name>.git with one
+// commit (a README) so it can be cloned. Returns the absolute path to the
+// bare repo, suitable for use as a gaal repository url.
+func initBareGitRepo(t *testing.T, env *testEnv, root, name string) string {
+	t.Helper()
+	bare := path.Join(root, name+".git")
+	work := path.Join(root, name+"-work")
+
+	env.c.MustExec(t, nil, "", "git", "init", "--bare", bare)
+	env.c.MustExec(t, nil, "", "git", "init", work)
+	env.c.WriteFile(t, path.Join(work, "README.md"), "# initial\n")
+	env.c.MustExec(t, gitConfigEnv, work, "git", "add", "README.md")
+	env.c.MustExec(t, gitConfigEnv, work, "git", "commit", "-m", "initial")
+	// Default branch name varies across git versions — force "main".
+	env.c.MustExec(t, gitConfigEnv, work, "git", "branch", "-M", "main")
+	env.c.MustExec(t, gitConfigEnv, work, "git", "remote", "add", "origin", bare)
+	env.c.MustExec(t, gitConfigEnv, work, "git", "push", "-u", "origin", "main")
+	return bare
+}
+
+// addCommitToBare makes a new commit on the bare repo's main branch via a
+// fresh worktree. Used to test update-after-upstream-change. Returns the
+// short hash of the new commit.
+func addCommitToBare(t *testing.T, env *testEnv, bare, fileName, content string) {
+	t.Helper()
+	work := bare + "-update-work"
+	env.c.MustExec(t, nil, "", "rm", "-rf", work)
+	env.c.MustExec(t, nil, "", "git", "clone", bare, work)
+	env.c.WriteFile(t, path.Join(work, fileName), content)
+	env.c.MustExec(t, gitConfigEnv, work, "git", "add", fileName)
+	env.c.MustExec(t, gitConfigEnv, work, "git", "commit", "-m", "add "+fileName)
+	env.c.MustExec(t, gitConfigEnv, work, "git", "push", "origin", "main")
+}
+
+// TestVCS_GitBackend_CloneAndCheckout asserts gaal can clone a hermetic
+// bare repo via the git backend (go-git, no binary required) and lay out
+// the repository at the configured path.
+func TestVCS_GitBackend_CloneAndCheckout(t *testing.T) {
+	env := newTestEnv(t)
+
+	reposRoot := path.Join(env.home, "test-repos")
+	env.c.MustExec(t, nil, "", "mkdir", "-p", reposRoot)
+	bare := initBareGitRepo(t, env, reposRoot, "myrepo")
+
+	cfg := newConfig().
+		AddRepository("src/myrepo", "git", bare, "").
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	// The README from the initial commit must exist at the expected path.
+	dst := path.Join(env.workdir, "src", "myrepo", "README.md")
+	if !env.c.FileExists(t, dst) {
+		t.Fatalf("expected cloned README at %s after sync", dst)
+	}
+	content := env.c.ReadFile(t, dst)
+	if content != "# initial\n" {
+		t.Errorf("README content mismatch: got %q", content)
+	}
+}
+
+// TestVCS_GitBackend_UpdateAfterUpstreamChange asserts a second sync picks
+// up a new upstream commit. Regression target for the Update path —
+// initial Clone is the easy case; making sure subsequent Updates actually
+// pull is the surface that historically breaks (#125).
+func TestVCS_GitBackend_UpdateAfterUpstreamChange(t *testing.T) {
+	env := newTestEnv(t)
+
+	reposRoot := path.Join(env.home, "test-repos")
+	env.c.MustExec(t, nil, "", "mkdir", "-p", reposRoot)
+	bare := initBareGitRepo(t, env, reposRoot, "updaterepo")
+
+	cfg := newConfig().
+		AddRepository("src/updaterepo", "git", bare, "").
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+
+	env.mustGaal(t, cfgPath, "sync")
+
+	// Push a new commit to the bare repo and re-sync.
+	addCommitToBare(t, env, bare, "NEWFILE.md", "added later\n")
+	env.mustGaal(t, cfgPath, "sync")
+
+	dst := path.Join(env.workdir, "src", "updaterepo", "NEWFILE.md")
+	if !env.c.FileExists(t, dst) {
+		t.Fatalf("expected NEWFILE.md after second sync (update path); not found")
+	}
+	if got := env.c.ReadFile(t, dst); got != "added later\n" {
+		t.Errorf("NEWFILE.md content mismatch: got %q", got)
+	}
+}
+
+// TestVCS_GitBackend_VersionPin clones the repo at a specific commit hash
+// and asserts only the pinned commit's content is present (the later one
+// is not). Pins #125's "version-aware checkout" half.
+func TestVCS_GitBackend_VersionPin(t *testing.T) {
+	env := newTestEnv(t)
+
+	reposRoot := path.Join(env.home, "test-repos")
+	env.c.MustExec(t, nil, "", "mkdir", "-p", reposRoot)
+	bare := initBareGitRepo(t, env, reposRoot, "pinrepo")
+
+	// Capture the initial commit hash before adding more.
+	initial := env.c.MustExec(t, nil, "",
+		"git", "--git-dir", bare, "rev-parse", "HEAD").Stdout
+	initial = trimNewline(initial)
+
+	addCommitToBare(t, env, bare, "LATER.md", "later commit\n")
+
+	cfg := newConfig().
+		AddRepository("src/pinrepo", "git", bare, initial).
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	dst := path.Join(env.workdir, "src", "pinrepo", "README.md")
+	if !env.c.FileExists(t, dst) {
+		t.Fatalf("README missing after pinned sync at %s", dst)
+	}
+	// The later file MUST NOT be present — version pin held.
+	later := path.Join(env.workdir, "src", "pinrepo", "LATER.md")
+	if env.c.FileExists(t, later) {
+		t.Errorf("version pin (%s) did not hold: LATER.md from a later commit is present",
+			initial)
+	}
+}
+
+func trimNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- New \`test/e2e/vcs_git_test.go\` exercises the git backend hermetically (bare repo bootstrapped inside the container; no external network)
- \`configBuilder\` gains \`AddRepository\` + a \`repositories:\` block emitter
- Three tests pin: clone-and-checkout, update-after-upstream-change, version-pin (#125 regression target)

## Why
The e2e suite previously sourced everything from local fixture paths — the actual VCS backends (\`internal/core/vcs/{git,hg,svn,bzr,archive}.go\`) were untouched. A regression in any of them (broken ref resolution, partial-clone recovery, version pin) shipped green.

This PR establishes the hermetic-VCS pattern (bootstrap repo in container, point gaal at it) so adding the remaining backends (hg/svn/bzr/tar/zip) is mechanical.

## Scope note
Only the **git** backend is covered here. hg/svn/bzr need their respective binaries added to the fixture image; tar/zip need a localhost HTTP fileserver inside the container. Both are tracked as **follow-up scope** under #143 and should be straightforward to layer on with the helpers this PR introduces.

## Test plan
- [x] \`go vet -tags e2e ./test/e2e/...\`
- [ ] CI runs \`make test-e2e\` (git binary already in fixture image; nothing else added)