### PR TITLE
fix(secfile): make Write atomic (temp + fsync + rename)

### DIFF
--- a/internal/secfile/secfile.go
+++ b/internal/secfile/secfile.go
@@ -1,27 +1,67 @@
-// Package secfile writes files with mode 0o600 and tightens existing files
-// that were created with looser permissions. Use this for any file that may
-// hold secrets — MCP env tokens, telemetry state, log records, gaal config.
+// Package secfile writes files with mode 0o600 atomically (temp + rename)
+// and tightens existing files that were created with looser permissions.
+// Use this for any file that may hold secrets — MCP env tokens, telemetry
+// state, log records, gaal config.
 package secfile
 
 import (
 	"log/slog"
 	"os"
+	"path/filepath"
 )
 
 // Mode is the permission bits applied to all secret files.
 const Mode os.FileMode = 0o600
 
-// Write writes data to path with mode 0o600. If path already exists with
-// looser permissions, it is tightened via Chmod after the write — os.WriteFile
-// only honours the mode argument on file creation, so an existing 0o644 file
-// would otherwise stay world-readable.
+// Write writes data to path with mode 0o600 **atomically**: bytes land in
+// a sibling temp file, are fsynced, then renamed onto the final path. A
+// crash, SIGINT, or full-disk during the write cannot leave a half-
+// written file at the target — either the previous content survives or
+// the new content is fully present (#120).
+//
+// On filesystems that don't support a same-dir CreateTemp (rare), Write
+// falls back to a direct os.WriteFile + Chmod, with a warn log so the
+// degraded mode is visible.
 func Write(path string, data []byte) error {
-	if err := os.WriteFile(path, data, Mode); err != nil {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".gaal-tmp-*")
+	if err != nil {
+		slog.Warn("secfile: temp file creation failed; falling back to direct write",
+			"path", path, "err", err)
+		if werr := os.WriteFile(path, data, Mode); werr != nil {
+			return werr
+		}
+		if cerr := os.Chmod(path, Mode); cerr != nil {
+			slog.Warn("secfile: chmod failed", "path", path, "err", cerr)
+		}
+		return nil
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
 		return err
 	}
-	if err := os.Chmod(path, Mode); err != nil {
-		slog.Warn("secfile: chmod failed", "path", path, "err", err)
+	if err := tmp.Chmod(Mode); err != nil {
+		slog.Warn("secfile: chmod (temp) failed", "path", tmpPath, "err", err)
 	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
 	return nil
 }
 


### PR DESCRIPTION
Closes #120. `secfile.Write` (the helper every MCP/telemetry/init writer routes through) now writes to a sibling temp file, fsyncs, and atomically renames onto the target. A crash mid-write cannot leave a half-written file at the destination.