### PR TITLE
test(e2e): add GAAL_E2E_VERBOSE for live docker exec streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,16 @@ make test-e2e   # reuses the cached base layers; only the binary COPY re-runs
 CI uploads the JUnit report (`report/e2e-tests.xml`) plus
 `docker logs`/`docker inspect` diagnostics on failure as workflow artifacts.
 
+For interactive debugging — watching every `docker exec` invocation
+(banner) and gaal's stdout/stderr stream live to the terminal:
+
+```bash
+GAAL_E2E_VERBOSE=1 go test -v -tags e2e -run TestVCS_GitBackend_CloneAndCheckout ./test/e2e/...
+```
+
+Off by default so the per-PR run stays clean; the captured `ExecResult`
+fields are unchanged either way so existing assertions keep working.
+
 See [`docs/architecture.md`](docs/architecture.md) for a full description of the internals.
 
 ---

--- a/test/e2e/container_test.go
+++ b/test/e2e/container_test.go
@@ -7,6 +7,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"path"
 	"sort"
@@ -15,6 +17,43 @@ import (
 	"testing"
 	"time"
 )
+
+// verboseExec reports whether GAAL_E2E_VERBOSE=1 is set. When true, every
+// Exec / ExecTTY / WriteFileBytes call prints a banner to stderr before
+// running and streams the in-container process's stdout + stderr live (via
+// io.MultiWriter) so a developer running `go test -v` can watch gaal's
+// behavior in real time. The captured ExecResult fields are unchanged so
+// existing assertions keep working. See issue #181.
+func verboseExec() bool {
+	return os.Getenv("GAAL_E2E_VERBOSE") == "1"
+}
+
+// vbanner prints "[gaal-e2e] docker <argv>" to stderr in verbose mode.
+// Kept short on purpose: the value is showing the exec line itself; long
+// prefixes get in the way of grep.
+func vbanner(args []string) {
+	if !verboseExec() {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "[gaal-e2e] docker "+strings.Join(args, " "))
+}
+
+// vstdout / vstderr return the writers Exec/ExecTTY use. In verbose mode
+// the captured buffer also tees to os.Stderr/os.Stdout so output streams
+// live; in normal mode the writers are the buffer alone (current behavior).
+func vstdout(buf io.Writer) io.Writer {
+	if verboseExec() {
+		return io.MultiWriter(buf, os.Stderr)
+	}
+	return buf
+}
+
+func vstderr(buf io.Writer) io.Writer {
+	if verboseExec() {
+		return io.MultiWriter(buf, os.Stderr)
+	}
+	return buf
+}
 
 // TestContainer wraps the long-lived Docker container shared across the
 // suite. All exec, file-IO and lifecycle operations route through it so
@@ -110,10 +149,11 @@ func (c *TestContainer) Exec(t *testing.T, env Env, workdir string, argv ...stri
 	full = append(full, c.id)
 	full = append(full, argv...)
 
+	vbanner(full)
 	cmd := exec.Command("docker", full...)
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = vstdout(&stdout)
+	cmd.Stderr = vstderr(&stderr)
 	err := cmd.Run()
 	res := ExecResult{Stdout: stdout.String(), Stderr: stderr.String()}
 	if err != nil {
@@ -156,9 +196,13 @@ func (c *TestContainer) ExecTTY(t *testing.T, env Env, workdir string, argv ...s
 	full = append(full, c.id)
 	full = append(full, argv...)
 
+	vbanner(full)
 	cmd := exec.Command("docker", full...)
-	out, err := cmd.CombinedOutput()
-	res := ExecResult{Stdout: string(out)}
+	var combined bytes.Buffer
+	cmd.Stdout = vstdout(&combined)
+	cmd.Stderr = vstderr(&combined)
+	err := cmd.Run()
+	res := ExecResult{Stdout: combined.String()}
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			res.ExitCode = ee.ExitCode()
@@ -188,6 +232,9 @@ func (c *TestContainer) WriteFileBytes(t *testing.T, p string, content []byte) {
 		t.Fatalf("mkdir -p %s: %s", parent, mk.Combined())
 	}
 	args := []string{"exec", "-i", c.id, "sh", "-c", "cat > " + shellQuote(p)}
+	if verboseExec() {
+		fmt.Fprintf(os.Stderr, "[gaal-e2e] docker exec -i <cid> write %s (%d bytes)\n", p, len(content))
+	}
 	cmd := exec.Command("docker", args...)
 	cmd.Stdin = bytes.NewReader(content)
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
Closes #181.

## Summary
Opt-in verbose mode for the e2e harness, keyed off \`GAAL_E2E_VERBOSE=1\`. When set:

- Every \`Exec\` / \`ExecTTY\` / \`WriteFileBytes\` prints a one-line banner to stderr:
  \`\`\`
  [gaal-e2e] docker exec -e HOME=... -w /work <cid> gaal -c gaal.yaml sync
  \`\`\`
- stdout + stderr stream live via \`io.MultiWriter\` (buffer + os.Stderr) so the captured \`ExecResult\` fields stay unchanged for existing assertions but the bytes appear on the terminal as gaal produces them.

## Why
Until now the harness captures every \`docker exec\` via \`cmd.CombinedOutput()\` and only surfaces the output when an assertion fails. Watching gaal's behavior in flight — say, while debugging a subtle sync misorder — required guessing or adding throwaway \`t.Logf\` calls.

## Off by default
Per-PR runs and CI keep their current clean output. Verbose is a debug-only opt-in.

## Usage
\`\`\`bash
GAAL_E2E_VERBOSE=1 go test -v -run TestVCS_GitBackend_CloneAndCheckout -tags e2e ./test/e2e/...
\`\`\`

## Test plan
- [x] Verbose mode: \`GAAL_E2E_VERBOSE=1 go test -v -run TestSmoke_Version -tags e2e ./test/e2e/...\` prints every docker exec banner + gaal's stdout (\`gaal dev\` / \`built unknown\`) live; PASS in 0.26s
- [x] Default mode: same command without the env var produces only \`ok gaal/test/e2e 1.122s\`
- [x] \`go vet -tags e2e ./test/e2e/...\`
- [x] README \`Development\` section updated