### PR TITLE
style: gofmt scope_test.go denied map alignment

### DIFF
--- a/test/e2e/scope_test.go
+++ b/test/e2e/scope_test.go
@@ -248,11 +248,11 @@ func TestScope_NoSpuriousFiles(t *testing.T) {
 
 	homeEntries := env.c.ListDir(t, env.home)
 	denied := map[string]string{
-		".gaal":        "gaal must not create a top-level ~/.gaal dir (state lives under ~/.cache/gaal)",
-		".local":       "gaal must not write under ~/.local/ (XDG state should land in ~/.cache/gaal/state)",
-		".gaal-state":  "legacy state location should not be re-introduced",
-		".gaal-cache":  "legacy cache location should not be re-introduced",
-		"gaal.yaml":    "gaal must not write a yaml at $HOME root (those go to ~/.config/gaal/)",
+		".gaal":       "gaal must not create a top-level ~/.gaal dir (state lives under ~/.cache/gaal)",
+		".local":      "gaal must not write under ~/.local/ (XDG state should land in ~/.cache/gaal/state)",
+		".gaal-state": "legacy state location should not be re-introduced",
+		".gaal-cache": "legacy cache location should not be re-introduced",
+		"gaal.yaml":   "gaal must not write a yaml at $HOME root (those go to ~/.config/gaal/)",
 	}
 	for _, e := range homeEntries {
 		if reason, bad := denied[e]; bad {


### PR DESCRIPTION
## Summary
Pure gofmt — fixes a misaligned map literal introduced in #167. CI lint failed:

\`\`\`
The following files are not gofmt formatted:
test/e2e/scope_test.go
\`\`\`

No behavior change.

## Test plan
- [x] \`make lint\`