### PR TITLE
fix(summary): count MCP servers per agent in sync brief rollup

### DIFF
--- a/internal/engine/ops/agents.go
+++ b/internal/engine/ops/agents.go
@@ -42,13 +42,20 @@ func ListAgents(home, workDir string) ([]render.AgentEntry, error) {
 			source = "user"
 		}
 
+		// Resolved (absolute) MCP config paths for both scopes. Render
+		// uses these to attribute MCP entries to their owning agent —
+		// see render.buildAgentRollup (#127 fix).
+		projectMCP, _ := agent.ProjectMCPConfigPath(a.Name, home)
+		globalMCP, _ := agent.GlobalMCPConfigPath(a.Name, home)
+
 		entries = append(entries, render.AgentEntry{
 			Name:                    a.Name,
 			Installed:               installed,
 			Source:                  source,
 			ProjectSkillsDir:        projectDir,
 			GlobalSkillsDir:         globalDir,
-			ProjectMCPConfigFile:    a.Info.GlobalMCPConfigFile,
+			ProjectMCPConfigFile:    projectMCP,
+			GlobalMCPConfigFile:     globalMCP,
 			ProjectSkillsViaGeneric: a.Info.SupportsGenericProject,
 			GlobalSkillsViaGeneric:  a.Info.SupportsGenericGlobal,
 		})

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -46,6 +46,7 @@ type AgentEntry struct {
 	ProjectSkillsDir        string `json:"project_skills_dir"`
 	GlobalSkillsDir         string `json:"global_skills_dir"`
 	ProjectMCPConfigFile    string `json:"project_mcp_config_file,omitempty"`
+	GlobalMCPConfigFile     string `json:"global_mcp_config_file,omitempty"`
 	ProjectSkillsViaGeneric bool   `json:"project_skills_via_generic,omitempty"`
 	GlobalSkillsViaGeneric  bool   `json:"global_skills_via_generic,omitempty"`
 }

--- a/internal/engine/render/summary_sync.go
+++ b/internal/engine/render/summary_sync.go
@@ -134,11 +134,24 @@ func buildAgentRollup(status *StatusReport) []string {
 		skillsByAgent[e.Agent] += len(e.Installed)
 	}
 
-	// Count managed MCPs (exclude unmanaged).
-	mcpCount := 0
+	// Count MCPs per agent by matching each entry's Target to the agent's
+	// known MCP config paths (project + global). Fix for #127 — the
+	// previous code reused one global mcpCount across every per-agent
+	// row so a single MCP entry showed up under three agents.
+	mcpsByAgent := map[string]int{}
 	for _, m := range status.MCPs {
-		if m.Status != StatusUnmanaged {
-			mcpCount++
+		if m.Status == StatusUnmanaged || m.Target == "" {
+			continue
+		}
+		for _, a := range status.Agents {
+			if !a.Installed {
+				continue
+			}
+			if (a.ProjectMCPConfigFile != "" && a.ProjectMCPConfigFile == m.Target) ||
+				(a.GlobalMCPConfigFile != "" && a.GlobalMCPConfigFile == m.Target) {
+				mcpsByAgent[a.Name]++
+				break
+			}
 		}
 	}
 
@@ -151,7 +164,7 @@ func buildAgentRollup(status *StatusReport) []string {
 		entries = append(entries, agentRollupEntry{
 			name:       a.Name,
 			skillCount: skillsByAgent[a.Name],
-			mcpCount:   mcpCount,
+			mcpCount:   mcpsByAgent[a.Name],
 		})
 	}
 


### PR DESCRIPTION
Closes #127. The previous `buildAgentRollup` reused one global `mcpCount` across every per-agent row. Now matches each MCP entry's `Target` against the agent's resolved project + global MCP config paths via the new `GlobalMCPConfigFile` field on `AgentEntry`.