### PR TITLE
fix(http): hardened internal/httpx client (timeout, TLS, redirect SSRF, UA, body cap)

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,6 +6,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"gaal/internal/httpx"
 )
 
 // These variables are optionally injected at build time via ldflags:
@@ -36,4 +38,5 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	httpx.SetUserAgent("gaal/" + Version)
 }

--- a/internal/core/vcs/archive.go
+++ b/internal/core/vcs/archive.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gaal/internal/httpx"
 	"gaal/internal/urlx"
 )
 
@@ -96,16 +97,18 @@ func (a *VcsArchive) HasChanges(_ context.Context, _ string) (bool, error) {
 }
 
 // fetchURL performs a GET request and returns the response body.
+// Body-size enforcement is the caller's responsibility — extractors wrap
+// the returned ReadCloser in io.LimitReader(MaxArchiveBytes+1).
 func fetchURL(ctx context.Context, rawURL string) (io.ReadCloser, error) {
 	if err := urlx.ValidateRemoteFetchURL(rawURL); err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	req, err := httpx.NewRequest(ctx, http.MethodGet, rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("building request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpx.Client().Do(req)
 	safeURL := urlx.Redact(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetching %s: %w", safeURL, err)

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -1,0 +1,199 @@
+// Package httpx provides a single hardened HTTP client for outbound
+// fetches (MCP remote configs, archive downloads). Centralising the
+// configuration here makes the security posture auditable and prevents
+// stray http.DefaultClient calls from regressing the defaults.
+//
+// Defaults applied:
+//   - Hard timeout per request (configurable via context, plus a generous
+//     fallback Client.Timeout so a hung connection cannot pin a sync
+//     forever).
+//   - TLS minimum version 1.2.
+//   - Redirect cap of 10 hops; cross-scheme downgrades (https→http) and
+//     redirects to loopback / RFC1918 hosts are rejected to defend
+//     against SSRF via redirect.
+//   - Stable User-Agent ("gaal/<version>") so well-behaved servers can
+//     identify and rate-limit us.
+//
+// Body-size enforcement is the caller's responsibility — wrap the
+// returned body in io.LimitReader(MaxBodyBytes) before consuming it.
+// We don't hide that inside the client because tar/zip extraction
+// needs to stream large payloads with its own per-entry caps.
+package httpx
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// MaxBodyBytes is the recommended cap for ad-hoc JSON/text fetches
+// (e.g. remote MCP server entries). Archive downloads use their own,
+// larger cap defined in core/vcs.
+const MaxBodyBytes int64 = 16 << 20 // 16 MiB
+
+// DefaultClientTimeout is the per-request hard cap. Generous so that
+// large archive downloads complete on slow links, but finite so a
+// stalled handshake can't hang sync indefinitely.
+const DefaultClientTimeout = 5 * time.Minute
+
+// MaxRedirects caps how many 3xx hops the client will follow before
+// giving up. Matches the historical http.DefaultClient cap so existing
+// well-behaved redirects keep working.
+const MaxRedirects = 10
+
+var userAgent atomic.Value // string
+
+func init() {
+	userAgent.Store("gaal")
+}
+
+// SetUserAgent updates the User-Agent header used by Client(). Safe to
+// call from cmd init once the version string is known.
+func SetUserAgent(ua string) {
+	if ua == "" {
+		return
+	}
+	userAgent.Store(ua)
+}
+
+// UserAgent returns the current User-Agent.
+func UserAgent() string {
+	if v, ok := userAgent.Load().(string); ok {
+		return v
+	}
+	return "gaal"
+}
+
+var sharedClient = newClient()
+
+// Client returns the shared hardened http.Client. The same instance is
+// returned on every call so connection pooling works across fetches.
+func Client() *http.Client {
+	return sharedClient
+}
+
+func newClient() *http.Client {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+
+	return &http.Client{
+		Transport:     transport,
+		Timeout:       DefaultClientTimeout,
+		CheckRedirect: checkRedirect,
+	}
+}
+
+// ErrCrossSchemeRedirect is returned when an https:// response 3xx-points
+// to an http:// target (other than loopback). Returning an error from
+// CheckRedirect causes Client.Do to surface it to the caller without
+// following the redirect.
+var ErrCrossSchemeRedirect = errors.New("redirect downgrades scheme from https to http")
+
+// ErrTooManyRedirects is returned when the redirect chain exceeds MaxRedirects.
+var ErrTooManyRedirects = errors.New("too many redirects")
+
+// ErrInternalRedirect is returned when an external host redirects to a
+// loopback or RFC1918 / link-local address (SSRF defence).
+var ErrInternalRedirect = errors.New("redirect to internal/loopback host blocked")
+
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= MaxRedirects {
+		return fmt.Errorf("%w (>%d hops)", ErrTooManyRedirects, MaxRedirects)
+	}
+	if len(via) == 0 {
+		return nil
+	}
+	prev := via[len(via)-1].URL
+	next := req.URL
+
+	// Block https → http downgrades unless the target is loopback (CI
+	// fixtures legitimately bounce through 127.0.0.1).
+	if strings.EqualFold(prev.Scheme, "https") && strings.EqualFold(next.Scheme, "http") {
+		if !isLoopback(next.Host) {
+			return fmt.Errorf("%w: %s → %s", ErrCrossSchemeRedirect, prev.Redacted(), next.Redacted())
+		}
+	}
+
+	// Block external → internal redirects. If the original request went to
+	// a public host but a redirect points us at an internal/loopback
+	// address, that's the textbook SSRF redirect attack.
+	origin := via[0].URL
+	if !isInternal(origin.Host) && isInternal(next.Host) {
+		return fmt.Errorf("%w: %s → %s", ErrInternalRedirect, origin.Redacted(), next.Redacted())
+	}
+
+	// Carry the User-Agent across redirects (net/http drops some headers
+	// across hops; UA is fine to propagate).
+	req.Header.Set("User-Agent", UserAgent())
+	return nil
+}
+
+// isLoopback reports whether host:port is a literal loopback address.
+// We deliberately do not DNS-resolve; that would race against the
+// actual connection.
+func isLoopback(hostport string) bool {
+	host := hostport
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// isInternal returns true for loopback, link-local, and RFC1918 / RFC4193
+// private address space. Used by the redirect SSRF guard.
+func isInternal(hostport string) bool {
+	host := hostport
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() {
+		return true
+	}
+	return false
+}
+
+// NewRequest is a thin wrapper around http.NewRequestWithContext that
+// applies the default User-Agent header. Use it instead of building
+// requests by hand.
+func NewRequest(ctx context.Context, method, rawURL string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", UserAgent())
+	return req, nil
+}

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -1,0 +1,156 @@
+package httpx
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUserAgentDefault(t *testing.T) {
+	if got := UserAgent(); got != "gaal" {
+		t.Errorf("default UserAgent = %q, want %q", got, "gaal")
+	}
+}
+
+func TestSetUserAgent(t *testing.T) {
+	orig := UserAgent()
+	t.Cleanup(func() { SetUserAgent(orig) })
+
+	SetUserAgent("gaal/1.2.3")
+	if got := UserAgent(); got != "gaal/1.2.3" {
+		t.Errorf("UserAgent after Set = %q, want %q", got, "gaal/1.2.3")
+	}
+
+	// Empty string is a no-op.
+	SetUserAgent("")
+	if got := UserAgent(); got != "gaal/1.2.3" {
+		t.Errorf("UserAgent after Set(\"\") = %q, want unchanged %q", got, "gaal/1.2.3")
+	}
+}
+
+func TestNewRequestSetsUserAgent(t *testing.T) {
+	orig := UserAgent()
+	t.Cleanup(func() { SetUserAgent(orig) })
+	SetUserAgent("gaal/test")
+
+	req, err := NewRequest(context.Background(), http.MethodGet, "https://example.invalid/x")
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if got := req.Header.Get("User-Agent"); got != "gaal/test" {
+		t.Errorf("UA header = %q, want %q", got, "gaal/test")
+	}
+}
+
+// TestClientTimeoutFires verifies that a request whose context deadline
+// is already past returns promptly (the context cancel beats the
+// generous Client.Timeout). We assert both the prompt return and the
+// fact that the error mentions context cancellation.
+func TestClientTimeoutFires(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Sleep longer than the test's context deadline.
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(2 * time.Second):
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	req, err := NewRequest(ctx, http.MethodGet, srv.URL)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	start := time.Now()
+	_, err = Client().Do(req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if elapsed > time.Second {
+		t.Errorf("request took %v, expected <1s after 100ms context", elapsed)
+	}
+}
+
+// TestRedirectCap verifies the client refuses to follow more than
+// MaxRedirects hops.
+func TestRedirectCap(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv.URL, http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	_, err = Client().Do(req)
+	if err == nil {
+		t.Fatal("expected redirect-cap error, got nil")
+	}
+	if !errors.Is(err, ErrTooManyRedirects) && !strings.Contains(err.Error(), "stopped after") {
+		t.Errorf("error = %v, want too-many-redirects", err)
+	}
+}
+
+func TestIsLoopback(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"localhost", true},
+		{"localhost:8080", true},
+		{"127.0.0.1", true},
+		{"127.0.0.1:443", true},
+		{"[::1]", true},
+		{"[::1]:8080", true},
+		{"::1", true},
+		{"example.com", false},
+		{"8.8.8.8", false},
+		{"10.0.0.1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := isLoopback(tt.in); got != tt.want {
+				t.Errorf("isLoopback(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInternal(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"10.0.0.1", true},
+		{"172.16.0.1", true},
+		{"192.168.1.1", true},
+		{"169.254.169.254", true}, // AWS IMDS
+		{"::1", true},
+		{"fe80::1", true},
+		{"example.com", false},
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := isInternal(tt.in); got != tt.want {
+				t.Errorf("isInternal(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"gaal/internal/config"
 	"gaal/internal/core/agent"
 	"gaal/internal/discover"
+	"gaal/internal/httpx"
 	"gaal/internal/urlx"
 )
 
@@ -227,12 +229,12 @@ func fetchRemoteEntry(ctx context.Context, rawURL, name string) (serverEntry, er
 	}
 	safeURL := urlx.Redact(rawURL)
 	slog.DebugContext(ctx, "fetching remote mcp config", "url", safeURL, "name", name)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	req, err := httpx.NewRequest(ctx, http.MethodGet, rawURL)
 	if err != nil {
 		return serverEntry{}, fmt.Errorf("building request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpx.Client().Do(req)
 	if err != nil {
 		return serverEntry{}, fmt.Errorf("fetching %s: %w", safeURL, err)
 	}
@@ -242,11 +244,15 @@ func fetchRemoteEntry(ctx context.Context, rawURL, name string) (serverEntry, er
 		return serverEntry{}, fmt.Errorf("fetching %s: HTTP %d", safeURL, resp.StatusCode)
 	}
 
+	// Cap the JSON body so a hostile or runaway server cannot OOM the
+	// process. 16 MiB is well above any realistic mcpServers document.
+	body := io.LimitReader(resp.Body, httpx.MaxBodyBytes+1)
+
 	// Try to decode as a full mcpServers document first.
 	var doc struct {
 		MCPServers map[string]serverEntry `json:"mcpServers"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+	if err := json.NewDecoder(body).Decode(&doc); err != nil {
 		return serverEntry{}, fmt.Errorf("decoding JSON: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- New `internal/httpx` package owns the single outbound HTTP client.
- Replaces both `http.DefaultClient` call sites: `internal/mcp/manager.go` (remote MCP config fetch) and `internal/core/vcs/archive.go` (archive download).
- Hardens defaults: TLS 1.2 minimum, 5-min request timeout (callers can tighten via context), 10-hop redirect cap.
- SSRF defence on redirects: refuses https→http downgrades to non-loopback, refuses external→internal/loopback redirects (e.g. AWS IMDS at 169.254.169.254).
- Stable User-Agent \`gaal/<Version>\` set from cmd init.
- MCP JSON body capped via \`io.LimitReader(MaxBodyBytes+1)\`. Archive extraction already streams under \`MaxArchiveBytes+1\` so the fetcher documents that body capping is the caller's responsibility.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/httpx/ ./internal/mcp/ ./internal/core/vcs/\`
- [x] New tests cover UA, redirect cap, context-timeout propagation, and loopback / internal classifiers.

Closes #123