### PR TITLE
fix(vcs): VcsGit IsCloned validates HEAD; Clone recovers atomically

### DIFF
--- a/internal/core/vcs/git.go
+++ b/internal/core/vcs/git.go
@@ -36,14 +36,30 @@ func (g *VcsGit) Clone(ctx context.Context, url, path, version string) error {
 	if err := urlx.ValidateRepoURL(url); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return fmt.Errorf("creating parent directory: %w", err)
 	}
 
 	safeURL := urlx.Redact(url)
 	slog.DebugContext(ctx, "cloning", "url", safeURL, "path", shortPath(path), "version", version)
 
-	r, err := gogit.PlainCloneContext(ctx, path, false, &gogit.CloneOptions{
+	// Stage into a sibling temp dir then atomically rename. Defends
+	// against partial-clone leftovers (Ctrl-C, network drop, full disk):
+	// the destination is either the previous tree or the new one, never
+	// a half-written .git. #125.
+	staging, err := os.MkdirTemp(parent, ".gaal-git-tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating clone staging dir: %w", err)
+	}
+	cleanupStage := true
+	defer func() {
+		if cleanupStage {
+			_ = os.RemoveAll(staging)
+		}
+	}()
+
+	r, err := gogit.PlainCloneContext(ctx, staging, false, &gogit.CloneOptions{
 		URL:               url,
 		RecurseSubmodules: gogit.DefaultSubmoduleRecursionDepth,
 		Tags:              gogit.AllTags,
@@ -54,8 +70,24 @@ func (g *VcsGit) Clone(ctx context.Context, url, path, version string) error {
 	}
 
 	if version != "" {
-		return checkoutVersion(r, version)
+		if err := checkoutVersion(r, version); err != nil {
+			return err
+		}
 	}
+
+	// If path exists (e.g. a previously broken clone left behind), remove
+	// it — the manager only calls Clone when IsCloned reports false, which
+	// now means the previous content is invalid as a git repo.
+	if _, statErr := os.Stat(path); statErr == nil {
+		slog.DebugContext(ctx, "removing previous broken clone", "path", shortPath(path))
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("removing previous clone: %w", err)
+		}
+	}
+	if err := os.Rename(staging, path); err != nil {
+		return fmt.Errorf("renaming staging clone: %w", err)
+	}
+	cleanupStage = false
 	return nil
 }
 
@@ -130,9 +162,30 @@ func (g *VcsGit) resetToRemoteHEAD(ctx context.Context, r *gogit.Repository) err
 	})
 }
 
+// IsCloned reports whether path holds a valid git working copy. Older
+// versions only checked for the existence of a .git entry, which would
+// also succeed for half-cloned destinations (Ctrl-C, network drop) and
+// for non-git directories that happened to have a .git file/dir inside.
+// We now open the repository and verify it has a HEAD reference; on
+// failure the caller (repo.Manager.syncOne) will fall back to Clone,
+// which atomically replaces the broken tree. #125.
 func (g *VcsGit) IsCloned(path string) bool {
-	_, err := os.Stat(filepath.Join(path, ".git"))
-	return err == nil
+	if _, err := os.Stat(filepath.Join(path, ".git")); err != nil {
+		return false
+	}
+	r, err := gogit.PlainOpen(path)
+	if err != nil {
+		slog.Debug("git: IsCloned: PlainOpen failed, treating as not cloned", "path", shortPath(path), "err", err)
+		return false
+	}
+	if _, err := r.Head(); err != nil {
+		// A repo with no HEAD is either freshly initialised (no commits
+		// yet) or partially fetched. Either way it is not in a state
+		// where Update would succeed; force a re-clone.
+		slog.Debug("git: IsCloned: HEAD missing, treating as not cloned", "path", shortPath(path), "err", err)
+		return false
+	}
+	return true
 }
 
 func (g *VcsGit) CurrentVersion(_ context.Context, path string) (string, error) {

--- a/internal/core/vcs/git_test.go
+++ b/internal/core/vcs/git_test.go
@@ -219,12 +219,85 @@ func TestVcsGit_IsCloned_False(t *testing.T) {
 
 func TestVcsGit_IsCloned_True(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := gogit.PlainInit(dir, false); err != nil {
-		t.Fatalf("PlainInit: %v", err)
-	}
+	makeLocalRepo(t, dir)
 	g := &VcsGit{}
 	if !g.IsCloned(dir) {
-		t.Error("expected IsCloned=true for go-git initialised repo")
+		t.Error("expected IsCloned=true for repo with HEAD")
+	}
+}
+
+// TestVcsGit_IsCloned_FakeDotGit guards against the historical
+// behaviour where IsCloned returned true for any directory containing a
+// .git entry — including a non-git folder that happens to have one.
+// With the new HEAD validation the call must report false. #125.
+func TestVcsGit_IsCloned_FakeDotGit(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	g := &VcsGit{}
+	if g.IsCloned(dir) {
+		t.Error("IsCloned should return false for a fake .git directory with no HEAD")
+	}
+}
+
+// TestVcsGit_IsCloned_PartialClone guards against half-cloned states
+// (Ctrl-C, network drop): .git exists with some content but PlainOpen
+// or HEAD lookup fails. The repo manager relies on IsCloned=false so
+// the caller falls back to a fresh Clone (which now atomically
+// replaces the broken tree). #125.
+func TestVcsGit_IsCloned_PartialClone(t *testing.T) {
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(filepath.Join(gitDir, "refs", "heads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// PlainOpen needs HEAD to exist; create one but pointed at a
+	// non-existent commit so r.Head() fails — matches a half-fetched
+	// repo where refs were written before objects.
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	g := &VcsGit{}
+	if g.IsCloned(dir) {
+		t.Error("IsCloned should return false for a partial clone with no resolvable HEAD")
+	}
+}
+
+// TestVcsGit_Clone_RecoversFromBrokenDest verifies the recovery path:
+// a directory left behind by a previous failed clone (only .git) is
+// detected as not-cloned by IsCloned, and the next Clone wipes it and
+// installs a fresh tree atomically. #125.
+func TestVcsGit_Clone_RecoversFromBrokenDest(t *testing.T) {
+	srcDir := t.TempDir()
+	makeLocalRepo(t, srcDir)
+
+	destDir := filepath.Join(t.TempDir(), "dest")
+	// Simulate a broken previous clone.
+	if err := os.MkdirAll(filepath.Join(destDir, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(destDir, "leftover.txt"), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	g := &VcsGit{}
+	if g.IsCloned(destDir) {
+		t.Fatal("precondition: broken dest should report not-cloned")
+	}
+	if err := g.Clone(context.Background(), srcDir, destDir, ""); err != nil {
+		t.Fatalf("Clone over broken dest: %v", err)
+	}
+	if !g.IsCloned(destDir) {
+		t.Error("expected IsCloned=true after recovery clone")
+	}
+	// Stale leftover from the broken state must be gone.
+	if _, err := os.Stat(filepath.Join(destDir, "leftover.txt")); !os.IsNotExist(err) {
+		t.Errorf("leftover.txt should be removed (err=%v)", err)
+	}
+	// And the new content (README.md from makeLocalRepo) must be present.
+	if _, err := os.Stat(filepath.Join(destDir, "README.md")); err != nil {
+		t.Errorf("expected README.md from cloned source: %v", err)
 	}
 }
 

--- a/internal/skill/manager_helpers_test.go
+++ b/internal/skill/manager_helpers_test.go
@@ -5,9 +5,43 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"gaal/internal/config"
 )
+
+// mustInitGitRepoWithCommit creates a git repository at path with one
+// initial commit so VcsGit.IsCloned (which validates HEAD) reports
+// true. Used by tests that pre-populate the skill cache and don't want
+// to hit the network for a real clone.
+func mustInitGitRepoWithCommit(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	r, err := gogit.PlainInit(path, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	readme := filepath.Join(path, ".gaal-readme")
+	if err := os.WriteFile(readme, []byte("init\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := w.Add(".gaal-readme"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	sig := &object.Signature{Name: "test", Email: "t@example.com", When: time.Now()}
+	if _, err := w.Commit("init", &gogit.CommitOptions{Author: sig, Committer: sig}); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+}
 
 func TestToCloneURL_GitHubShorthand(t *testing.T) {
 	got := toCloneURL("owner/repo")
@@ -213,8 +247,12 @@ func TestManager_Sync_PreCachedRemoteSource(t *testing.T) {
 	cacheKey := urlToCacheKey(cloneURL)
 	localPath := filepath.Join(cacheDir, cacheKey)
 
-	// Pre-populate .git so gitVCS.isCloned returns true.
-	os.MkdirAll(filepath.Join(localPath, ".git"), 0o755)
+	// Pre-populate the cache with a real bare-initialised git repo + one
+	// commit so VcsGit.IsCloned (which now validates HEAD) returns true.
+	// Without the commit, gogit.PlainOpen succeeds but r.Head() fails,
+	// and the manager falls through to a network Clone — which is
+	// exactly what this test is designed to avoid.
+	mustInitGitRepoWithCommit(t, localPath)
 
 	// Also create a skill inside so syncOne has something to discover.
 	skillDir := filepath.Join(localPath, "demo-skill")


### PR DESCRIPTION
## Summary
- \`VcsGit.IsCloned\` now opens the repo via \`gogit.PlainOpen\` and verifies a resolvable HEAD instead of just checking for a \`.git\` entry. Broken / half-cloned trees correctly report not-cloned so the caller falls back to \`Clone\`.
- \`VcsGit.Clone\` stages into a sibling temp dir and atomically renames into place. If the destination already exists (leftover from a previously broken clone) it is removed before the swap. Recovery is automatic — no \`--repair\` flag needed.
- A crash mid-clone leaves either the previous tree intact or the new one fully installed; never a half-written hybrid.

## Why
The historical \`IsCloned\` returned true for any directory containing a \`.git\` entry — including non-git folders that happened to have one, half-cloned destinations from a Ctrl-C / network-drop, and renamed-into-place dirs. \`Update\` then opened the broken state and surfaced a cryptic go-git error with no recovery path.

## Pattern parity
This matches the staging-temp-dir + atomic rename used in #121 (skill install) and #124 (archive update). The three backends that overlay-wrote before now have consistent file-system semantics.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` — full suite green
- [x] New tests: \`IsCloned_FakeDotGit\`, \`IsCloned_PartialClone\`, \`Clone_RecoversFromBrokenDest\`
- [x] Pre-existing skill test that faked a \`.git\` dir now uses a real one-commit init via a small helper.

Closes #125