### PR TITLE
ci: upload e2e JUnit report as artifact (PR + nightly Layer 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,10 +253,48 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # gotestsum drives the e2e run when available, producing
+      # report/e2e-tests.xml that the upload step ships as an artifact.
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       # ubuntu-latest ships with the Docker daemon and BuildKit enabled by
       # default — no extra setup step needed before `make test-e2e`.
       - name: Run e2e suite
         run: make test-e2e
+
+      - name: Post e2e test summary
+        if: always()
+        run: |
+          python3 - <<'EOF'
+          import xml.etree.ElementTree as ET, os, pathlib
+          p = pathlib.Path("report/e2e-tests.xml")
+          if not p.exists():
+              print("No e2e test report found.")
+          else:
+              tree = ET.parse(p)
+              root = tree.getroot()
+              suites = root.findall("testsuite") or ([root] if root.tag == "testsuite" else [])
+              tests = sum(int(s.get("tests", 0)) for s in suites)
+              failed = sum(int(s.get("failures", 0)) + int(s.get("errors", 0)) for s in suites)
+              skipped = sum(int(s.get("skipped", 0)) for s in suites)
+              passed = tests - failed - skipped
+              summary = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/stdout")
+              with open(summary, "a") as f:
+                  f.write("## E2E Test Results\n\n")
+                  f.write("| Suites | Tests | ✅ Passed | ❌ Failed | ⏭ Skipped |\n")
+                  f.write("|--------|-------|-----------|-----------|----------|\n")
+                  f.write(f"| {len(suites)} | {tests} | {passed} | {failed} | {skipped} |\n\n")
+          EOF
+
+      - name: Upload e2e test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-test-results
+          path: report/e2e-tests.xml
+          retention-days: 30
+          if-no-files-found: warn
 
       # On failure, capture the suite container's logs and any stray gaal
       # state under /tmp inside it. The harness uses `docker run --rm`

--- a/.github/workflows/nightly-e2e-cli.yml
+++ b/.github/workflows/nightly-e2e-cli.yml
@@ -26,8 +26,20 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Run Layer 2 e2e suite
         run: make test-e2e-cli
+
+      - name: Upload Layer 2 test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-layer2-test-results
+          path: report/e2e-cli-tests.xml
+          retention-days: 30
+          if-no-files-found: warn
 
       - name: Capture e2e diagnostics on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -74,22 +74,39 @@ test-ci:
 ##   builds the test image with a matching --platform, runs the suite.
 ##   Requires Docker on the host. Set GAAL_E2E_REBUILD=1 to force a rebuild.
 ##   Override the target arch with: make test-e2e GOARCH=amd64
+##
+##   When gotestsum is on PATH (CI sets this up via test-ci's install step),
+##   a JUnit XML report is written to report/e2e-tests.xml. CI uploads it
+##   as the e2e-test-results artifact alongside the unit test report.
 test-e2e:
-	@mkdir -p test/e2e/fixtures
+	@mkdir -p test/e2e/fixtures report
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) \
 		go build -trimpath -o test/e2e/fixtures/gaal .
-	GAAL_E2E_PLATFORM=linux/$(GOARCH) \
-		go test -tags e2e -count=1 -timeout 15m ./test/e2e/...
+	@if [ -x "$(GOBIN)/gotestsum" ]; then \
+		GAAL_E2E_PLATFORM=linux/$(GOARCH) \
+			$(GOBIN)/gotestsum --junitfile report/e2e-tests.xml --format github-actions \
+			-- -tags e2e -count=1 -timeout 15m ./test/e2e/...; \
+	else \
+		GAAL_E2E_PLATFORM=linux/$(GOARCH) \
+			go test -tags e2e -count=1 -timeout 15m ./test/e2e/...; \
+	fi
 
 ## test-e2e-cli: full e2e suite including the heavy CLI verification layer
 ##   Installs claude-code + codex into the image and exercises them
 ##   against the configs gaal wrote. Slower; meant for nightly / release CI.
+##   Writes report/e2e-cli-tests.xml when gotestsum is available.
 test-e2e-cli:
-	@mkdir -p test/e2e/fixtures
+	@mkdir -p test/e2e/fixtures report
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) \
 		go build -trimpath -o test/e2e/fixtures/gaal .
-	GAAL_E2E_CLI=1 GAAL_E2E_PLATFORM=linux/$(GOARCH) \
-		go test -tags e2e -count=1 -timeout 30m ./test/e2e/...
+	@if [ -x "$(GOBIN)/gotestsum" ]; then \
+		GAAL_E2E_CLI=1 GAAL_E2E_PLATFORM=linux/$(GOARCH) \
+			$(GOBIN)/gotestsum --junitfile report/e2e-cli-tests.xml --format github-actions \
+			-- -tags e2e -count=1 -timeout 30m ./test/e2e/...; \
+	else \
+		GAAL_E2E_CLI=1 GAAL_E2E_PLATFORM=linux/$(GOARCH) \
+			go test -tags e2e -count=1 -timeout 30m ./test/e2e/...; \
+	fi
 
 ## coverage: run tests with coverage — generates all reports in report/
 ##   report/coverage.html          — standard go tool cover (default)


### PR DESCRIPTION
## Summary
- \`Makefile\` \`test-e2e\` + \`test-e2e-cli\`: drive \`go test\` through \`gotestsum --junitfile report/e2e-tests.xml\` when gotestsum is on PATH, fall back to plain \`go test\` otherwise (so ad-hoc local runs still work).
- \`.github/workflows/ci.yml\` e2e job: install gotestsum, post a passed/failed/skipped table to the GitHub job summary page, upload \`report/e2e-tests.xml\` as the \`e2e-test-results\` artifact (30-day retention, same as the unit-test report).
- \`.github/workflows/nightly-e2e-cli.yml\`: same install + upload pattern; report stays as \`e2e-layer2-test-results\`.

## Why
Previously the e2e job left only the inline log + docker diagnostics on failure. No machine-readable result for downstream tooling (test-history dashboards, flaky-test detection, etc.).

## Test plan
- [x] Local: \`make test-e2e\` writes \`report/e2e-tests.xml\` (54 tests, 3 skipped, 0 failures)
- [ ] CI runs \`make test-e2e\`; \`e2e-test-results\` artifact appears on the workflow run