### PR TITLE
fix(info): route output through effectiveOutputFormat to honor --verbose

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -50,5 +50,5 @@ func runInfo(_ *cobra.Command, args []string) error {
 
 	telemetry.Track("info")
 	return engine.NewWithOptions(cfg.Config, engineOpts).
-		Info(context.Background(), pkg, filter, engine.OutputFormat(outputFormat))
+		Info(context.Background(), pkg, filter, engine.OutputFormat(effectiveOutputFormat()))
 }


### PR DESCRIPTION
Closes #129. `info` was passing the raw `outputFormat` string instead of calling `effectiveOutputFormat()`, so `gaal -v info skill` looked identical to `gaal info skill`.