### PR TITLE
test(e2e): cover hg, tar, zip VCS backends; document svn/bzr exclusion

### DIFF
--- a/test/e2e/container_test.go
+++ b/test/e2e/container_test.go
@@ -175,13 +175,21 @@ func (c *TestContainer) ExecTTY(t *testing.T, env Env, workdir string, argv ...s
 // shell-escaping.
 func (c *TestContainer) WriteFile(t *testing.T, p string, content string) {
 	t.Helper()
+	c.WriteFileBytes(t, p, []byte(content))
+}
+
+// WriteFileBytes is the binary-safe variant of WriteFile. Use it when the
+// payload may contain null bytes or other content that would not survive a
+// string-typed path (e.g. tar/zip archives in #143's hermetic VCS tests).
+func (c *TestContainer) WriteFileBytes(t *testing.T, p string, content []byte) {
+	t.Helper()
 	parent := path.Dir(p)
 	if mk := c.Exec(t, nil, "", "mkdir", "-p", parent); mk.ExitCode != 0 {
 		t.Fatalf("mkdir -p %s: %s", parent, mk.Combined())
 	}
 	args := []string{"exec", "-i", c.id, "sh", "-c", "cat > " + shellQuote(p)}
 	cmd := exec.Command("docker", args...)
-	cmd.Stdin = strings.NewReader(content)
+	cmd.Stdin = bytes.NewReader(content)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/test/e2e/fixtures/Dockerfile
+++ b/test/e2e/fixtures/Dockerfile
@@ -27,8 +27,10 @@ RUN apk add --no-cache \
         ca-certificates \
         coreutils \
         git \
+        mercurial \
         nodejs \
-        npm
+        npm \
+        python3
 
 # Optional: install the agent CLIs that the heavy CLI-verification layer
 # uses. Skipped by default so layer-1 builds stay fast.

--- a/test/e2e/vcs_other_test.go
+++ b/test/e2e/vcs_other_test.go
@@ -1,0 +1,258 @@
+//go:build e2e
+
+// Hermetic coverage for the non-git VCS backends — issue #143 follow-up.
+//
+//   - hg: clone via local-path URL (mercurial accepts plain paths).
+//   - tar / zip: clone via http://127.0.0.1:<port>, fileserver hosted by a
+//     python3 -m http.server started in the suite container.
+//   - svn / bzr: skipped. svn requires a `file://` URL or an svnserve
+//     daemon, both of which require either widening the urlx scheme
+//     allowlist (which #117 deliberately tightened) or adding more
+//     services to the fixture image. Tracked as follow-up scope under
+//     #143.
+package e2e
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"path"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ── hg ──────────────────────────────────────────────────────────────────────
+
+// hgConfigEnv satisfies hg's "no user configured" check (mercurial requires
+// ui.username to be set for `hg commit`).
+var hgConfigEnv = Env{
+	"HGUSER": "gaal-e2e <e2e@example.test>",
+}
+
+// initBareHgRepo creates a Mercurial repo at <root>/<name> with a single
+// commit and returns the absolute path. hg supports cloning from a plain
+// filesystem path (no scheme required) so the path itself is a valid url.
+func initBareHgRepo(t *testing.T, env *testEnv, root, name string) string {
+	t.Helper()
+	repo := path.Join(root, name)
+	env.c.MustExec(t, hgConfigEnv, "", "hg", "init", repo)
+	env.c.WriteFile(t, path.Join(repo, "README.md"), "# initial hg\n")
+	env.c.MustExec(t, hgConfigEnv, repo, "hg", "add", "README.md")
+	env.c.MustExec(t, hgConfigEnv, repo, "hg", "commit", "-m", "initial")
+	return repo
+}
+
+func TestVCS_HgBackend_CloneAndCheckout(t *testing.T) {
+	if !haveBinary(t, "hg") {
+		t.Skip("mercurial not available in fixture image")
+	}
+	env := newTestEnv(t)
+
+	reposRoot := path.Join(env.home, "test-repos")
+	env.c.MustExec(t, nil, "", "mkdir", "-p", reposRoot)
+	repo := initBareHgRepo(t, env, reposRoot, "myhg")
+
+	cfg := newConfig().
+		AddRepository("src/myhg", "hg", repo, "").
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	dst := path.Join(env.workdir, "src", "myhg", "README.md")
+	if !env.c.FileExists(t, dst) {
+		t.Fatalf("expected hg-cloned README at %s", dst)
+	}
+	if got := env.c.ReadFile(t, dst); got != "# initial hg\n" {
+		t.Errorf("hg README mismatch: got %q", got)
+	}
+}
+
+// ── tar / zip via local HTTP server ────────────────────────────────────────
+
+// httpServerPort and httpServerOnce coordinate the suite-wide python3
+// -m http.server. One server is enough — every test writes its own
+// uniquely-named archive into the served directory.
+var (
+	httpServerOnce  atomic.Bool
+	httpServerRoot  = "/tmp/gaal-e2e-http-root"
+	httpServerPort  = "8765"
+	httpServerReady = make(chan struct{}, 1)
+)
+
+// ensureHTTPServer starts python3 -m http.server in the suite container the
+// first time it is called and returns the base URL (e.g.
+// "http://127.0.0.1:8765"). Idempotent.
+func ensureHTTPServer(t *testing.T) string {
+	t.Helper()
+	base := "http://127.0.0.1:" + httpServerPort
+	if !httpServerOnce.CompareAndSwap(false, true) {
+		<-httpServerReady
+		httpServerReady <- struct{}{}
+		return base
+	}
+	suite.MustExec(t, nil, "", "mkdir", "-p", httpServerRoot)
+	// Fire-and-forget — `nohup` keeps the process alive past the
+	// `docker exec`'s lifetime. The container is torn down at suite end.
+	suite.MustExec(t, nil, "", "sh", "-c",
+		"nohup python3 -m http.server "+httpServerPort+
+			" --directory "+httpServerRoot+" >/tmp/gaal-http.log 2>&1 & echo $! >/tmp/gaal-http.pid")
+
+	// Spin until the server accepts connections (up to 5s).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		probe := suite.Exec(t, nil, "", "sh", "-c",
+			"wget -qO- "+base+"/ >/dev/null 2>&1 || curl -fsS -o /dev/null "+base+"/")
+		if probe.ExitCode == 0 {
+			httpServerReady <- struct{}{}
+			return base
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("python3 http.server did not become ready on %s", base)
+	return ""
+}
+
+// hostArchive writes data under httpServerRoot and returns the served URL.
+// name should be unique per test (the suite shares one server).
+func hostArchive(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	base := ensureHTTPServer(t)
+	dst := path.Join(httpServerRoot, name)
+	// Pipe via base64 to avoid shell-quoting binary data.
+	suite.WriteFileBytes(t, dst, data)
+	return base + "/" + name
+}
+
+func TestVCS_TarBackend_Clone(t *testing.T) {
+	if !haveBinary(t, "python3") {
+		t.Skip("python3 not available in fixture image — needed for HTTP fileserver")
+	}
+	env := newTestEnv(t)
+
+	// Build a tiny .tar.gz with a single top-level dir (gaal strips it on
+	// extract). README ends up at <dest>/README.md after extraction.
+	data := buildTarGz(t, map[string]string{
+		"project/README.md": "# initial tar\n",
+	})
+	url := hostArchive(t, sanitizeName(t.Name())+".tar.gz", data)
+
+	cfg := newConfig().
+		AddRepository("src/mytar", "tar", url, "").
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	dst := path.Join(env.workdir, "src", "mytar", "README.md")
+	if !env.c.FileExists(t, dst) {
+		t.Fatalf("expected tar-extracted README at %s", dst)
+	}
+	if got := env.c.ReadFile(t, dst); got != "# initial tar\n" {
+		t.Errorf("tar README mismatch: got %q", got)
+	}
+}
+
+func TestVCS_ZipBackend_Clone(t *testing.T) {
+	if !haveBinary(t, "python3") {
+		t.Skip("python3 not available in fixture image — needed for HTTP fileserver")
+	}
+	env := newTestEnv(t)
+
+	data := buildZip(t, map[string]string{
+		"project/README.md": "# initial zip\n",
+	})
+	url := hostArchive(t, sanitizeName(t.Name())+".zip", data)
+
+	cfg := newConfig().
+		AddRepository("src/myzip", "zip", url, "").
+		String()
+	cfgPath := env.writeProjectConfig(t, cfg)
+	env.mustGaal(t, cfgPath, "sync")
+
+	dst := path.Join(env.workdir, "src", "myzip", "README.md")
+	if !env.c.FileExists(t, dst) {
+		t.Fatalf("expected zip-extracted README at %s", dst)
+	}
+	if got := env.c.ReadFile(t, dst); got != "# initial zip\n" {
+		t.Errorf("zip README mismatch: got %q", got)
+	}
+}
+
+// ── svn / bzr — security gate ──────────────────────────────────────────────
+
+// TestVCS_SvnBackend_Skipped documents why svn coverage is not in this PR.
+// svn checkout requires either a `file://` URL or a daemon protocol
+// (svn://, svn+ssh://, svn+http://). PR #117 deliberately removed
+// `file://` from urlx.ValidateRepoURL because a malicious workspace YAML
+// could otherwise exfiltrate arbitrary local paths via go-git's PlainClone
+// (and the same risk applies to svn). Daemon coverage requires svnserve in
+// the fixture image plus port wiring; tracked as a follow-up under #143.
+func TestVCS_SvnBackend_Skipped(t *testing.T) {
+	t.Skip("svn requires file:// or svnserve daemon — see PR #117 + #143 follow-up")
+}
+
+// TestVCS_BzrBackend_Skipped: same reason as svn, plus alpine 3.20 no
+// longer ships a Bazaar-compatible package by default. Tracked under #143.
+func TestVCS_BzrBackend_Skipped(t *testing.T) {
+	t.Skip("bzr requires file:// (PR #117) and is not in alpine 3.20 — see #143 follow-up")
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+// haveBinary reports whether `name` is on PATH inside the suite container.
+func haveBinary(t *testing.T, name string) bool {
+	t.Helper()
+	res := suite.Exec(t, nil, "", "sh", "-c", "command -v "+name+" >/dev/null")
+	return res.ExitCode == 0
+}
+
+// buildTarGz returns a .tar.gz body containing the named files.
+func buildTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for name, content := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("tar header: %v", err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("tar body: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// buildZip returns a .zip body containing the named files.
+func buildZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip create: %v", err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("zip write: %v", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// fmtBytes is a no-op formatting helper kept so future tests can grow
+// asserts on archive sizes; suppress unused-import bother for fmt.
+var _ = fmt.Sprintf


### PR DESCRIPTION
## Summary
Picks up the follow-up scope of #143 (PR #172 covered git only):

- \`mercurial\` + \`python3\` added to the fixture Dockerfile
- New \`Container.WriteFileBytes\` (binary-safe writer for archives)
- New \`ensureHTTPServer\` helper brings up \`python3 -m http.server\` on \`127.0.0.1:8765\` in the suite container; idempotent
- New tests:
  - \`TestVCS_HgBackend_CloneAndCheckout\` — bare hg repo, cloned via local-path URL
  - \`TestVCS_TarBackend_Clone\` — \`.tar.gz\` over HTTP
  - \`TestVCS_ZipBackend_Clone\` — \`.zip\` over HTTP
- \`TestVCS_SvnBackend_Skipped\` / \`TestVCS_BzrBackend_Skipped\` — explicit \`t.Skip\` with reason

## Why svn/bzr are skipped (not just \"not added\")
svn checkout requires either a \`file://\` URL or a daemon protocol (svn://, svn+ssh://, svn+http://). PR #117 deliberately removed \`file://\` from \`urlx.ValidateRepoURL\` — a malicious workspace YAML could otherwise exfiltrate arbitrary local paths via go-git's PlainClone (and the same risk applies to svn). Daemon coverage requires \`svnserve\` in the fixture image plus port wiring; tracked as further follow-up under #143.

bzr has the same constraint plus alpine 3.20 no longer ships a Bazaar-compatible package by default.

## Coverage matrix after this PR
| Backend | Status |
|---|---|
| git | ✅ #172 |
| hg | ✅ this PR |
| tar | ✅ this PR |
| zip | ✅ this PR |
| svn | ⏸ skipped (security) |
| bzr | ⏸ skipped (security + package) |

## Test plan
- [x] \`go vet -tags e2e ./test/e2e/...\`
- [x] \`make test-e2e\` (all tests pass in 61s — image rebuild + 3 new VCS tests)