### PR TITLE
fix(migrate): drop dead --yes flag

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -12,7 +12,6 @@ import (
 var (
 	migrateTarget string
 	migrateDryRun bool
-	migrateYes    bool
 )
 
 var migrateCmd = &cobra.Command{
@@ -30,8 +29,7 @@ when migration becomes available.
 
 Examples:
   gaal migrate --to community https://community.example.com
-  gaal migrate --to community https://community.example.com --dry-run
-  gaal migrate --to community https://community.example.com --yes`,
+  gaal migrate --to community https://community.example.com --dry-run`,
 	SilenceUsage: true,
 	Args:         cobra.MaximumNArgs(1),
 	RunE:         runMigrate,
@@ -40,7 +38,6 @@ Examples:
 func init() {
 	migrateCmd.Flags().StringVar(&migrateTarget, "to", "", `migration target (currently only "community" is supported)`)
 	migrateCmd.Flags().BoolVar(&migrateDryRun, "dry-run", false, "validate everything but do not perform the migration")
-	migrateCmd.Flags().BoolVar(&migrateYes, "yes", false, "skip interactive confirmation")
 	rootCmd.AddCommand(migrateCmd)
 }
 

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -14,20 +14,17 @@ func resetMigrateFlags(t *testing.T) {
 	origCfg := cfgFile
 	origTarget := migrateTarget
 	origDryRun := migrateDryRun
-	origYes := migrateYes
 	origOpts := engineOpts
 	origResolved := resolvedCfg
 	t.Cleanup(func() {
 		cfgFile = origCfg
 		migrateTarget = origTarget
 		migrateDryRun = origDryRun
-		migrateYes = origYes
 		engineOpts = origOpts
 		resolvedCfg = origResolved
 	})
 	migrateTarget = ""
 	migrateDryRun = false
-	migrateYes = false
 }
 
 func writeMinimalConfig(t *testing.T, dir string) string {


### PR DESCRIPTION
Closes #141. The flag was declared and advertised but never read in `runMigrate` — migrate is currently a stub that never prompts. Re-add when migrate gains an interactive confirmation step.