### PR TITLE
fix(e2e): two test bugs surfaced by the first run on merged main

### DIFF
--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -75,9 +75,12 @@ func TestSmoke_AgentsInstalled(t *testing.T) {
 
 // TestSmoke_InfoAgent shows the detail view for a known agent. The command
 // is `gaal info <kind> [name]` per cmd/info.go; here we ask for an agent.
+// info requires a config (it is not annotated `optional`), so the test
+// writes an empty skeleton first.
 func TestSmoke_InfoAgent(t *testing.T) {
 	env := newTestEnv(t)
-	res := env.mustGaal(t, "", "info", "agent", "claude-code")
+	cfgPath := env.writeProjectConfig(t, newConfig().String())
+	res := env.mustGaal(t, cfgPath, "info", "agent", "claude-code")
 	if !strings.Contains(res.Stdout, "claude-code") {
 		t.Errorf("expected `gaal info agent claude-code` to mention the agent\n%s",
 			res.Combined())

--- a/test/e2e/vcs_git_test.go
+++ b/test/e2e/vcs_git_test.go
@@ -47,6 +47,12 @@ func initBareGitRepo(t *testing.T, env *testEnv, root, name string) string {
 	env.c.MustExec(t, gitConfigEnv, work, "git", "branch", "-M", "main")
 	env.c.MustExec(t, gitConfigEnv, work, "git", "remote", "add", "origin", bare)
 	env.c.MustExec(t, gitConfigEnv, work, "git", "push", "-u", "origin", "main")
+	// Re-point HEAD on the bare repo so go-git's PlainClone resolves the
+	// default branch. `git init --bare` defaults HEAD to whatever
+	// init.defaultBranch is (often "master") which leaves it unborn after
+	// pushing "main"; clone then fails with "reference not found".
+	env.c.MustExec(t, nil, "", "git", "--git-dir", bare,
+		"symbolic-ref", "HEAD", "refs/heads/main")
 	return bare
 }
 


### PR DESCRIPTION
## Summary
After merging the e2e batch (#164–#172) the suite found two bugs in the tests **I just wrote**, not in production code:

1. **\`TestSmoke_InfoAgent\`**: \`gaal info\` requires a config file (it lacks the \`optional\` annotation that \`audit\` / \`doctor\` carry). The test passed \`""\` as the config path → "no configuration file found". Fix: write an empty-but-valid skeleton first.

2. **\`initBareGitRepo\`**: \`git init --bare\` sets HEAD to \`init.defaultBranch\` (often \`master\`). Pushing to \`main\` leaves HEAD pointing at an unborn ref → go-git's \`PlainClone\` fails with "reference not found"; \`git --git-dir <bare> rev-parse HEAD\` fails the same way. Fix: \`git symbolic-ref HEAD refs/heads/main\` on the bare after the push.

## Why
Surfaced by running \`make test-e2e\` against merged main. Fixing in the same week the tests landed so the first nightly Layer 2 run on a green build is meaningful.

## Test plan
- [x] \`make test-e2e\` (passes locally in 42s)
- [x] \`go vet -tags e2e ./test/e2e/...\`
- [ ] CI confirms (the same failures would have surfaced on the e2e job for any of #164–#172 had \`changes\` filter not skipped them — first time on main is the first opportunity)