### PR TITLE
build(e2e): cache fixture docker image (BuildKit GHA + ghcr publish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,13 +253,41 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # buildx with GHA cache so apk + npm layers survive across CI runs.
+      # Pulling from ghcr too (when published from main) gives us a warm
+      # cache even after a GHA cache eviction.
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build gaal binary for fixture
+        run: |
+          mkdir -p test/e2e/fixtures
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+            go build -trimpath -o test/e2e/fixtures/gaal .
+
+      - name: Pre-build fixture image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: test/e2e/fixtures
+          file: test/e2e/fixtures/Dockerfile
+          target: final
+          tags: gaal-e2e:dev
+          load: true
+          platforms: linux/amd64
+          cache-from: |
+            type=gha,scope=e2e-base
+            type=registry,ref=ghcr.io/getgaal/gaal-e2e:base-cache
+          cache-to: type=gha,mode=max,scope=e2e-base
+
+
       # gotestsum drives the e2e run when available, producing
       # report/e2e-tests.xml that the upload step ships as an artifact.
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
       # ubuntu-latest ships with the Docker daemon and BuildKit enabled by
-      # default — no extra setup step needed before `make test-e2e`.
+      # default — no extra setup step needed before `make test-e2e`. The
+      # harness's own `docker build` is now a near-no-op cache hit because
+      # the pre-build step loaded the image into the local daemon.
       - name: Run e2e suite
         run: make test-e2e
 

--- a/.github/workflows/publish-e2e-image.yml
+++ b/.github/workflows/publish-e2e-image.yml
@@ -1,0 +1,62 @@
+name: Publish E2E fixture image
+
+# Publishes the test/e2e/fixtures `base` stage to ghcr.io so that:
+#   1. CI's e2e job can pull `base-cache` as a long-lived registry cache,
+#      surviving GitHub Actions cache evictions.
+#   2. Local devs can `docker pull ghcr.io/getgaal/gaal-e2e:base-latest`
+#      to skip the slow apk + npm install on first `make test-e2e`.
+#
+# Triggered on:
+#   - push to main when test/e2e/fixtures/Dockerfile changes
+#   - manual dispatch (release manager / dockerfile-pin bumps)
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'test/e2e/fixtures/Dockerfile'
+      - '.github/workflows/publish-e2e-image.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build & push base image to ghcr.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push base image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: test/e2e/fixtures
+          file: test/e2e/fixtures/Dockerfile
+          target: base
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/getgaal/gaal-e2e:base-latest
+            ghcr.io/getgaal/gaal-e2e:base-${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/getgaal/gaal-e2e:base-cache
+          cache-to: type=registry,ref=ghcr.io/getgaal/gaal-e2e:base-cache,mode=max
+          # Don't bake the Layer-2 agent CLIs into the published base —
+          # they change often and would invalidate the cache for every PR.
+          # Layer 2 builds them on top via INSTALL_AGENT_CLIS=1 build arg.
+          build-args: |
+            INSTALL_AGENT_CLIS=0

--- a/test/e2e/fixtures/Dockerfile
+++ b/test/e2e/fixtures/Dockerfile
@@ -2,21 +2,25 @@
 #
 # Builds a small Alpine image carrying the prerequisites the e2e suite
 # exercises:
-#   - git, ca-certificates                    — VCS + TLS for skill cloning
+#   - git, mercurial, python3                 — VCS backends + HTTP fileserver
+#   - ca-certificates                         — TLS for skill cloning
 #   - bash, coreutils                         — predictable shell semantics
 #   - node + npm                              — agent CLIs (claude-code, codex)
 #
-# The gaal binary itself is NOT installed by the agent CLI install step:
-# the surrounding Makefile target compiles it for linux/amd64 and the test
-# harness COPYs it into /usr/local/bin/gaal as the LAST layer so iterative
-# rebuilds only re-do the cheap final step. The agent CLIs are gated behind
-# a build arg so the cheap layer-1 image can skip the slow npm install when
-# Layer 2 (`GAAL_E2E_CLI=1`) is not requested.
+# Two stages:
+#
+#   `base`   apk + (optional) npm install. Cacheable across CI runs and
+#            published as `ghcr.io/getgaal/gaal-e2e:base-latest` from main.
+#            Local devs and CI both pull it as a cache source so the slow
+#            apk + npm install layers are reused.
+#
+#   `final`  base + the gaal binary. The binary changes per build, so this
+#            layer is the only one that re-runs in the per-PR loop.
 #
 # Versions are pinned to specific patches so an upstream publish cannot
-# break CI overnight. Bump these deliberately (and re-run `make test-e2e`)
+# break CI overnight. Bump them deliberately (and re-run `make test-e2e`)
 # rather than letting the floating tags drift.
-FROM alpine:3.20.3
+FROM alpine:3.20.3 AS base
 
 ARG INSTALL_AGENT_CLIS=0
 ARG CLAUDE_CODE_VERSION=2.1.126
@@ -44,7 +48,12 @@ RUN if [ "$INSTALL_AGENT_CLIS" = "1" ]; then \
 # alive per `go test` invocation and `docker exec`s into it for every test.
 CMD ["sleep", "infinity"]
 
-# The gaal binary is copied last so editing the binary only invalidates
-# this layer (apk + npm stay cached).
+# Final stage adds the gaal binary on top of the cached base. Local devs
+# can pull just the base via:
+#   docker pull ghcr.io/getgaal/gaal-e2e:base-latest
+#   docker tag  ghcr.io/getgaal/gaal-e2e:base-latest gaal-e2e:base-latest
+# and `make test-e2e` will reuse those layers on its next build.
+FROM base AS final
+
 COPY gaal /usr/local/bin/gaal
 RUN chmod +x /usr/local/bin/gaal


### PR DESCRIPTION
Closes #177.

## Summary
Two-layer caching of the e2e fixture image so unchanged Dockerfiles stop costing 30–90s of apk + npm install on every CI run.

### A. BuildKit GHA cache (per-PR)
\`.github/workflows/ci.yml\` e2e job adds:
- \`docker/setup-buildx-action@v3\`
- \`docker/build-push-action@v6\` pre-build with:
  - \`--cache-from type=gha,scope=e2e-base\`
  - \`--cache-from type=registry,ref=ghcr.io/getgaal/gaal-e2e:base-cache\`
  - \`--cache-to type=gha,mode=max,scope=e2e-base\`
  - \`--load\`

The harness's own \`docker build\` becomes a near-no-op cache hit because the pre-build loaded the image into the local daemon.

### B. ghcr.io publish (per-Dockerfile-change)
New \`.github/workflows/publish-e2e-image.yml\`:
- Triggered on push to main when \`test/e2e/fixtures/Dockerfile\` changes (or manual dispatch)
- Builds \`--target base\` for linux/amd64 + linux/arm64
- Pushes \`ghcr.io/getgaal/gaal-e2e\` with tags:
  - \`base-latest\` (local devs pull this)
  - \`base-<sha>\` (immutable per-commit reference)
  - \`base-cache\` (registry-cache ref consumed by CI)

### Multi-stage Dockerfile
\`base\` stage: alpine + apk + optional npm. Cacheable.
\`final\` stage: base + \`COPY gaal\`. Only this stage re-runs per PR.

\`INSTALL_AGENT_CLIS=0\` for the published base so it stays small + stable; the heavier Layer 2 image with claude-code/codex builds on top in the nightly workflow.

## Why both A and B
- A alone: CI gets fast, local devs still pay first-run cost.
- B alone: published image goes stale between Dockerfile changes; CI's first run after a stale period still rebuilds.
- A + B: local + CI + cross-runner, all warm.

## Test plan
- [x] \`make test-e2e\` passes locally with the new multi-stage Dockerfile (44s)
- [ ] First CI run on this PR populates GHA cache; subsequent runs hit it
- [ ] After merge, the publish workflow runs once (paths filter triggers on the Dockerfile change in this PR), seeding ghcr
- [ ] Local: \`docker pull ghcr.io/getgaal/gaal-e2e:base-latest\` works after publish