### PR TITLE
fix(vcs): VcsArchive.Update re-fetches and atomically replaces dest

### DIFF
--- a/internal/core/vcs/archive.go
+++ b/internal/core/vcs/archive.go
@@ -48,9 +48,41 @@ const (
 var errEntryTooLarge = errors.New("archive entry exceeds per-file size cap")
 
 func (a *VcsArchive) Clone(ctx context.Context, url, path, version string) error {
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		return fmt.Errorf("creating target directory: %w", err)
+	return a.fetchAndExtract(ctx, url, path, version)
+}
+
+// Update re-downloads and re-extracts the archive. Archives have no
+// incremental-update primitive (no commit graph, no working metadata) so
+// every Update is a fresh fetch + atomic swap of the destination tree.
+// Unlike the historical no-op behaviour, this guarantees that changes to
+// the upstream archive — or to the configured version: prefix — are
+// reflected on the next sync. #124.
+func (a *VcsArchive) Update(ctx context.Context, url, path, version string) error {
+	if url == "" {
+		return fmt.Errorf("archive update requires a url (callers must pass cfg.URL)")
 	}
+	return a.fetchAndExtract(ctx, url, path, version)
+}
+
+// fetchAndExtract downloads the archive at url and extracts it into path,
+// staging into a sibling temp directory and atomically replacing path on
+// success. A crash mid-extract leaves the previous tree intact (or the
+// new one fully installed) — never a half-written hybrid.
+func (a *VcsArchive) fetchAndExtract(ctx context.Context, url, path, version string) error {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("creating archive parent dir: %w", err)
+	}
+	staging, err := os.MkdirTemp(parent, ".gaal-archive-tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating archive staging dir: %w", err)
+	}
+	cleanupStage := true
+	defer func() {
+		if cleanupStage {
+			_ = os.RemoveAll(staging)
+		}
+	}()
 
 	data, err := fetchURL(ctx, url)
 	if err != nil {
@@ -64,19 +96,29 @@ func (a *VcsArchive) Clone(ctx context.Context, url, path, version string) error
 
 	switch a.Format {
 	case "tar":
-		return extractTar(limited, path, version)
+		if err := extractTar(limited, staging, version); err != nil {
+			return err
+		}
 	case "zip":
-		return extractZip(limited, path, version)
+		if err := extractZip(limited, staging, version); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("unsupported archive format: %q", a.Format)
 	}
-}
 
-// Update re-downloads and extracts the archive (no incremental update possible).
-func (a *VcsArchive) Update(ctx context.Context, path, version string) error {
-	// Archives have no "version" concept — just re-extract.
-	// We need the URL: it is not stored in the struct, so Update is a no-op
-	// for archives. The manager should call Clone instead.
+	// Replace path atomically. RemoveAll + Rename — Go's os.Rename onto
+	// an existing directory fails on POSIX, so we have to remove first.
+	// The window is brief and a crash mid-swap leaves either the old
+	// tree (Remove failed before Rename ran) or the new one (Rename
+	// completed); never a partial overlay.
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("removing previous archive dir: %w", err)
+	}
+	if err := os.Rename(staging, path); err != nil {
+		return fmt.Errorf("renaming staging archive dir: %w", err)
+	}
+	cleanupStage = false
 	return nil
 }
 

--- a/internal/core/vcs/archive_test.go
+++ b/internal/core/vcs/archive_test.go
@@ -83,11 +83,71 @@ func TestVcsArchive_CurrentVersion(t *testing.T) {
 	}
 }
 
-func TestVcsArchive_Update_NoOp(t *testing.T) {
+// TestVcsArchive_Update_RequiresURL guards against a future regression
+// to the historical no-op behaviour: Update must surface the missing
+// URL instead of silently doing nothing.
+func TestVcsArchive_Update_RequiresURL(t *testing.T) {
 	a := &VcsArchive{Format: "tar"}
-	err := a.Update(context.Background(), t.TempDir(), "")
-	if err != nil {
-		t.Errorf("Update should be a no-op, got error: %v", err)
+	err := a.Update(context.Background(), "", t.TempDir(), "")
+	if err == nil {
+		t.Fatal("expected error when Update is called without a URL")
+	}
+}
+
+// TestVcsArchive_Update_RefetchesAndReplaces verifies that a second
+// Update call against a changed upstream archive produces a fresh
+// extracted tree (and removes files no longer present in the new
+// archive). This is the regression test for #124.
+func TestVcsArchive_Update_RefetchesAndReplaces(t *testing.T) {
+	v1 := buildTarGz(t, map[string]string{
+		"project/keep.txt":   "v1",
+		"project/old.txt":    "removed in v2",
+		"project/sub/data.x": "v1",
+	})
+	v2 := buildTarGz(t, map[string]string{
+		"project/keep.txt":   "v2",
+		"project/new.txt":    "added in v2",
+		"project/sub/data.x": "v2",
+	})
+
+	var serveV2 bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		if serveV2 {
+			w.Write(v2)
+			return
+		}
+		w.Write(v1)
+	}))
+	t.Cleanup(srv.Close)
+
+	dest := filepath.Join(t.TempDir(), "extract")
+	a := &VcsArchive{Format: "tar"}
+
+	// First Clone — extracts v1.
+	if err := a.Clone(context.Background(), srv.URL, dest, ""); err != nil {
+		t.Fatalf("Clone v1: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dest, "keep.txt")); string(got) != "v1" {
+		t.Errorf("keep.txt after v1 = %q, want %q", got, "v1")
+	}
+	if _, err := os.Stat(filepath.Join(dest, "old.txt")); err != nil {
+		t.Errorf("old.txt missing after v1 install: %v", err)
+	}
+
+	// Update against changed upstream — extracts v2, drops old.txt, adds new.txt.
+	serveV2 = true
+	if err := a.Update(context.Background(), srv.URL, dest, ""); err != nil {
+		t.Fatalf("Update v2: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dest, "keep.txt")); string(got) != "v2" {
+		t.Errorf("keep.txt after v2 = %q, want %q", got, "v2")
+	}
+	if got, _ := os.ReadFile(filepath.Join(dest, "new.txt")); string(got) != "added in v2" {
+		t.Errorf("new.txt after v2 = %q, want %q", got, "added in v2")
+	}
+	if _, err := os.Stat(filepath.Join(dest, "old.txt")); !os.IsNotExist(err) {
+		t.Errorf("old.txt should be removed after v2 install (err=%v)", err)
 	}
 }
 

--- a/internal/core/vcs/bzr.go
+++ b/internal/core/vcs/bzr.go
@@ -43,7 +43,7 @@ func (b *VcsBazaar) Clone(ctx context.Context, url, path, version string) error 
 	return runner.Run(ctx, "branching "+shortPath(path), "", "bzr", args...)
 }
 
-func (b *VcsBazaar) Update(ctx context.Context, path, version string) error {
+func (b *VcsBazaar) Update(ctx context.Context, _ /* url */, path, version string) error {
 	if err := requireBinary("bzr"); err != nil {
 		return err
 	}

--- a/internal/core/vcs/bzr_test.go
+++ b/internal/core/vcs/bzr_test.go
@@ -43,7 +43,7 @@ func TestVcsBazaar_Clone_NoBinary(t *testing.T) {
 func TestVcsBazaar_Update_NoBinary(t *testing.T) {
 	t.Setenv("PATH", "")
 	b := &VcsBazaar{}
-	err := b.Update(context.Background(), t.TempDir(), "")
+	err := b.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when bzr binary missing")
 	}
@@ -86,7 +86,7 @@ func TestVcsBazaar_Update_FakeBin(t *testing.T) {
 	binDir := makeFakeBin(t, "bzr", "exit 0")
 	t.Setenv("PATH", binDir)
 	b := &VcsBazaar{}
-	if err := b.Update(context.Background(), t.TempDir(), ""); err != nil {
+	if err := b.Update(context.Background(), "", t.TempDir(), ""); err != nil {
 		t.Fatalf("Update with fake bzr: %v", err)
 	}
 }
@@ -95,7 +95,7 @@ func TestVcsBazaar_Update_FakeBin_WithVersion(t *testing.T) {
 	binDir := makeFakeBin(t, "bzr", "exit 0")
 	t.Setenv("PATH", binDir)
 	b := &VcsBazaar{}
-	if err := b.Update(context.Background(), t.TempDir(), "2"); err != nil {
+	if err := b.Update(context.Background(), "", t.TempDir(), "2"); err != nil {
 		t.Fatalf("Update with fake bzr + version: %v", err)
 	}
 }
@@ -104,7 +104,7 @@ func TestVcsBazaar_Update_PullFails(t *testing.T) {
 	binDir := makeFakeBin(t, "bzr", "exit 1")
 	t.Setenv("PATH", binDir)
 	b := &VcsBazaar{}
-	err := b.Update(context.Background(), t.TempDir(), "")
+	err := b.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when bzr pull fails")
 	}

--- a/internal/core/vcs/git.go
+++ b/internal/core/vcs/git.go
@@ -59,7 +59,7 @@ func (g *VcsGit) Clone(ctx context.Context, url, path, version string) error {
 	return nil
 }
 
-func (g *VcsGit) Update(ctx context.Context, path, version string) error {
+func (g *VcsGit) Update(ctx context.Context, _ /* url */, path, version string) error {
 	r, err := gogit.PlainOpen(path)
 	if err != nil {
 		return fmt.Errorf("opening repository at %s: %w", shortPath(path), err)

--- a/internal/core/vcs/git_test.go
+++ b/internal/core/vcs/git_test.go
@@ -72,7 +72,7 @@ func TestVcsGit_Update_AfterClone(t *testing.T) {
 	if err := g.Clone(context.Background(), srcDir, destDir, ""); err != nil {
 		t.Fatalf("Clone: %v", err)
 	}
-	err := g.Update(context.Background(), destDir, "")
+	err := g.Update(context.Background(), "", destDir, "")
 	_ = err
 }
 
@@ -238,7 +238,7 @@ func TestVcsGit_Clone_BadURL(t *testing.T) {
 
 func TestVcsGit_Update_NotARepo(t *testing.T) {
 	g := &VcsGit{}
-	err := g.Update(context.Background(), t.TempDir(), "")
+	err := g.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when updating non-git directory")
 	}
@@ -260,7 +260,7 @@ func TestVcsGit_Update_InitedRepoNoRemote(t *testing.T) {
 	g := &VcsGit{}
 	// Update will fail because there is no remote configured; this covers
 	// the fetch error branch.
-	err := g.Update(context.Background(), dir, "")
+	err := g.Update(context.Background(), "", dir, "")
 	if err == nil {
 		t.Log("update succeeded unexpectedly on repo without remote")
 	}
@@ -363,7 +363,7 @@ func TestVcsGit_Update_Shallow_ResetsToOrigin(t *testing.T) {
 		t.Fatalf("Commit: %v", err)
 	}
 
-	if err := g.Update(context.Background(), destDir, ""); err != nil {
+	if err := g.Update(context.Background(), "", destDir, ""); err != nil {
 		t.Fatalf("shallow Update: %v", err)
 	}
 	// The new file should now exist in the destination.

--- a/internal/core/vcs/hg.go
+++ b/internal/core/vcs/hg.go
@@ -43,7 +43,7 @@ func (m *VcsMercurial) Clone(ctx context.Context, url, path, version string) err
 	return runner.Run(ctx, "cloning "+shortPath(path), "", "hg", args...)
 }
 
-func (m *VcsMercurial) Update(ctx context.Context, path, version string) error {
+func (m *VcsMercurial) Update(ctx context.Context, _ /* url */, path, version string) error {
 	if err := requireBinary("hg"); err != nil {
 		return err
 	}

--- a/internal/core/vcs/hg_test.go
+++ b/internal/core/vcs/hg_test.go
@@ -43,7 +43,7 @@ func TestVcsMercurial_Clone_NoBinary(t *testing.T) {
 func TestVcsMercurial_Update_NoBinary(t *testing.T) {
 	t.Setenv("PATH", "")
 	m := &VcsMercurial{}
-	err := m.Update(context.Background(), t.TempDir(), "")
+	err := m.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when hg binary missing")
 	}
@@ -86,7 +86,7 @@ func TestVcsMercurial_Update_FakeBin(t *testing.T) {
 	binDir := makeFakeBin(t, "hg", "exit 0")
 	t.Setenv("PATH", binDir)
 	m := &VcsMercurial{}
-	if err := m.Update(context.Background(), t.TempDir(), ""); err != nil {
+	if err := m.Update(context.Background(), "", t.TempDir(), ""); err != nil {
 		t.Fatalf("Update with fake hg: %v", err)
 	}
 }
@@ -95,7 +95,7 @@ func TestVcsMercurial_Update_FakeBin_WithVersion(t *testing.T) {
 	binDir := makeFakeBin(t, "hg", "exit 0")
 	t.Setenv("PATH", binDir)
 	m := &VcsMercurial{}
-	if err := m.Update(context.Background(), t.TempDir(), "tip"); err != nil {
+	if err := m.Update(context.Background(), "", t.TempDir(), "tip"); err != nil {
 		t.Fatalf("Update with fake hg + version: %v", err)
 	}
 }
@@ -104,7 +104,7 @@ func TestVcsMercurial_Update_PullFails(t *testing.T) {
 	binDir := makeFakeBin(t, "hg", "exit 1")
 	t.Setenv("PATH", binDir)
 	m := &VcsMercurial{}
-	err := m.Update(context.Background(), t.TempDir(), "")
+	err := m.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when hg pull fails")
 	}

--- a/internal/core/vcs/svn.go
+++ b/internal/core/vcs/svn.go
@@ -43,7 +43,7 @@ func (s *VcsSVN) Clone(ctx context.Context, url, path, version string) error {
 	return runner.Run(ctx, "checkout "+shortPath(path), "", "svn", args...)
 }
 
-func (s *VcsSVN) Update(ctx context.Context, path, version string) error {
+func (s *VcsSVN) Update(ctx context.Context, _ /* url */, path, version string) error {
 	if err := requireBinary("svn"); err != nil {
 		return err
 	}

--- a/internal/core/vcs/svn_test.go
+++ b/internal/core/vcs/svn_test.go
@@ -43,7 +43,7 @@ func TestVcsSVN_Clone_NoBinary(t *testing.T) {
 func TestVcsSVN_Update_NoBinary(t *testing.T) {
 	t.Setenv("PATH", "")
 	s := &VcsSVN{}
-	err := s.Update(context.Background(), t.TempDir(), "")
+	err := s.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when svn binary missing")
 	}
@@ -86,7 +86,7 @@ func TestVcsSVN_Update_FakeBin(t *testing.T) {
 	binDir := makeFakeBin(t, "svn", "exit 0")
 	t.Setenv("PATH", binDir)
 	s := &VcsSVN{}
-	if err := s.Update(context.Background(), t.TempDir(), ""); err != nil {
+	if err := s.Update(context.Background(), "", t.TempDir(), ""); err != nil {
 		t.Fatalf("Update with fake svn: %v", err)
 	}
 }
@@ -95,7 +95,7 @@ func TestVcsSVN_Update_FakeBin_WithVersion(t *testing.T) {
 	binDir := makeFakeBin(t, "svn", "exit 0")
 	t.Setenv("PATH", binDir)
 	s := &VcsSVN{}
-	if err := s.Update(context.Background(), t.TempDir(), "42"); err != nil {
+	if err := s.Update(context.Background(), "", t.TempDir(), "42"); err != nil {
 		t.Fatalf("Update with fake svn + version: %v", err)
 	}
 }

--- a/internal/core/vcs/vcs.go
+++ b/internal/core/vcs/vcs.go
@@ -11,8 +11,13 @@ type VCS interface {
 	// If version is empty the default branch is used.
 	Clone(ctx context.Context, url, path, version string) error
 
-	// Update fetches and checks out version in an already-cloned repo at path.
-	Update(ctx context.Context, path, version string) error
+	// Update fetches and checks out version in an already-cloned repo at
+	// path. The url is provided for backends that have no on-disk metadata
+	// recording the origin (notably VcsArchive, which has to re-fetch the
+	// upstream URL). Backends like git/hg/svn/bzr already track origin in
+	// their own metadata and may ignore this argument; an empty url means
+	// "use whatever the working copy already has".
+	Update(ctx context.Context, url, path, version string) error
 
 	// IsCloned reports whether path contains a valid local working copy.
 	IsCloned(path string) bool

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,7 +1,12 @@
 package engine
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,16 +55,27 @@ func TestRunOnce_EmptyConfig(t *testing.T) {
 }
 
 func TestRunOnce_WithRepository_NoNetwork(t *testing.T) {
-	// A repo with an archive type (Update is a no-op) pointing at a local
-	// directory avoids any network call. We use a pre-cloned archive path
-	// (a dir that already exists) so IsCloned returns true and Update is invoked.
+	// Archive Update used to be a silent no-op; with #124 it re-fetches.
+	// Stand up a local httptest server so the test stays hermetic.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gw)
+		_ = tw.WriteHeader(&tar.Header{Name: "project/file.txt", Mode: 0o644, Size: 2})
+		_, _ = tw.Write([]byte("hi"))
+		_ = tw.Close()
+		_ = gw.Close()
+		_, _ = w.Write(buf.Bytes())
+	}))
+	t.Cleanup(srv.Close)
+
 	existing := t.TempDir()
 
 	cfg := &config.Config{
 		Repositories: map[string]config.ConfigRepo{
 			existing: {
 				Type: "tar",
-				URL:  "https://example.com/unused.tar.gz",
+				URL:  srv.URL + "/x.tar.gz",
 			},
 		},
 	}

--- a/internal/repo/backends_test.go
+++ b/internal/repo/backends_test.go
@@ -1,7 +1,14 @@
 package repo
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"gaal/internal/config"
@@ -26,14 +33,32 @@ func TestManager_Sync_Empty(t *testing.T) {
 }
 
 func TestManager_Sync_ArchiveAlreadyCloned(t *testing.T) {
-	// Archive.Update is a no-op, so this tests the Update path.
+	// Archive.Update used to be a silent no-op (#124); now it re-fetches
+	// and atomically swaps the destination. Verify the path doesn't
+	// regress: an existing archive directory triggers Update, which
+	// must succeed against a live upstream.
 	existing := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gw)
+		_ = tw.WriteHeader(&tar.Header{Name: "project/file.txt", Mode: 0o644, Size: 2})
+		_, _ = tw.Write([]byte("hi"))
+		_ = tw.Close()
+		_ = gw.Close()
+		_, _ = w.Write(buf.Bytes())
+	}))
+	t.Cleanup(srv.Close)
+
 	repos := map[string]config.ConfigRepo{
-		existing: {Type: "tar", URL: "https://example.com/x.tar.gz"},
+		existing: {Type: "tar", URL: srv.URL + "/x.tar.gz"},
 	}
 	m := NewManager(repos, "")
 	if err := m.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync with already-cloned archive: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(existing, "file.txt")); string(got) != "hi" {
+		t.Errorf("file.txt = %q, want %q", got, "hi")
 	}
 }
 

--- a/internal/repo/manager.go
+++ b/internal/repo/manager.go
@@ -78,7 +78,7 @@ func (m *Manager) syncOne(ctx context.Context, path string, cfg config.ConfigRep
 	}
 
 	slog.Debug("updating repository", "path", path)
-	return backend.Update(ctx, path, cfg.Version)
+	return backend.Update(ctx, cfg.URL, path, cfg.Version)
 }
 
 // Status returns the current status of every repository.

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -239,7 +239,9 @@ func (m *Manager) resolveSource(ctx context.Context, source string) (string, err
 		backend, err := vcs.NewShallow(vcsType)
 		if err == nil && backend.IsCloned(expanded) {
 			slog.DebugContext(ctx, "updating local source", "path", expanded, "vcs", vcsType)
-			if err := backend.Update(ctx, expanded, ""); err != nil {
+			// Local source: no upstream URL available. Backends that need
+			// one (notably VcsArchive) will refuse; we ignore the warn.
+			if err := backend.Update(ctx, "", expanded, ""); err != nil {
 				slog.Warn("could not update local source", "path", expanded, "err", err)
 			}
 		}
@@ -264,7 +266,7 @@ func (m *Manager) resolveSource(ctx context.Context, source string) (string, err
 		}
 	} else {
 		slog.Debug("updating skill source", "path", localPath)
-		if err := backend.Update(ctx, localPath, ""); err != nil {
+		if err := backend.Update(ctx, cloneURL, localPath, ""); err != nil {
 			slog.Warn("could not update skill source", "path", localPath, "err", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- Extends the \`VCS.Update\` interface signature with a \`url\` parameter so the archive backend has access to the upstream URL it needs to re-fetch.
- \`VcsArchive.Update\` now re-downloads and re-extracts using the same staging-temp-dir + \`RemoveAll\` + \`Rename\` pattern as #121, so a crash leaves either the previous or the new tree intact — never a half-written hybrid.
- Files removed upstream disappear from the destination on the next sync (overlay extraction never deleted them before).
- Returns an error if called without a URL — defensive guard so a forgotten plumbing change can't silently regress to no-op.

## Why
\`VcsArchive.Update\` was \`return nil\` with a TODO comment. Combined with \`repo.Manager.syncOne\` only calling \`Clone\` when \`!IsCloned(path)\`, every sync after the first was a silent no-op for archive-backed repos. Users pinning to an archive URL got permanently stale content with no signal.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` — full suite green
- [x] New \`TestVcsArchive_Update_RefetchesAndReplaces\` exercises the regression: install v1, swap upstream, re-Update, assert v2 content + removed file gone + new file present.
- [x] Updated \`internal/repo\` and \`internal/engine\` tests that previously relied on the no-op now stand up a local \`httptest\` server.
- [ ] Manual e2e: change archive URL in config, re-run sync, verify new content.

Closes #124