### PR TITLE
test(e2e): verbose mode also turns on gaal --verbose; suppress git init hint

### DIFF
--- a/test/e2e/container_test.go
+++ b/test/e2e/container_test.go
@@ -358,9 +358,18 @@ func (e *testEnv) gaalEnv() Env {
 // The first argv element is typically "sync"/"status"/"prune"; the test
 // supplies a config path via -c. The --no-banner flag suppresses the
 // ASCII art so test output stays grep-friendly.
+//
+// When GAAL_E2E_VERBOSE=1, --verbose is also injected so gaal's own
+// slog DEBUG lines stream out (the harness's docker-exec MultiWriter
+// only carries them through if gaal actually emits them — default mode
+// is summary-first by design, so without --verbose there is nothing
+// meaningful to watch). See issue #183.
 func (e *testEnv) gaal(t *testing.T, configPath string, argv ...string) ExecResult {
 	t.Helper()
 	full := []string{"gaal", "--no-banner"}
+	if verboseExec() {
+		full = append(full, "--verbose")
+	}
 	if configPath != "" {
 		full = append(full, "-c", configPath)
 	}

--- a/test/e2e/vcs_git_test.go
+++ b/test/e2e/vcs_git_test.go
@@ -38,19 +38,20 @@ func initBareGitRepo(t *testing.T, env *testEnv, root, name string) string {
 	bare := path.Join(root, name+".git")
 	work := path.Join(root, name+"-work")
 
-	env.c.MustExec(t, nil, "", "git", "init", "--bare", bare)
-	env.c.MustExec(t, nil, "", "git", "init", work)
+	// `git -c init.defaultBranch=main` per call sets the initial branch
+	// without ever touching the host's global git config (AGENTS.md
+	// forbids global mutations) and silences the "Using 'master'" hint
+	// that would otherwise pollute verbose / failure logs.
+	env.c.MustExec(t, nil, "", "git", "-c", "init.defaultBranch=main", "init", "--bare", bare)
+	env.c.MustExec(t, nil, "", "git", "-c", "init.defaultBranch=main", "init", work)
 	env.c.WriteFile(t, path.Join(work, "README.md"), "# initial\n")
 	env.c.MustExec(t, gitConfigEnv, work, "git", "add", "README.md")
 	env.c.MustExec(t, gitConfigEnv, work, "git", "commit", "-m", "initial")
-	// Default branch name varies across git versions — force "main".
-	env.c.MustExec(t, gitConfigEnv, work, "git", "branch", "-M", "main")
 	env.c.MustExec(t, gitConfigEnv, work, "git", "remote", "add", "origin", bare)
 	env.c.MustExec(t, gitConfigEnv, work, "git", "push", "-u", "origin", "main")
 	// Re-point HEAD on the bare repo so go-git's PlainClone resolves the
-	// default branch. `git init --bare` defaults HEAD to whatever
-	// init.defaultBranch is (often "master") which leaves it unborn after
-	// pushing "main"; clone then fails with "reference not found".
+	// default branch. Even with init.defaultBranch=main on `git init --bare`,
+	// the bare's HEAD is unborn until the first push lands.
 	env.c.MustExec(t, nil, "", "git", "--git-dir", bare,
 		"symbolic-ref", "HEAD", "refs/heads/main")
 	return bare


### PR DESCRIPTION
Closes #183.

## Summary
1. **\`env.gaal()\` injects \`--verbose\`** when \`GAAL_E2E_VERBOSE=1\`. Without it the harness banners appeared but gaal stdout was 1–2 summary lines (per #107's quiet-by-default design), so verbose mode looked like it wasn't doing anything useful. With this, every gaal sync prints its full slog DEBUG trace through the harness's MultiWriter to stderr.
2. **\`git -c init.defaultBranch=main init ...\`** — silences the noisy "hint: Using 'master'..." block that printed twice per git VCS test. \`-c\` is per-call so the host's global git config stays untouched (AGENTS.md / git policy forbids modifying it). The redundant \`git branch -M main\` after the first commit is removed.

## Verified locally
Same \`TestVCS_GitBackend_CloneAndCheckout\` that the user ran on \`main\`:

**Before** (default verbose):
\`\`\`
[gaal-e2e] docker exec ... git init --bare ...
hint: Using 'master' as the name for the initial branch...
hint: ...git config --global init.defaultBranch <name>...
[gaal-e2e] docker exec ... git init <work>
hint: Using 'master'... (again)
...
[gaal-e2e] docker exec ... gaal --no-banner -c gaal.yaml sync
Cloned /tmp/.../src/myrepo.
✓ Synced in 8ms.
\`\`\`

**After**:
- No \`hint: Using 'master'\` blocks anywhere
- gaal sync prints ~80 lines of slog DEBUG (\`resolving project skills search dirs\`, \`scanning workspace dir=\`, \`checking for local changes path=\`, etc.) in real time, ending with \`✓ /tmp/.../src/myrepo cloned\` and \`sync complete in 9ms\`

## Test plan
- [x] \`go vet -tags e2e ./test/e2e/...\`
- [x] \`make test-e2e\` (still passes; the additional \`--verbose\` lines are captured but not asserted on, and git VCS tests no longer surface the warning)
- [x] Verbose run on \`TestVCS_GitBackend_CloneAndCheckout\` shows gaal slog DEBUG output and no git hint