### PR TITLE
docs: per-command and per-package guides under docs/{commands,packages}

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,12 +37,21 @@ gaal/
     ├── engine/                # Central orchestrator — sequences the three managers
     │   ├── ops/               # Command operations (audit, info, init, status)
     │   └── render/            # Output types and renderers (table, JSON)
+    ├── httpx/                 # Hardened outbound HTTP client (TLS min, redirect SSRF, body cap, UA)
+    ├── installscript/         # `curl | sh` installer payload generation
     ├── logger/                # Console logging (colorized) + JSON file handler
     ├── mcp/                   # MCP configuration management
     ├── repo/                  # Repository manager (uses core/vcs)
     ├── runner/                # External subprocess execution
-    └── skill/                 # AI agent skill management (uses core/vcs + core/agent)
+    ├── secfile/               # Atomic 0o600 file writes (temp + fsync + rename)
+    ├── skill/                 # AI agent skill management (uses core/vcs + core/agent)
+    ├── telemetry/             # Anonymous usage telemetry (consent-gated)
+    ├── tools/                 # External-tool PATH probe (declared by sources)
+    └── urlx/                  # URL validation + credential redaction (scheme allowlist)
 ```
+
+Per-package detail lives in [`docs/packages/`](packages/); per-command flows
+live in [`docs/commands/`](commands/).
 
 ---
 
@@ -70,7 +79,7 @@ All sub-commands share the global flags defined on the root command:
 | `gaal audit` | — | Discover all skills and MCP servers installed on this machine |
 | `gaal doctor` | `--offline`, `--no-upsell` | Run configuration health checks and report agent status |
 | `gaal init` | `--scope`, `--import-all`, `--empty`, `--force/-f` | Bootstrap a `gaal.yaml` from discovered skills and MCPs |
-| `gaal migrate` | `--to`, `--dry-run`, `--yes` | Migrate configuration to a Community Edition instance |
+| `gaal migrate` | `--to`, `--dry-run` | Migrate configuration to a Community Edition instance (stub — not yet implemented) |
 | `gaal version` | — | Version string and build timestamp |
 | `gaal schema` | `--file/-f` | Print the JSON Schema (draft-07) for the config file |
 | `gaal completion <bash\|zsh\|fish\|powershell>` | — | Shell completion script (built-in Cobra) |
@@ -255,7 +264,7 @@ VCS backends are described in [**docs/core.md — VCS Sub-package**](core.md#vcs
 
 ### Parallelism
 
-`repo.Manager.Sync()` spawns one goroutine per repository. Errors flow through a buffered channel and are aggregated after `sync.WaitGroup`. The `version` field in `RepoConfig` acts as a strip prefix for archive extraction; `Update()` is a no-op for archives.
+`repo.Manager.Sync()` spawns one goroutine per repository. Errors flow through a buffered channel and are aggregated after `sync.WaitGroup`. The `version` field in `RepoConfig` acts as a strip prefix for archive extraction; `VcsArchive.Update` is currently a no-op (tracked: #124). See [packages/repo.md](packages/repo.md) and [packages/core-vcs.md](packages/core-vcs.md) for the per-backend behaviour.
 
 ---
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -1,0 +1,37 @@
+# Commands — gaal
+
+> One page per CLI command. Each page covers what the command does, the
+> end-to-end execution flow (rendered as a `mermaid` diagram), the
+> caching and on-disk effects, the failure modes, and the exit codes.
+
+For the architectural overview that ties commands together (Cobra
+bootstrap, `PersistentPreRunE`, sandbox, telemetry), see
+[`docs/architecture.md`](../architecture.md).
+
+## Index
+
+| Command | Description |
+|---------|-------------|
+| [`gaal sync`](sync.md) | Clone/update repos, install skills, upsert MCP entries (one-shot or `--service`) |
+| [`gaal status`](status.md) | Snapshot of the current resource state on disk vs. config |
+| [`gaal info`](info.md) | Detailed per-entry card for a resource type |
+| [`gaal init`](init.md) | Bootstrap a `gaal.yaml` (empty, imported, or via wizard) |
+| [`gaal audit`](audit.md) | Discover every skill / MCP server present on this machine |
+| [`gaal agents`](agents.md) | List registered coding agents and detect installed ones |
+| [`gaal doctor`](doctor.md) | Configuration health checks + actionable hints |
+| [`gaal migrate`](migrate.md) | (Stub) Migrate to a Community Edition instance |
+| [`gaal schema`](schema.md) | Emit the JSON Schema for `gaal.yaml` |
+| [`gaal version`](version.md) | Version string and build timestamp |
+
+## Conventions used in these pages
+
+- **`mermaid` diagrams** depict the runtime flow. Subgraphs scope to a
+  package; rectangles are functions; diamonds are decisions; rounded
+  terminals are exits.
+- **Exit codes** are listed explicitly per command. `gaal` uses a
+  `cmd.ExitCodeError{Code,Cause}` wrapper so non-zero exits flow
+  through Cobra's `RunE` and still hit `PersistentPostRunE` (telemetry
+  flush, consent persistence) — see [`packages/telemetry.md`](../packages/telemetry.md).
+- **Side effects** sections list every path the command reads or writes,
+  along with the secfile / atomicity semantics (see
+  [`packages/secfile.md`](../packages/secfile.md)).

--- a/docs/commands/agents.md
+++ b/docs/commands/agents.md
@@ -1,0 +1,77 @@
+# `gaal agents`
+
+> List registered coding agents and detect installed ones, or show the
+> full path layout for a single agent.
+
+## Usage
+
+```
+gaal agents                # list every registered agent
+gaal agents <name>         # detail card for one agent
+gaal agents --installed    # filter list to detected installs only
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--installed / -i` | `false` | Show only agents detected as installed on this machine |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Rendered |
+| `2` | Unknown agent name (when called with `<name>`) |
+
+---
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[gaal agents] --> B{name arg?}
+    B -- no --> C[engine.ListAgents]
+    B -- yes --> D[engine.AgentDetail name]
+    C --> C1[ops.ListAgents — agent.List + per-entry IsInstalled]
+    C1 --> C2{--installed?}
+    C2 -- yes --> C3[filter installed=true]
+    C2 -- no --> C4[keep all]
+    C3 --> R[render list]
+    C4 --> R
+    D --> D1[ops.AgentDetail — Lookup + path expansion]
+    D1 --> R2[render detail card]
+    R --> Z([exit 0])
+    R2 --> Z
+```
+
+## What "installed" means
+
+For each registered agent, `IsInstalled` checks for the agent's
+canonical install marker:
+
+| Agent kind | Marker |
+|-----------|--------|
+| Most agents | Existence of the agent's project skills dir, global skills dir, or MCP config dir |
+| `claude-desktop` | App-specific path on macOS / Windows (PR #194 / #128) — never reports installed on Linux |
+
+The detection is **structural** (file/dir existence), not behavioural
+(no command execution). False positives are possible if a directory was
+created manually; false negatives if the agent stores state in a
+non-standard location.
+
+## Registry source
+
+The agent registry is loaded from [`internal/core/agent/agents.yaml`](../../internal/core/agent/agents.yaml)
+(embedded at build time) and optionally extended via
+`~/.config/gaal/agents.yaml`. See [`docs/core.md`](../core.md) for the
+full registry contract and security constraints.
+
+---
+
+## Side effects
+
+Read-only.
+
+## Related
+
+- [`gaal info agent <name>`](info.md) — equivalent to `gaal agents <name>`.
+- [`docs/core.md`](../core.md) — agent registry rules.

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -1,0 +1,93 @@
+# `gaal audit`
+
+> Discover every skill and MCP server installed on this machine,
+> regardless of whether it is declared in `gaal.yaml`.
+
+`audit` is the **config-independent** counterpart to `gaal status`:
+where status shows declared resources reconciled with disk, audit shows
+**only what is on disk** — useful for spotting skills installed
+manually, by another tool, or by a previous `gaal` config that was
+since edited.
+
+## Usage
+
+```
+gaal audit
+```
+
+Inherits global flags only. The `--config` is optional — `audit` works
+without any config file present (it sets the engine to an empty
+config).
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Inventory rendered |
+| `2` | Discovery scan failed (rare; FS error) |
+
+---
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[gaal audit] --> B[PreRunE: load config optional]
+    B --> C[telemetry.Track audit]
+    C --> D[engine.NewWithOptions empty config]
+    D --> E[engine.Audit ctx, format]
+    E --> F[ops.Audit]
+    F --> G[discover.Scan ctx, home, workDir, opts]
+
+    subgraph Scan
+      G --> G1[scanGlobal — agent.List × global+user dirs]
+      G --> G2[scanMCPs — agent.List × MCP config files]
+      G --> G3[scanWorkspace — depth-limited FS walk if opts.IncludeWorkspace]
+    end
+
+    G1 --> H[buildAuditReport]
+    G2 --> H
+    G3 --> H
+    H --> R{format}
+    R -->|text| RT[compact summary]
+    R -->|verbose| RV[full per-skill / per-mcp lines]
+    R -->|table| RB[pterm boxed tables]
+    R -->|json| RJ[stdout JSON]
+    RT --> Z([exit 0])
+    RV --> Z
+    RB --> Z
+    RJ --> Z
+```
+
+## What audit scans
+
+For each registered agent (from
+[`internal/core/agent`](../packages/core-agent.md)):
+
+- **Project skills**: `<workDir>/<ProjectSkillsSearch>/...` (1-level deep)
+- **Global skills**: `~/<GlobalSkillsSearch>/...` (1-level deep)
+- **PM (package manager) skills**: `~/<PmSkillsSearch>/...` (recursive)
+- **MCP config**: agent's `ProjectMCPConfigPath` and `GlobalMCPConfigPath`
+
+PR #193 (#137) added `scanMCPs` coverage of both project- and
+global-scoped MCP files; PR #194 (#128) added `claude-desktop` install
+detection.
+
+## Drift annotation
+
+For every discovered skill, `audit` annotates whether it is **managed**
+(declared in the merged config) or **unmanaged**. Detection uses the
+same `discover.Scan` snapshot machinery as `status` so the labels are
+consistent across the two commands. See
+[`docs/packages/discover.md`](../packages/discover.md).
+
+---
+
+## Side effects
+
+Read-only.
+
+## Related
+
+- [`gaal status`](status.md) — config-aware view.
+- [`docs/packages/discover.md`](../packages/discover.md) — scan internals.

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -1,0 +1,94 @@
+# `gaal doctor`
+
+> Configuration health checks. Verifies that the merged config parses
+> against the live schema, that targeted skill sources are reachable,
+> that MCP target files are readable, that required external tools are
+> on `PATH`, and that the targeted agents exist on this machine.
+
+## Usage
+
+```
+gaal doctor [flags]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--offline` | `false` | Skip every network probe (skill source reachability) |
+| `--no-upsell` | `false` | Suppress the Community Edition upsell footer |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All checks passed |
+| `1` | Warnings only (e.g. agents declared in config but not detected) |
+| `2` | At least one error (schema mismatch, missing required tool with no fallback, unreadable MCP target) |
+
+---
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[gaal doctor] --> B[Parse flags]
+    B --> C[telemetry.Track doctor]
+    C --> D[Build engine cfg or empty]
+    D --> E[ops.RunDoctor]
+    E --> F1[checkSchema per level]
+    F1 --> F2[checkTelemetry consent state]
+    F2 --> F3{offline?}
+    F3 -- no --> F4[checkSkillSources network probe]
+    F3 -- yes --> F4skip[skip network probe]
+    F4 --> F5[checkMCPTargets readable JSON/TOML]
+    F4skip --> F5
+    F5 --> F6[checkTools PATH lookup via tools.Check]
+    F6 --> F7[checkAgents installed count]
+    F7 --> G[aggregate findings → ExitCode]
+    G --> H{format}
+    H -->|json| RJ[renderDoctorJSON]
+    H -->|table| RB[renderDoctorTable + config tree]
+    H -->|text + verbose| RV[renderDoctorText section per line]
+    H -->|text| RS[renderDoctorSummary one line per section]
+    RB --> US{!--no-upsell}
+    RV --> US
+    RS --> US
+    RJ --> EX
+    US -- yes --> UP[renderCommunityBlock] --> EX
+    US -- no --> EX
+    EX{ExitCode != 0} -- yes --> Z([ExitCodeError code])
+    EX -- no --> POST[PostRunE: telemetry flush]
+    POST --> ZZ([exit 0])
+```
+
+## Checks
+
+| Check | What it does | Failure mode |
+|-------|-------------|--------------|
+| `checkSchema` | Validates each config level (global / user / workspace) against `Config` struct rules; reports unknown YAML keys (PR #190 / #135) | error |
+| `checkTelemetry` | Reports current consent state and where it is stored | informational |
+| `checkSkillSources` | HTTP HEAD-like probe via [`internal/httpx`](../packages/httpx.md) for each remote skill source | warning |
+| `checkMCPTargets` | Tries to read each resolved MCP target path | error if unreadable; warning if missing |
+| `checkTools` | Looks up every tool declared by a config source via [`internal/tools`](../packages/tools.md) on `PATH` | warning |
+| `checkAgents` | Counts agents registered vs. detected as installed | warning |
+
+## Hook into the rest of gaal
+
+`doctor` is the only command that surfaces the **same probe** as
+`gaal sync`'s `warnMissingTools` banner, but with full attribution
+(which source declares the tool) and a non-zero exit code when the
+config is unhealthy. Use it in CI to gate a `gaal sync`.
+
+---
+
+## Side effects
+
+Read-only, except for telemetry tracking (consent-gated).
+
+## Related
+
+- [`gaal sync`](sync.md) — `warnMissingTools` banner shares the
+  underlying probe.
+- [`docs/packages/tools.md`](../packages/tools.md) — how external-tool
+  declarations are collected from config.
+- [`docs/packages/telemetry.md`](../packages/telemetry.md) — consent
+  state checked by `checkTelemetry`.

--- a/docs/commands/info.md
+++ b/docs/commands/info.md
@@ -1,0 +1,73 @@
+# `gaal info`
+
+> Detailed per-entry card for a single resource type. Read-only.
+
+## Usage
+
+```
+gaal info <repo|skill|mcp|agent> [filter]
+```
+
+| Argument | Description |
+|----------|-------------|
+| Resource type | One of `repo`, `skill`, `mcp`, `agent` |
+| Filter | Optional case-insensitive substring match against the resource name |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Rendered (even if zero matches) |
+| `2` | Could not load config or resolve resource |
+
+---
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[gaal info type filter] --> B[engine.Info ctx, type, filter, fmt]
+    B --> C[ops.Info]
+    C --> D{type}
+    D -->|repo| E1[ops.Collect → repos slice]
+    D -->|skill| E2[ops.Collect → skills slice]
+    D -->|mcp| E3[ops.Collect → mcps slice]
+    D -->|agent| E4[agent.List + per-agent path expansion]
+    E1 --> F[filter substring]
+    E2 --> F
+    E3 --> F
+    E4 --> F
+    F --> G{output format}
+    G -->|text| H[compact summary lines]
+    G -->|verbose| I[full per-card detail]
+    G -->|table| J[pterm table]
+    G -->|json| K[stdout JSON]
+```
+
+`info` reuses the same `ops.Collect` as `gaal status`, then renders a
+**deeper** view: instead of the one-line-per-resource summary it emits a
+multi-line card per matching entry (paths, version, install targets,
+detected drift, source URL — credentials redacted via
+[`urlx.Redact`](../packages/urlx.md)).
+
+## Output format honoring `--verbose`
+
+PR #186 (#129) routes `gaal info` through `effectiveOutputFormat()` so
+`--verbose` produces the full card in text mode (rather than the
+default compact summary). Without `--verbose`:
+
+- `text` → one summary line per match
+- `verbose` (or `-v`) → full card per match
+- `table` / `json` → unaffected by `--verbose` (always full detail)
+
+---
+
+## Side effects
+
+Read-only: `gaal info` reads the same paths as `gaal status` (config
+chain + agent dirs + snapshots). It writes nothing.
+
+## Related
+
+- [`gaal status`](status.md) — summary view of the same data.
+- [`gaal agents`](agents.md) — `gaal info agent <name>` is a superset.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -1,0 +1,126 @@
+# `gaal init`
+
+> Bootstrap a `gaal.yaml`: empty skeleton, full import of installed
+> resources, or interactive wizard.
+
+## Usage
+
+```
+gaal init [flags]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--scope` | _(prompt)_ | `project` (writes `gaal.yaml` in CWD) or `global` (writes user config) |
+| `--import-all` | `false` | Non-interactive: import every detected skill / MCP |
+| `--empty` | `false` | Non-interactive: write the documented skeleton only |
+| `--force / -f` | `false` | Allow overwriting an existing destination (a backup is taken first — see [Backup](#backup)) |
+
+`--import-all` and `--empty` are mutually exclusive.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | File written |
+| `1` | Wizard cancelled by user — pterm prints "init cancelled"; treated as a clean cancel via `cmd.ExitCodeError{Code:130}` (PR #188 / #140) |
+| `2` | Hard error (FS, permissions, validation) |
+
+---
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[gaal init] --> B[Parse flags]
+    B --> C{import-all && empty?}
+    C -- yes --> Z1([err: mutually exclusive])
+    C -- no --> D[telemetry.Track init]
+    D --> E[Detect TTY on stdin]
+    E --> F[resolveInitMode]
+    F -->|--empty| G[ModeEmpty]
+    F -->|--import-all| H[ModeImport]
+    F -->|TTY interactive| I[wizard.SelectMode]
+    F -->|non-TTY no flag| FERR([err: needs TTY or flag])
+    G --> J[resolveInitScope]
+    H --> J
+    I --> J
+    J -->|--scope| K[ScopeProject or ScopeGlobal]
+    J -->|TTY| L[wizard.SelectScope]
+    J -->|non-TTY no flag| JERR([err: needs TTY or --scope])
+    K --> M[resolveInitDestination]
+    L --> M
+    M --> N[preflightDestination]
+    N -->|exists, no --force| NERR([err: already exists])
+    N -->|exists, --force| BAK[backupExisting → dest.bak.RFC3339]
+    N -->|new file| OK
+    BAK --> OK
+    OK --> O{mode}
+    O -->|empty| P[engine.Init writes documented skeleton]
+    O -->|import| Q[BuildImportCandidates]
+    Q --> R{candidates empty?}
+    R -- yes --> P
+    R -- no --> S[selectPlan]
+    S -->|--import-all| T[flattenAll + BuildPlan]
+    S -->|TTY| U[wizard.SelectSections]
+    S -->|non-TTY no flag| SERR([err: needs --import-all])
+    T --> V{TTY && !import-all?}
+    U --> V
+    V -- yes --> W[Confirm prompt]
+    W -- no --> WCAN([cancelled, exit 130])
+    W -- yes --> X[engine.InitFromPlan]
+    V -- no --> X
+    X --> Y[Print summary]
+    P --> Y
+    Y --> Z([exit 0])
+```
+
+---
+
+## Backup
+
+When `--force` is used and the destination exists, the previous file is
+renamed to `<dest>.bak.<UTC-RFC3339>` **before** the new file is
+written (PR #198, closes #139). The user always has a recoverable copy
+of their old config:
+
+```
+gaal.yaml          ← new content
+gaal.yaml.bak.2026-05-03T05:14:31Z   ← previous content
+```
+
+The backup uses [`secfile.Write`](../packages/secfile.md) so it lands
+with `0o600` even if the original was looser.
+
+## Documented skeleton
+
+The "empty" mode is **not** an empty file. `engine.Init` (which
+delegates to `internal/config/template`) generates a fully-commented
+YAML skeleton from the live struct tags — the comments stay in sync
+with the schema automatically. See [`docs/config.md — Template`](../config.md#data-model)
+for the field-introspection mechanism.
+
+## Import mode
+
+`BuildImportCandidates(ctx, scope)` runs a config-independent FS scan
+(via [`internal/discover`](../packages/discover.md)) for skills + MCP
+servers, then `BuildPlan` selects either everything (`--import-all`) or
+the user's wizard picks. `engine.InitFromPlan` writes the resulting
+YAML using the template renderer so the imported file has the same
+structure (and comments) as a freshly-initialised one.
+
+---
+
+## Side effects
+
+| Path | Notes |
+|------|-------|
+| `gaal.yaml` (or `~/.config/gaal/config.yaml` for `--scope global`) | created via `secfile.Write` 0o600 |
+| `<dest>.bak.<timestamp>` | written **before** the destination when `--force` is used |
+| Agent skill/MCP dirs | read-only scan during `import` mode |
+
+## Related
+
+- [`docs/config.md`](../config.md) — full reference for the resulting file.
+- [`gaal sync`](sync.md) — the natural next step after `gaal init`.
+- [`gaal schema`](schema.md) — emit JSON Schema for IDE validation.

--- a/docs/commands/migrate.md
+++ b/docs/commands/migrate.md
@@ -1,0 +1,69 @@
+# `gaal migrate`
+
+> Migrate the merged config to a Community Edition instance.
+> **Stub** — counts only; no actual transfer happens yet.
+
+## Usage
+
+```
+gaal migrate --to community <url> [--dry-run]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--to` | _(required)_ | Migration target. Only `community` is recognised today |
+| `--dry-run` | `false` | Print the would-be summary line and exit |
+
+The `--yes` flag was removed in PR #185 (#141) — it was declared but
+never used.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Plan rendered (this is the only success path until the full migration ships) |
+| `2` | Unknown `--to` target, or invalid URL |
+
+---
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[gaal migrate] --> B[Parse flags + URL arg]
+    B --> C[engine.Migrate target, url, dryRun]
+    C --> D{target == community?}
+    D -- no --> Z1([err: unknown target])
+    D -- yes --> E[url.Parse]
+    E -- bad --> Z2([err: invalid url])
+    E -- ok --> F[Build MigrateResult counts only]
+    F --> G[telemetry.Track migrate + Custom]
+    G --> H{dryRun?}
+    H -- yes --> I["print '[dry-run]' prefix"]
+    H -- no --> J[skip prefix]
+    I --> K["print 'Would migrate N repos, M skills, K mcps'"]
+    J --> K
+    K --> L[printDisclaimer 'not yet available']
+    L --> Z([exit 0])
+```
+
+## Why a stub
+
+The CLI surface is intentionally locked in early so `gaal migrate` is
+documented and discoverable, even while the implementation is pending.
+The first non-stub release will:
+
+- Authenticate with the target Community Edition instance.
+- Push declared repos / skills / MCP entries via the instance API.
+- Reconcile remote acceptance results back into the user's config.
+
+---
+
+## Side effects
+
+None today.
+
+## Related
+
+- [`gaal init`](init.md) — bootstraps the config that `migrate` would
+  push.

--- a/docs/commands/schema.md
+++ b/docs/commands/schema.md
@@ -1,0 +1,77 @@
+# `gaal schema`
+
+> Emit the JSON Schema (draft 2020-12) for `gaal.yaml`. Used by IDEs
+> for live validation and autocompletion.
+
+## Usage
+
+```
+gaal schema                      # write to stdout
+gaal schema --file schema.json   # write to disk
+gaal schema -f -                 # explicit stdout
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--file / -f` | `""` | Output path; empty or `-` writes to stdout |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Schema rendered |
+| `2` | File write failed |
+
+---
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[gaal schema] --> B[config.GenerateSchema]
+    B --> C[schema.Generate Default]
+    C --> D[invopop/jsonschema reflects Config]
+    D --> E[Config.JSONSchemaExtend post-processing]
+    E --> F{--file?}
+    F -- empty / `-` --> G[os.Stdout]
+    F -- path --> H[os.WriteFile path 0o644]
+    G --> Z([exit 0])
+    H --> Z
+```
+
+## Why it stays in sync
+
+The schema is generated from the **runtime** `Config` struct via
+`reflect`, so it is always 1-to-1 with the source code. `make build`
+re-runs `dist/gaal schema -f dist/schema.json` after compilation to
+keep the committed schema fresh.
+
+The active generator is swappable via
+`config/schema.Set(g Generator)` — useful for tests or for
+experimenting with alternative schema libraries. See
+[`docs/config.md — Schema Generation`](../config.md#schema-sub-package-internalconfigschema).
+
+## IDE setup
+
+```yaml
+# .vscode/settings.json
+{
+  "yaml.schemas": {
+    "./schema.json": ["gaal.yaml"]
+  }
+}
+```
+
+JetBrains IDEs and Neovim with `yaml-language-server` follow the same
+pattern.
+
+---
+
+## Side effects
+
+Reads nothing from the user's config. Writes either stdout or the file
+named by `--file`.
+
+## Related
+
+- [`docs/config.md`](../config.md) — schema generation pillar.

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -1,0 +1,128 @@
+# `gaal status`
+
+> Read-only snapshot of the current resource state on disk versus the
+> merged configuration. Never writes.
+
+For the **end-user reading guide** (what each column / icon means in
+the rendered output), see [`docs/status.md`](../status.md). This page
+covers the **architecture and execution flow**.
+
+---
+
+## Usage
+
+```
+gaal status [flags]
+```
+
+Inherits global flags only (`--config`, `--output`, `--verbose`,
+`--sandbox`, `--no-banner`, `--log-file`).
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Status collected and rendered (no implicit failure if drift is reported) |
+| `2` | Could not collect status (config load error, FS unreadable, etc.) |
+
+`gaal status` is informational — drift alone never sets a non-zero exit.
+Use the JSON output (`--output json`) and grep / `jq` for CI checks.
+
+---
+
+## Execution flow
+
+```mermaid
+flowchart TD
+    A[gaal status] --> B[root.PersistentPreRunE]
+    B --> C[engine.NewWithOptions cfg, opts]
+    C --> D[engine.Status ctx, format]
+    D --> D1[ops.Status]
+    D1 --> E[ops.Collect — managers + discover]
+
+    subgraph Collect
+      E --> E1[repos.Status fan-out goroutines]
+      E --> E2[skills.Status — per source × per agent]
+      E --> E3[mcps.Status — per resolved target]
+      E --> E4[discover.Scan — FS-first inventory]
+      E1 --> EM[reconcileRepos — managed + unmanaged]
+      E2 --> EM
+      E3 --> EM
+      E4 --> EM
+    end
+
+    EM --> R[render.NewRenderer format]
+    R -->|text| RT[summary block]
+    R -->|table| RT2[pterm boxed tables]
+    R -->|json| RJ[stdout JSON]
+    RT --> Z([exit 0])
+    RT2 --> Z
+    RJ --> Z
+```
+
+### Collect — the merge layer
+
+`ops.Collect` is the only place where **config-declared** resources
+(driven by the three managers) and **FS-discovered** resources (driven
+by `internal/discover`) meet. The reconcile rules:
+
+| Source of resource | Treatment |
+|--------------------|-----------|
+| Declared in `gaal.yaml` and present on disk | Status from manager + drift from snapshot |
+| Declared but missing on disk | Status `partial` / `not cloned` |
+| Present on disk but not declared | Appended as `unmanaged` (status `?`) |
+| Snapshot record but no FS entry | Drift `missing` |
+
+The same `Collect` powers both `gaal status` and the `eng.Collect`
+post-sync summary used by `gaal sync` — it is the single source of
+truth for "what is the current state?".
+
+---
+
+## Drift detection (Git-index fast path)
+
+Skills, repos and MCP files all use the same heuristic from
+[`internal/discover`](../packages/discover.md):
+
+```mermaid
+flowchart LR
+    A[FS entry] --> B{stat: size+mtime match snapshot?}
+    B -- yes --> OK([drift: ok])
+    B -- no  --> C[sha256 of file]
+    C --> D{hash matches snapshot?}
+    D -- yes --> R[update snapshot mtime — racy-git repair]
+    D -- no  --> M([drift: modified])
+    R --> OK
+```
+
+For directories tracked by a VCS, `vcs.HasChanges()` is consulted
+**first** — VCS-native detection is faster and authoritative for git /
+hg / svn / bzr trees.
+
+---
+
+## Side effects
+
+`gaal status` reads the following:
+
+| Path | Notes |
+|------|-------|
+| `gaal.yaml` and the merge chain | as resolved by `internal/config` |
+| Every declared repo / skill destination | `os.Stat` + selective hashing |
+| Every registered agent's skill / MCP directory | for unmanaged scan |
+| `~/.cache/gaal/state/*.json` (sandbox-aware) | snapshots written by past `gaal sync` |
+
+It writes **nothing** other than possibly a snapshot mtime touch
+(racy-git repair) — and only when the file content already matches the
+recorded hash.
+
+---
+
+## Related
+
+- [`gaal sync`](sync.md) — the writer side.
+- [`gaal audit`](audit.md) — config-independent inventory.
+- [`docs/status.md`](../status.md) — end-user reading guide for the
+  rendered output.
+- [`docs/packages/discover.md`](../packages/discover.md) — snapshot
+  internals.

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -1,0 +1,344 @@
+# `gaal sync`
+
+> Clone or update every repository, install every skill into every
+> targeted agent, and upsert every MCP server entry into the targeted
+> agent JSON / TOML file. One-shot by default; loops on a ticker with
+> `--service`.
+
+`sync` is the only command that **writes** to disk and to agent
+configuration files. Every other command is read-only or scoped to its
+own state directory.
+
+---
+
+## Usage
+
+```
+gaal sync [flags]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--service / -s` | `false` | Run continuously at `--interval`, exit on SIGINT/SIGTERM |
+| `--interval / -i` | `5m` | Polling interval in service mode |
+| `--dry-run` | `false` | Compute the plan and render it; never write |
+| `--prune` | `false` | After a one-shot sync, remove on-disk skills and MCP entries that are no longer declared (and gated per entry — see [Prune](#prune)) |
+| `--force` | `false` | When `agents: ["*"]`, install into every registered agent — even those without an installed config dir |
+
+`--dry-run` and `--service` are mutually exclusive (a dry-run loop is
+meaningless). `--prune` is incompatible with `--service` (destructive
+operations stay one-shot).
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success — nothing to do, or every change applied without error |
+| `1` | `--dry-run` only: there are pending changes (informational) |
+| `2` | A managed resource failed (network error, validation, FS error). Surfaces through `cmd.ExitCodeError{Code:2,Cause:err}` so `PersistentPostRunE` still runs (telemetry + consent flush) |
+| `130` | SIGINT / SIGTERM during sync — propagated via context cancel |
+
+---
+
+## End-to-end flow
+
+```mermaid
+flowchart TD
+    A[gaal sync invoked] --> B[root.PersistentPreRunE]
+    B --> B1[setupLogger + applyOptions sandbox]
+    B1 --> B2[config.LoadChain global→user→workspace]
+    B2 --> B3[telemetry.Init + consent prompt]
+    B3 --> C[runSync]
+
+    C --> C1{flag combo valid?}
+    C1 -- no --> Z1([err: incompatible flags])
+    C1 -- yes --> C2[warnMissingTools stderr banner]
+    C2 --> C3[signal.NotifyContext SIGINT/SIGTERM]
+    C3 --> C4[engine.NewWithOptions cfg, opts]
+
+    C4 --> D{mode}
+    D -->|--dry-run| DR[eng.DryRun ctx, format]
+    D -->|--service| SV[eng.RunService ctx, interval]
+    D -->|one-shot| OS[eng.Plan → eng.RunOnce]
+
+    DR --> DR1[ops.SyncPlan: collect+plan repos/skills/mcps]
+    DR1 --> DR2[render PlanReport text/table/json]
+    DR2 --> DR3{HasErrors / HasChanges}
+    DR3 -- err --> ZE([ExitCodeError 2])
+    DR3 -- changes --> ZC([ExitCodeError 1])
+    DR3 -- clean --> ZK([exit 0])
+
+    SV --> SV1[RunOnce immediately]
+    SV1 --> SV2{ctx.Done?}
+    SV2 -- no --> SV3[ticker tick] --> SV1
+    SV2 -- yes --> ZSV([service stopping, exit 0])
+
+    OS --> OR[repos.Sync]
+    OS --> OS_S[skills.Sync]
+    OS --> OS_M[mcps.Sync]
+    OR --> P{--prune?}
+    OS_S --> P
+    OS_M --> P
+    P -- yes --> PR[skills.Prune + mcps.Prune]
+    P -- no --> RS[eng.Collect post-sync]
+    PR --> RS
+    RS --> RR{verbose?}
+    RR -- yes --> RR1[RenderSyncSummary]
+    RR -- no --> RR2[RenderSyncBrief]
+    RR1 --> EX[telemetry.Track sync + TrackFirstSync]
+    RR2 --> EX
+    EX --> POST[root.PersistentPostRunE: FlushConsent + Shutdown]
+    POST --> ZZ([exit 0])
+```
+
+---
+
+## Inside the three managers
+
+`engine.RunOnce` calls each manager's `Sync(ctx)` in order: repositories,
+skills, MCPs. Errors from one manager do not abort the others — all three
+runs are attempted, and per-manager errors are joined via
+`errors.Join` for the final non-zero exit.
+
+### 1 — `repo.Manager.Sync` (parallel goroutines per repo)
+
+```mermaid
+flowchart LR
+    A[repo.Manager.Sync] --> B[fan-out goroutines]
+    B --> C{IsCloned path?}
+    C -- no --> D[backend.Clone ctx, url, path, version]
+    C -- yes --> E[backend.Update ctx, path, version]
+    D --> F[errCh]
+    E --> F
+    F --> G[wg.Wait → errors.Join]
+```
+
+- One goroutine per `repositories:` entry.
+- Backend selection comes from `vcs.New(cfg.Type)`:
+  `git`, `hg`, `svn`, `bzr` (full clones), or `tar` / `zip` (HTTP
+  archive fetch + atomic extract).
+- For `git`, `IsCloned` validates HEAD via `gogit.PlainOpen` — a
+  half-cloned dir reports `false` so the next sync re-clones into a
+  staging dir and atomically swaps in (PRs #207 + #204 share the
+  staging-then-rename pattern).
+- For `tar` / `zip`, see [`packages/core-vcs.md`](../packages/core-vcs.md);
+  the per-entry size cap is 256 MiB, the per-archive cap 1 GiB, and
+  the entry count cap 50 000.
+
+### 2 — `skill.Manager.Sync` (sequential per source)
+
+```mermaid
+flowchart TD
+    A[skill.Manager.Sync] --> B[for each ConfigSkill]
+    B --> C[resolveSource]
+    C --> C1{local path?}
+    C1 -- yes --> C1a[expand ~/, return path]
+    C1 -- no --> C1b[urlToCacheKey → ~/.cache/gaal/skills/<key>]
+    C1b --> C1c{IsCloned?}
+    C1c -- no --> C1d[NewShallow git Clone depth=1]
+    C1c -- yes --> C1e[NewShallow git Update — hard-reset to origin HEAD]
+    C1a --> D
+    C1d --> D
+    C1e --> D
+    D[discoverSkills source] --> E[filterSkills via select:]
+    E --> F[resolveAgents — expand `[*]` to detected installed]
+    F --> G[for each agent, for each skill]
+    G --> H[installSkill src→dst]
+    H --> H1[mkdir staging .gaal-skill-tmp-*]
+    H1 --> H2[walkDir src → copyFile staging]
+    H2 --> H3[RemoveAll dst → Rename staging dst]
+    H3 --> I[writeSkillSnapshot dst]
+    I --> J[discover.Save SnapshotPath]
+```
+
+#### Local skill cache layout
+
+Remote sources are cloned into `os.UserCacheDir()/gaal/skills/<key>/`
+where `<key>` is derived from the URL via `urlToCacheKey()`:
+
+| OS | Cache root | Full path |
+|----|------------|-----------|
+| Linux | `$XDG_CACHE_HOME` or `~/.cache` | `~/.cache/gaal/skills/<key>/` |
+| macOS | `~/Library/Caches` | `~/Library/Caches/gaal/skills/<key>/` |
+| Windows | `%LocalAppData%` | `%LocalAppData%\gaal\skills\<key>\` |
+
+In `--sandbox` mode `os.UserCacheDir()` is redirected so the cache
+resolves inside the sandbox tree.
+
+For `git` sources the cache is a **shallow** clone (`depth=1`) and
+updates are hard-resets to `origin/HEAD` — robust against force-pushes
+and history rewrites.
+
+#### Atomic install
+
+`installSkill` stages the entire copy into a sibling temp directory
+(`.gaal-skill-tmp-*`), then `RemoveAll(dst) + Rename(staging, dst)`.
+A crash mid-copy leaves the previous skill untouched (or the new one
+fully installed) — never a half-written tree the next sync would treat
+as up-to-date. Files removed upstream disappear because `dst` is
+replaced wholesale, not overlay-merged.
+
+#### Snapshot writes
+
+After every successful `installSkill`, `writeSkillSnapshot()` records
+size + mtime + sha256 for every file under `dst` so the next
+`gaal status` can use the Git-index fast path. See
+[`packages/discover.md`](../packages/discover.md) for the snapshot
+format and lifecycle.
+
+### 3 — `mcp.Manager.Sync` (sequential per entry)
+
+```mermaid
+flowchart TD
+    A[mcp.Manager.Sync] --> B[resolvedMCPs: expand agents+global → targets]
+    B --> C[for each resolved entry]
+    C --> D{source mode}
+    D -- inline: --> D1[serverEntry from config]
+    D -- source: --> D2[urlx.ValidateRemoteFetchURL]
+    D2 --> D3[httpx.Client.Do → io.LimitReader 16 MiB]
+    D3 --> D4[json.Decode mcpServers]
+    D1 --> E[mergeIntoTarget target, name, entry]
+    D4 --> E
+    E --> E1{ext .toml?}
+    E1 -- yes --> E2[tomlCodec.ReadServers + WriteServers]
+    E1 -- no --> E3[jsonCodec preserves top-level key order]
+    E2 --> F[secfile.Write atomic 0o600 temp+fsync+rename]
+    E3 --> F
+    F --> G[writeMCPSnapshot target]
+```
+
+- `resolvedMCPs()` expands `agents:` + `global:` into one concrete
+  target file per agent. The `["*"]` wildcard expands to every
+  registered agent that has a non-empty MCP config path.
+- The target file extension picks the codec:
+  - `.toml` → `tomlCodec` (used by Codex)
+  - anything else → `jsonCodec` (Claude Code, Claude Desktop, VS Code, Cursor…)
+- `jsonCodec` preserves top-level key order and per-key indentation by
+  walking the parse tokens directly (PR #203, closes #122).
+- Every write goes through `secfile.Write`: temp file beside the
+  destination → fsync → atomic rename → chmod 0o600 (PR #202, closes
+  #120).
+
+---
+
+## Plan vs. apply
+
+A `--dry-run` runs only the planning phase. The **same planner** runs
+ahead of every one-shot apply so the post-sync summary can use
+past-tense verbs ("cloned", "installed", "upserted") for each managed
+resource:
+
+```mermaid
+flowchart LR
+    A[runSync one-shot] --> B[eng.Plan ctx]
+    B --> B1[ops.SyncPlan: collect + diff + classify]
+    B1 --> C[eng.RunOnce ctx]
+    C --> D[eng.Collect ctx — post-sync state]
+    D --> E[Render summary using plan + post-state]
+```
+
+The plan never writes; the apply does. If `Plan` itself errors, the
+sync still proceeds (the planner is best-effort) but the rendered
+summary may be less precise.
+
+---
+
+## Cancellation
+
+`runSync` wraps the context with `signal.NotifyContext(SIGINT, SIGTERM)`.
+On Ctrl-C:
+
+- All running goroutines (`repo.Manager.Sync` fan-out, in-flight
+  HTTP fetches via `httpx.Client`) observe `ctx.Done()` and unwind.
+- `cmd/sync.go` calls `checkInterrupted(ctx)` after Plan / RunOnce /
+  Prune — early termination produces a clean exit with code 130 (PR
+  #200, closes #126).
+- `--service` mode cancels the ticker loop and returns `nil`.
+
+---
+
+## Prune
+
+`--prune` removes on-disk skills and MCP entries that are no longer
+declared in the merged config. Two safety gates apply:
+
+1. **`--prune` is incompatible with `--service`** — destructive
+   operations are explicitly one-shot.
+2. **MCP prune requires per-target opt-in** (`prune: true` on at
+   least one config entry pointing at that target file). Without the
+   opt-in, manually-curated entries on the user's machine are not
+   wiped (PR #199, closes #142).
+
+Repositories are **never** pruned automatically — deletion of source
+trees requires explicit user action (`rm -rf` on the path).
+
+---
+
+## Service mode
+
+`--service` runs `RunOnce` immediately, then loops on a `time.Ticker`:
+
+```mermaid
+flowchart LR
+    A[--service] --> B[RunOnce]
+    B --> C{ctx.Done?}
+    C -- no --> D[ticker tick]
+    D --> E[RunOnce]
+    E --> C
+    C -- yes --> F([exit 0])
+```
+
+A consecutive-failure cap (5) breaks the loop if the same iteration
+keeps erroring (PR #201, closes #134) — prevents a wedged config from
+silently filling logs forever. Successful iterations reset the counter.
+
+---
+
+## Tooling probe
+
+Before running, `warnMissingTools(cfg)` prints a stderr banner listing
+every required external tool that is **not** on `PATH`:
+
+```
+⚠ Required tools missing from PATH:
+    hg   — required by source vercel-labs/agent-skills (suggest: brew install mercurial)
+    svn  — required by repository src/legacy
+  Run `gaal doctor` for details.
+```
+
+Sync **never blocks** on missing tools — full attribution and exit-code
+semantics live in [`gaal doctor`](doctor.md). The probe is purely an
+early-warning so the user sees the cause before the per-entry failure
+that would otherwise come later. See [`packages/tools.md`](../packages/tools.md).
+
+---
+
+## Side effects (everything sync touches)
+
+| Path | Read / Write | Owner |
+|------|-------------|-------|
+| `gaal.yaml` (and `~/.config/gaal/config.yaml`, `/etc/gaal/config.yaml`) | read | `internal/config` |
+| `repositories.<path>` on disk | clone / update | `internal/repo` + `internal/core/vcs` |
+| `~/.cache/gaal/skills/<key>/` (sandbox-aware) | clone / update | `internal/skill` |
+| `<workDir>/<agent-skills-dir>/<skill>/` | install (atomic stage+rename) | `internal/skill` |
+| `~/.<agent>/skills/<skill>/` (when `global: true`) | install (atomic stage+rename) | `internal/skill` |
+| Agent MCP config (e.g. `~/.claude.json`, `~/.codex/config.toml`, `~/.cursor/mcp.json`) | upsert (atomic 0o600 write) | `internal/mcp` |
+| `~/.cache/gaal/state/<key>.json` (snapshot index) | write | `internal/discover` |
+| `~/.local/state/gaal/telemetry.jsonl` (when consented) | append (0o600) | `internal/telemetry` |
+
+In `--sandbox <dir>` mode, every `~/...` path above is rewritten under
+`<dir>/...` via `applyOptions`. Real user state is untouched.
+
+---
+
+## Related
+
+- [`docs/commands/status.md`](status.md) — read-only counterpart used to
+  observe the result of a sync.
+- [`docs/packages/repo.md`](../packages/repo.md),
+  [`docs/packages/skill.md`](../packages/skill.md),
+  [`docs/packages/mcp.md`](../packages/mcp.md) — manager internals.
+- [`docs/packages/discover.md`](../packages/discover.md) — snapshot
+  format and Git-index fast path.
+- [`docs/packages/secfile.md`](../packages/secfile.md) — atomic
+  write semantics shared across managers.

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -1,0 +1,60 @@
+# `gaal version`
+
+> Print the version string and build timestamp.
+
+## Usage
+
+```
+gaal version              # text: "gaal X.Y.Z\nbuilt YYYY-MM-DDTHH:MM:SSZ\n"
+gaal version --output json
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Always |
+
+---
+
+## Flow
+
+```mermaid
+flowchart LR
+    A[gaal version] --> B{output format?}
+    B -- text --> T[stdout: gaal Version + built BuildTime]
+    B -- json --> J[stdout: encoded version, built]
+```
+
+## Where the values come from
+
+`Version` and `BuildTime` are package-level vars in `cmd/version.go`,
+optionally injected at build time via `ldflags`:
+
+```
+go build -ldflags "
+  -X gaal/cmd.Version=$(git describe --tags --always --dirty)
+  -X gaal/cmd.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+"
+```
+
+Without these flags (e.g. `go run .`), values fall back to `"dev"` /
+`"unknown"`.
+
+## User-Agent propagation
+
+`cmd/version.go`'s `init()` calls `httpx.SetUserAgent("gaal/" + Version)`
+so every outbound HTTP request from
+[`internal/httpx`](../packages/httpx.md) carries the version. This
+matters for telemetry attribution and for upstream servers that rate-
+limit by UA.
+
+---
+
+## Side effects
+
+None.
+
+## Related
+
+- [`docs/packages/httpx.md`](../packages/httpx.md) — UA propagation.

--- a/docs/packages/README.md
+++ b/docs/packages/README.md
@@ -1,0 +1,59 @@
+# Packages — gaal
+
+> One page per Go package under `internal/`. Each page covers what the
+> package owns, its public API, the runtime flow (rendered as a
+> `mermaid` diagram), and where it sits in the dependency graph.
+
+For Pillars-level overviews, see the existing top-level docs:
+
+- [`docs/architecture.md`](../architecture.md) — package map and bootstrap
+- [`docs/config.md`](../config.md) — config / scope / schema / validation / platform / template pillars
+- [`docs/core.md`](../core.md) — VCS + Agent Registry pillars
+- [`docs/discover.md`](../discover.md) — discovery + snapshot pillar
+
+Per-package detail below; per-command flows in
+[`docs/commands/`](../commands/).
+
+## Index
+
+### Domain layer
+
+| Package | Page | Role |
+|---------|------|------|
+| `internal/config` | [config.md](config.md) | YAML loading, merge chain, schema, validation |
+| `internal/core/agent` | [core-agent.md](core-agent.md) | Agent registry, path expansion |
+| `internal/core/vcs` | [core-vcs.md](core-vcs.md) | VCS interface and backends |
+| `internal/discover` | [discover.md](discover.md) | FS-first discovery + snapshot drift |
+| `internal/repo` | [repo.md](repo.md) | Repository manager (uses `core/vcs`) |
+| `internal/skill` | [skill.md](skill.md) | Skill manager (uses `core/vcs` + `core/agent`) |
+| `internal/mcp` | [mcp.md](mcp.md) | MCP entry upsert (JSON / TOML) |
+
+### Orchestration layer
+
+| Package | Page | Role |
+|---------|------|------|
+| `internal/engine` | [engine.md](engine.md) | Single coupling point between cmd and managers |
+| `internal/engine/ops` | [engine-ops.md](engine-ops.md) | Per-command operations (status, audit, init…) |
+| `internal/engine/render` | [engine-render.md](engine-render.md) | Output types + renderers |
+
+### Support layer
+
+| Package | Page | Role |
+|---------|------|------|
+| `internal/httpx` | [httpx.md](httpx.md) | Hardened outbound HTTP client (TLS min, redirect SSRF, body cap, UA) |
+| `internal/installscript` | [installscript.md](installscript.md) | `curl \| sh` installer payload generation |
+| `internal/logger` | [logger.md](logger.md) | Console + JSON file slog handlers |
+| `internal/runner` | [runner.md](runner.md) | Subprocess execution adapter (TTY spinner) |
+| `internal/secfile` | [secfile.md](secfile.md) | Atomic 0o600 writes (temp + fsync + rename) |
+| `internal/telemetry` | [telemetry.md](telemetry.md) | Anonymous usage telemetry, consent-gated |
+| `internal/tools` | [tools.md](tools.md) | External-tool PATH probe |
+| `internal/urlx` | [urlx.md](urlx.md) | URL validation + credential redaction |
+
+## Conventions used in these pages
+
+- **`mermaid` diagrams** depict either the dependency graph or the
+  per-call flow (whichever is more revealing for the package).
+- **Public API** tables list only **exported** symbols. Unexported
+  helpers are described in prose where they matter for understanding.
+- Pages defer to the top-level Pillars docs (`config.md`, `core.md`,
+  `discover.md`) for sub-package detail rather than duplicating it.

--- a/docs/packages/config.md
+++ b/docs/packages/config.md
@@ -1,0 +1,71 @@
+# `internal/config`
+
+> YAML loading, three-level merge chain, scope policy, schema
+> generation, validation. The single source of truth for what
+> "configured" means in gaal.
+
+> **Pillar reference:** the full pillars description (config / scope
+> policy / schema / validation / platform / template) lives in
+> [`docs/config.md`](../config.md). This page is the package-level
+> summary.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `Load(path string) (*Config, error)` | Parse + validate + expand a single file |
+| `LoadChain(workspacePath string) (*ResolvedConfig, error)` | Merge global → user → workspace |
+| `GenerateSchema() ([]byte, error)` | JSON Schema for `Config` |
+| `GlobalConfigFilePath() string` | OS-aware system config path |
+| `UserConfigFilePath() string` | OS-aware user config path |
+| `ConfigScope`, `ScopeGlobal`, `ScopeUser`, `ScopeWorkspace` | Scope type + constants |
+| `ParseConfigScope(s string) (ConfigScope, error)` | Parse a scope string |
+
+## Sub-packages
+
+| Sub-package | Page | Role |
+|-------------|------|------|
+| `internal/config/platform` | (in [`docs/config.md`](../config.md#platform-sub-package-internalconfigplatform)) | OS-specific path resolution |
+| `internal/config/schema` | (in [`docs/config.md`](../config.md#schema-sub-package-internalconfigschema)) | Swappable schema generator + validator |
+| `internal/config/template` | (in [`docs/config.md`](../config.md#data-model)) | Documented YAML skeleton from struct tags |
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[Load path] --> B[os.ReadFile]
+    B --> C[yaml.NewDecoder + KnownFields true]
+    C --> D[validate via schema.DefaultValidator]
+    D --> E[expandPaths anchor=baseDir]
+    E --> F[*Config]
+
+    G[LoadChain workspace] --> H1[Load globalPath]
+    G --> H2[Load userPath]
+    G --> H3[Load workspacePath]
+    H1 --> I[merged := Config plus mergeFrom global]
+    H2 --> J[mergeFrom user with allowedAt scope guard]
+    H3 --> K[mergeFrom workspace with allowedAt scope guard]
+    I --> L[ResolvedConfig with Levels]
+    J --> L
+    K --> L
+```
+
+## Recent fixes worth knowing
+
+| PR | Issue | Effect |
+|----|-------|--------|
+| #190 | #135 | `yaml.NewDecoder(...).KnownFields(true)` rejects unknown keys |
+| #191 | #136 | `expandPaths` warns when two repository keys collide after expansion |
+| #192 | #138 | `isGitHubShorthand` validates GitHub identifier syntax (1-39 chars, alphanumerics + `-_.`, no leading/trailing separator) |
+
+## Tests
+
+`internal/config/...` targets **100 % coverage**. Path resolution tests
+live in `platform/manager_test.go`; expansion tests in `utils_test.go`;
+merge / scope tests in `manager_test.go`.
+
+## Related
+
+- [`docs/config.md`](../config.md) — full pillars description
+- [`packages/secfile.md`](secfile.md) — used to write config files
+  in `gaal init`

--- a/docs/packages/core-agent.md
+++ b/docs/packages/core-agent.md
@@ -1,0 +1,79 @@
+# `internal/core/agent`
+
+> Read-only registry mapping coding-agent identifiers to their on-disk
+> layout (skill dirs, MCP config paths). Embedded YAML is the source of
+> truth; user can extend via `~/.config/gaal/agents.yaml`.
+
+> **Pillar reference:** the full agent registry pillar — `Info`
+> descriptor, built-in registry, user extension, generic-redirect
+> convention, security constraints — lives in [`docs/core.md — Agent
+> Registry Sub-package`](../core.md#agent-registry-sub-package-internalcoreagent).
+> This page is the package-level summary.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `Names() []string` | All registered agent identifiers (unsorted) |
+| `List() []Entry` | All entries sorted by name |
+| `Lookup(name string) (Info, bool)` | Single-agent lookup |
+| `SkillDir(name, global, home string) (string, bool)` | Resolved skill install path; applies generic-convention redirect |
+| `ProjectMCPConfigPath(name, home string) (string, bool)` | Project-scope MCP config path (home-expanded) |
+| `GlobalMCPConfigPath(name, home string) (string, bool)` | Global-scope MCP config path |
+| `ExpandedProjectSkillsSearch(name string) []string` | Project-relative scan dirs |
+| `ExpandedGlobalSkillsSearch(name, home string) []string` | Home-expanded global scan dirs |
+| `ExpandedPmSkillsSearch(name, home string) []string` | Home-expanded package-manager scan dirs |
+| `ExpandHome(p, home string) string` | `~/` expansion |
+
+## Initialisation
+
+```mermaid
+flowchart TD
+    A[package init] --> B[//go:embed agents.yaml]
+    B --> C[loadInto builtins, allowOverride=false]
+    C --> D[userAgentsPath]
+    D --> E{file exists?}
+    E -- no --> Z([registry ready — built-ins only])
+    E -- yes --> F[os.ReadFile]
+    F --> G[loadInto user, allowOverride=true]
+    G --> G1{validateEntry per agent}
+    G1 -- ok --> H[merged registry ready]
+    G1 -- err --> SK[slog.Warn, skip entry]
+```
+
+## Security constraints (`validateEntry`)
+
+| Field | Constraint |
+|-------|-----------|
+| `project_skills_dir` | Relative; no `..` segments — or empty when `supports_generic_project: true` |
+| `global_skills_dir` | Must start with `~/` or `~\` — or empty when `supports_generic_global: true` |
+| `project_mcp_config_file`, `global_mcp_config_file` | Empty or `~/`-prefixed |
+| `*_search[]` | Same rules as their non-`_search` counterparts |
+
+`isAbsPath` rejects POSIX-style absolutes even on Windows (where
+`filepath.IsAbs` would miss them). `containsDotDot` splits on `/`
+(after `filepath.ToSlash`) and checks each segment.
+
+## Generic redirect
+
+Agents with `supports_generic_project: true` or `supports_generic_global:
+true` install into the shared `generic` agent's tree:
+
+- Project: `.agents/skills`
+- Global: `~/.agents/skills`
+
+The redirect is applied transparently inside `SkillDir()` — callers
+must never re-implement it.
+
+## Recent fixes worth knowing
+
+| PR | Issue | Effect |
+|----|-------|--------|
+| #194 | #128 | `claude-desktop` install detection via macOS app path / Windows `%APPDATA%` |
+| #189 | #127 | `AgentEntry` carries `GlobalMCPConfigFile` so summary rollups can match per-agent MCP targets |
+| #187 | #130 | Replaced string concat with `filepath.Join` in `ops/agents.go` |
+
+## Related
+
+- [`docs/core.md`](../core.md) — full pillar description
+- [`packages/skill.md`](skill.md), [`packages/mcp.md`](mcp.md) — main consumers

--- a/docs/packages/core-vcs.md
+++ b/docs/packages/core-vcs.md
@@ -1,0 +1,110 @@
+# `internal/core/vcs`
+
+> Abstract VCS interface and the five backends that satisfy it: git
+> (pure Go), hg / svn / bzr (subprocess), tar / zip (HTTP archive).
+
+> **Pillar reference:** the full VCS pillar description lives in
+> [`docs/core.md — VCS Sub-package`](../core.md#vcs-sub-package-internalcorevcs).
+> This page focuses on package shape and recent fixes.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `VCS` | Interface: `Clone`, `Update`, `IsCloned`, `CurrentVersion`, `HasChanges` |
+| `New(vcsType string) (VCS, error)` | Factory by type string |
+| `NewShallow(vcsType string) (VCS, error)` | Same, but git is `depth=1` (used for skill caches) |
+| `DetectType(source string) string` | Auto-detect from URL or local path |
+| `VcsGit`, `VcsMercurial`, `VcsSVN`, `VcsBazaar`, `VcsArchive` | Backend types |
+
+## Backends
+
+| Struct | Type | Strategy | Binary |
+|--------|------|---------|--------|
+| `VcsGit` | `git` | go-git, pure Go | none |
+| `VcsMercurial` | `hg` | subprocess | `hg` |
+| `VcsSVN` | `svn` | subprocess | `svn` + `svnversion` |
+| `VcsBazaar` | `bzr` | subprocess | `bzr` |
+| `VcsArchive` | `tar`, `zip` | HTTP fetch + stdlib extract | none |
+
+## Dependency graph
+
+```mermaid
+flowchart LR
+    R[internal/repo] --> V[internal/core/vcs]
+    S[internal/skill] --> V
+    V --> H[internal/httpx]
+    V --> U[internal/urlx]
+    V --> RN[internal/runner]
+    H --> NET[network]
+    RN --> SUB[subprocess]
+```
+
+`vcs` itself depends on:
+
+- [`packages/urlx.md`](urlx.md) — pre-clone URL validation
+- [`packages/httpx.md`](httpx.md) — archive fetch
+- [`packages/runner.md`](runner.md) — subprocess wrapping (hg/svn/bzr)
+- `go-git/go-git/v5` — git backend
+
+## Archive extraction (`VcsArchive`)
+
+```mermaid
+flowchart TD
+    A[Clone url, path, version] --> B[fetchURL ctx, url]
+    B --> B1[urlx.ValidateRemoteFetchURL]
+    B1 --> B2[httpx.NewRequest + Client.Do]
+    B2 --> C[io.LimitReader MaxArchiveBytes plus 1 GiB]
+    C --> D{format}
+    D -- tar --> E[extractTar]
+    D -- zip --> F[extractZip — buffer to tempfile, zip.NewReader]
+    E --> G[per-entry: path-traversal guard, size cap, write 0o644]
+    F --> G
+    G --> Z([extracted into path])
+```
+
+Resource limits (in `archive.go`):
+
+| Const | Value | Defends against |
+|-------|-------|-----------------|
+| `MaxArchiveBytes` | 1 GiB | Buffered/streamed body |
+| `MaxFileBytes` | 256 MiB | gzip bombs |
+| `MaxEntryCount` | 50 000 | Inode-exhaustion archives |
+
+Path containment is enforced via `archiveEntryPath` — strips first
+component, rejects absolute paths and `..` segments, then uses
+`filepath.Rel` against the dest to catch separator tricks (PR for
+#112).
+
+## Subprocess backends
+
+Every method that spawns a subprocess calls `requireBinary(name)` as
+its **first statement** — surfaces a clear "tool missing from PATH"
+error instead of a cryptic exec failure.
+
+URL validation (PR for #117) and operand validation (PR for #116) run
+before any subprocess invocation:
+
+- `urlx.ValidateRepoURL` — scheme allowlist
+- `validateVCSOperand("version", v)` — rejects leading-dash arguments
+  that could be parsed as flags
+
+Plus `--` separators are inserted before user-controlled positional
+args so `hg`, `svn`, `bzr` cannot be tricked into interpreting them as
+options.
+
+## Recent fixes worth knowing
+
+| PR | Issue | Effect |
+|----|-------|--------|
+| #117 | scheme allowlist | `ValidateRepoURL` enforces https/ssh/git + loopback-only http/svn/bzr |
+| #116 | argv injection | `--` separator + operand validation across all subprocess backends |
+| (open) #207 | partial-clone recovery | `VcsGit.IsCloned` validates HEAD; `Clone` stages + atomically swaps |
+| (open) #206 | archive update | `VcsArchive.Update` re-fetches and atomically replaces; interface gains `url` parameter |
+
+(Open PRs are noted as such — main does not yet carry their behaviour.)
+
+## Related
+
+- [`docs/core.md`](../core.md) — full pillar description
+- [`packages/repo.md`](repo.md), [`packages/skill.md`](skill.md) — main consumers

--- a/docs/packages/discover.md
+++ b/docs/packages/discover.md
@@ -1,0 +1,83 @@
+# `internal/discover`
+
+> FS-first resource discovery + Git-inspired snapshot drift detection.
+
+> **Pillar reference:** the full discovery pillar — resource model,
+> snapshot lifecycle, scan options, per-resource-type scan logic — lives
+> in [`docs/discover.md`](../discover.md). This page is the
+> package-level summary.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `Scan(ctx, home, workDir string, opts ScanOptions) ([]Resource, error)` | Public entry point |
+| `ScanOptions` | `MaxDepth`, `IncludeWorkspace`, `StateDir`, `Timeout` |
+| `Resource` | `{Type, Scope, Path, Name, Drift, VCSType, Managed, Meta}` |
+| `Snapshot` | `map[string]FileRecord` |
+| `Load`, `Save`, `Record`, `SnapshotDir`, `DiffPath`, `SnapshotPath`, `WorkdirKey` | Snapshot helpers |
+| `ResourceType`, `Scope`, `DriftState` | Enum types and constants |
+
+## Drift heuristic
+
+```mermaid
+flowchart LR
+    A[FS entry] --> B{vcs marker present?}
+    B -- yes --> C[vcs.HasChanges fast path]
+    B -- no --> D{stat: size+mtime match snapshot?}
+    D -- yes --> OK([drift: ok])
+    D -- no --> E[sha256 of file]
+    E --> F{hash matches snapshot?}
+    F -- yes --> R[update snapshot mtime — racy-git repair]
+    F -- no --> M([drift: modified])
+    R --> OK
+    C --> OK
+```
+
+## Snapshot lifecycle
+
+```mermaid
+flowchart TD
+    A[gaal sync] --> B[manager Sync]
+    B --> C[install / merge / clone]
+    C --> D[writeSkillSnapshot / writeMCPSnapshot]
+    D --> E[discover.SnapshotDir or Record]
+    E --> F[discover.Save SnapshotPath stateDir, key]
+
+    G[gaal status / info] --> H[discover.Scan]
+    H --> I[per-resource-type drift]
+    I --> J[discover.DiffPath root, snap]
+    J --> K[Resource Drift annotation]
+```
+
+## State directory
+
+| OS | Default path |
+|----|-------------|
+| Linux | `~/.cache/gaal/state/` |
+| macOS | `~/Library/Caches/gaal/state/` |
+| Windows | `%LocalAppData%\gaal\state\` |
+
+Sandbox-aware. Snapshots are keyed by `WorkdirKey(path)` (8-char hex of
+`sha256(path)[:4]`) so different installation paths for the same skill
+name never collide.
+
+## Per-resource-type scan
+
+| File | Scope |
+|------|-------|
+| `global.go` | Agent-registry skill dirs (global + user) |
+| `mcp.go` | Agent MCP config files (project + global since PR #193) |
+| `workspace.go` | Depth-limited FS walk for repos and skills in `workDir` |
+
+## Recent fixes worth knowing
+
+| PR | Issue | Effect |
+|----|-------|--------|
+| #193 | #137 | `scanMCPs` now scans both `ProjectMCPConfigPath` and `GlobalMCPConfigPath` |
+
+## Related
+
+- [`docs/discover.md`](../discover.md) — full pillar description
+- [`commands/status.md`](../commands/status.md), [`commands/audit.md`](../commands/audit.md) — main consumers
+- [`packages/secfile.md`](secfile.md) — atomic snapshot writes

--- a/docs/packages/engine-ops.md
+++ b/docs/packages/engine-ops.md
@@ -1,0 +1,79 @@
+# `internal/engine/ops`
+
+> Stateless functions that implement each CLI command. Each function
+> receives the managers and config it needs as parameters — no global
+> state, no init magic.
+
+## File layout
+
+| File | Exported symbols | Description |
+|------|-----------------|-------------|
+| `status.go` | `Collect()`, `Status()` | FS-first state via `discover.Scan`; reconciles config-declared and FS-discovered resources |
+| `plan.go` | `SyncPlan()`, `RenderPlan()` | Compute the sync plan (clone / install / upsert) |
+| `audit.go` | `Audit()` | Discover all installed skills + MCP servers |
+| `agents.go` | `ListAgents()`, `AgentDetail()` | Agent registry queries |
+| `doctor.go` | `RunDoctor()`, `DoctorReport`, `DoctorOptions` | Health checks |
+| `info.go` | `Info()` | Detailed per-entry card rendering |
+| `init.go` | `Init()` | Write skeleton + backup existing |
+| `init_plan.go` | `BuildCandidates()`, `BuildPlan()` | Import-mode planning |
+| `init_build.go` | `BuildFromPlan()` | Generate YAML from plan |
+| `init_source.go` | `ResolveSource()` | Resolve skill source for import scan |
+| `migrate.go` | `Migrate()`, `MigrateResult` | Migration stub |
+
+## Reconcile loop
+
+```mermaid
+flowchart TD
+    A[ops.Collect ctx, repos, skills, mcps, home, workDir, stateDir] --> B[repos.Status fan-out]
+    A --> C[skills.Status]
+    A --> D[mcps.Status]
+    A --> E[discover.Scan IncludeWorkspace=true]
+    B --> F[reconcileRepos managed + fs]
+    C --> G[reconcileSkills managed + fs]
+    D --> H[reconcileMCPs managed + fs]
+    E --> F
+    E --> G
+    E --> H
+    F --> R[StatusReport]
+    G --> R
+    H --> R
+```
+
+Reconcile rules: a resource declared in config and present on disk
+gets the manager-derived status; a resource on disk with no config
+match is appended as `unmanaged`; a snapshot record with no FS entry
+becomes `missing`.
+
+## Plan vs. Apply
+
+```mermaid
+flowchart LR
+    A[Plan or DryRun] --> B[ops.SyncPlan]
+    B --> C[ops.Collect under-the-hood]
+    C --> D[planRepos]
+    C --> E[planSkills]
+    C --> F[planMCPs]
+    D --> G[PlanReport HasChanges plus HasErrors]
+    E --> G
+    F --> G
+
+    H[Apply via engine.RunOnce] --> I[manager Sync]
+    I --> J[ops.Collect post-sync]
+    J --> K[render summary using Plan plus post-state]
+```
+
+The same planner runs in both branches so the post-sync summary can
+report past-tense verbs that match what the dry-run would have
+predicted.
+
+## Backup-on-init (PR #198 / #139)
+
+`Init` calls `backupExisting(dest)` before writing when `--force` is
+used. The previous file is renamed to `<dest>.bak.<UTC-RFC3339>` so
+the user always has a recoverable copy.
+
+## Related
+
+- [`packages/engine.md`](engine.md) — how `ops` is wired into the engine
+- [`packages/discover.md`](discover.md) — used by `Collect`
+- [`commands/`](../commands/) — one per command consuming these ops

--- a/docs/packages/engine-render.md
+++ b/docs/packages/engine-render.md
@@ -1,0 +1,75 @@
+# `internal/engine/render`
+
+> Pure rendering layer. No dependencies on the manager packages — the
+> renderers consume the report types and serialise to text / table /
+> JSON.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `OutputFormat` | `text`, `table`, `json`, `verbose` |
+| `Renderer` | `interface{ Render(io.Writer, *StatusReport) error }` |
+| `NewRenderer(format)` | Construct |
+| Report types | `StatusReport`, `RepoEntry`, `SkillEntry`, `MCPEntry`, `AgentEntry`, `AuditReport`, `PlanReport` |
+| Status codes | `StatusOK`, `StatusDirty`, `StatusNotCloned`, `StatusPartial`, `StatusPresent`, `StatusAbsent`, `StatusUnmanaged`, `StatusError` |
+| `RenderSyncBrief(w, plan, status, dur) error` | Default one-line summary after `gaal sync` |
+| `RenderSyncSummary(w, plan, status, dur) error` | `--verbose` summary used after `gaal sync --verbose` |
+| `WriteTip(w)` | Optional footer hint printed on TTY |
+
+## File layout
+
+| File | Contents |
+|------|----------|
+| `report.go` | All report types and status code constants |
+| `renderer.go` | `OutputFormat`, `Renderer` interface, `NewRenderer()` |
+| `json.go` | `jsonRenderer` — indented JSON encoder |
+| `table.go` | `tableRenderer` — adaptive `pterm` tables |
+| `audit.go` | `AuditRenderer`, JSON + table variants |
+| `summary_sync.go` | `RenderSyncBrief`, `RenderSyncSummary` |
+
+## Flow
+
+```mermaid
+flowchart LR
+    A[ops.Collect / ops.SyncPlan / ops.Audit] --> B[Report type]
+    B --> C[render.NewRenderer format]
+    C -->|text| D[summary lines]
+    C -->|verbose| E[full per-entry detail]
+    C -->|table| F[pterm boxed tables]
+    C -->|json| G[encoded JSON]
+    D --> H[stdout]
+    E --> H
+    F --> H
+    G --> H
+```
+
+## Why pure?
+
+`render` has zero dependencies on `repo`, `skill`, `mcp`, or `discover`
+— it only consumes the data structures defined in `report.go`. This
+keeps the renderer reusable from `cmd` (for the post-sync brief), from
+`ops` (for status / audit / plan), and from tests (which can build a
+report struct directly without standing up managers).
+
+## Sync summary modes
+
+| Mode | When | Format |
+|------|------|--------|
+| `RenderSyncBrief` | `gaal sync` (default) | Single line per resource type with counts |
+| `RenderSyncSummary` | `gaal sync --verbose` | Per-resource lines with detected drift, install targets, durations |
+
+Both render the **planner's** verb (cloned / installed / upserted) for
+each managed resource, paired with the **post-sync state** from
+`ops.Collect`.
+
+## Recent fixes worth knowing
+
+| PR | Issue | Effect |
+|----|-------|--------|
+| #189 | #127 | `summary_sync.go` correctly counts MCP servers per agent in the rollup line |
+
+## Related
+
+- [`packages/engine.md`](engine.md), [`packages/engine-ops.md`](engine-ops.md) — producers of the report types
+- [`commands/sync.md`](../commands/sync.md) — main consumer of `RenderSyncBrief` / `RenderSyncSummary`

--- a/docs/packages/engine.md
+++ b/docs/packages/engine.md
@@ -1,0 +1,100 @@
+# `internal/engine`
+
+> The single coupling point between `cmd/` and the three resource
+> managers (`repo`, `skill`, `mcp`). Holds no business logic of its own
+> — every command operation delegates to `engine/ops`, every rendering
+> concern to `engine/render`.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `New(cfg) *Engine` | Construct with default directories |
+| `NewWithOptions(cfg, Options) *Engine` | Construct with overrides |
+| `Options` | `WorkDir`, `StateDir`, `Force`, `Verbose` |
+| `Engine.RunOnce(ctx) error` | One-shot sync (repos → skills → mcps) |
+| `Engine.RunService(ctx, interval) error` | Service-mode loop |
+| `Engine.Plan(ctx) (*PlanReport, error)` | Compute sync plan without writes |
+| `Engine.DryRun(ctx, format) (*PlanReport, error)` | Plan + render |
+| `Engine.Prune(ctx) error` | Skill + MCP prune (gated per #199 / #142) |
+| `Engine.Collect(ctx) (*StatusReport, error)` | Read-only snapshot of resource state |
+| `Engine.Status(ctx, format) error` | Render status to stdout |
+| `Engine.Audit(ctx, format) error` | Render config-independent inventory |
+| `Engine.Info(ctx, pkg, filter, format) error` | Render per-entry detail |
+| `Engine.ListAgents() / AgentDetail(name)` | Agent registry queries |
+| `Engine.Init(dest, force) error` | Bootstrap a `gaal.yaml` skeleton |
+| `Engine.BuildImportCandidates(ctx, scope) (Candidates, error)` | FS scan for `init --import` |
+| `Engine.InitFromPlan(dest, plan, force) error` | Import-mode write |
+| `Engine.Migrate(target, url, dryRun) (*MigrateResult, error)` | (Stub) migration |
+| `Engine.Doctor(opts) *DoctorReport` | Configuration health checks |
+
+Type aliases re-export `engine/render` types (`OutputFormat`,
+`StatusCode`, `RepoEntry`, `SkillEntry`, …) for backward compatibility
+with `cmd/` callers.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph cmd
+      A[cmd/sync.go] -.->|RunOnce / RunService / Plan / DryRun / Prune| E
+      B[cmd/status.go] -.->|Status| E
+      C[cmd/info.go]  -.->|Info| E
+      D[cmd/init.go]  -.->|Init / InitFromPlan / BuildImportCandidates| E
+      F[cmd/audit.go] -.->|Audit| E
+      G[cmd/agents.go]-.->|ListAgents / AgentDetail| E
+      H[cmd/doctor.go]-.->|Doctor| E
+      I[cmd/migrate.go]-.->|Migrate| E
+    end
+
+    E[engine.Engine] --> Ops[internal/engine/ops]
+    E --> Render[internal/engine/render]
+    Ops --> Repo[internal/repo]
+    Ops --> Skill[internal/skill]
+    Ops --> MCP[internal/mcp]
+    Ops --> Discover[internal/discover]
+```
+
+## Why this shape?
+
+1. `cmd/*.go` files import **only** `internal/engine`. Adding a new
+   sub-command requires zero plumbing changes inside the managers.
+2. `engine.Engine` owns the three managers and the resolved directories
+   (`home`, `workDir`, `cacheRoot`, `stateDir`). Every operation that
+   needs them goes through here.
+3. Business logic (collect / plan / install / etc.) lives under
+   `engine/ops` so it can be unit-tested without standing up Cobra.
+4. Rendering lives under `engine/render` so the same data can be
+   serialised to text / table / JSON without touching the managers.
+
+## Service-mode failure cap (PR #201 / #134)
+
+```mermaid
+flowchart TD
+    A[RunService ctx, interval] --> B[runIteration RunOnce]
+    B --> C{success?}
+    C -- yes --> D[reset failure counter]
+    C -- no --> E[increment counter]
+    E --> F{>= maxConsecutiveServiceFailures 5?}
+    F -- yes --> G([abort service loop, return joined err])
+    F -- no --> H[wait next tick]
+    D --> H
+    H --> A
+```
+
+Prevents a wedged config from filling logs forever — successful
+iterations reset the counter so transient errors don't accumulate.
+
+## Cancellation (PR #200 / #126)
+
+`runSync` (in `cmd/sync.go`) calls `checkInterrupted(ctx)` after each
+phase (Plan / RunOnce / Prune). On Ctrl-C the engine's goroutines unwind
+and the command returns `&ExitCodeError{Code: 130}` so
+`PersistentPostRunE` still runs (telemetry flush + consent persist).
+
+## Related
+
+- [`packages/engine-ops.md`](engine-ops.md) — per-command operation logic
+- [`packages/engine-render.md`](engine-render.md) — output types and
+  renderers
+- [`packages/repo.md`](repo.md), [`packages/skill.md`](skill.md), [`packages/mcp.md`](mcp.md) — managers driven by engine

--- a/docs/packages/httpx.md
+++ b/docs/packages/httpx.md
@@ -1,0 +1,88 @@
+# `internal/httpx`
+
+> Single hardened outbound HTTP client. Centralises TLS, timeout,
+> redirect SSRF defence, body cap, and User-Agent so stray
+> `http.DefaultClient` calls cannot regress the security posture.
+
+Introduced in PR #205 (#123) as the consolidation of two ad-hoc call
+sites: `internal/mcp` (remote MCP config fetch) and
+`internal/core/vcs/archive.go` (archive download).
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `Client() *http.Client` | Shared client with the hardened defaults |
+| `NewRequest(ctx, method, url) (*http.Request, error)` | Wraps `http.NewRequestWithContext` and sets the `User-Agent` header |
+| `SetUserAgent(string)` | Mutates the package-level UA (called from `cmd/version.go init` to inject `gaal/<Version>`) |
+| `UserAgent() string` | Reads the current UA |
+| `MaxBodyBytes int64 = 16 << 20` | Recommended cap for ad-hoc JSON / text fetches; callers wrap `resp.Body` in `io.LimitReader(MaxBodyBytes+1)` |
+| `DefaultClientTimeout = 5 * time.Minute` | Per-request hard cap |
+| `MaxRedirects = 10` | Redirect cap |
+| `ErrCrossSchemeRedirect`, `ErrTooManyRedirects`, `ErrInternalRedirect` | Redirect-policy errors surfaced verbatim from `Client.Do` |
+
+## Defaults
+
+| Concern | Default |
+|---------|---------|
+| `Client.Timeout` | `5m` (callers can tighten via context) |
+| `Transport.TLSClientConfig.MinVersion` | `tls.VersionTLS12` |
+| `Transport.TLSHandshakeTimeout` | `10s` |
+| `Transport.DialContext` | `30s` connect, `30s` keepalive |
+| `Transport.ExpectContinueTimeout` | `1s` |
+| `Transport.ForceAttemptHTTP2` | `true` |
+| Proxy | `http.ProxyFromEnvironment` |
+| Redirect cap | 10 hops |
+| https → http downgrade redirect | rejected unless target is loopback |
+| External → internal/loopback redirect | rejected (SSRF defence) |
+| User-Agent | `gaal/<Version>` (set by `cmd init`) |
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[caller] --> B[httpx.NewRequest ctx, GET, url]
+    B --> C[req.Header User-Agent = UserAgent]
+    C --> D[httpx.Client.Do req]
+    D --> E[Transport TLS+HTTP/2 dial]
+    E --> F{response 3xx?}
+    F -- no --> Out[caller drains body via io.LimitReader MaxBodyBytes+1]
+    F -- yes --> G[checkRedirect]
+    G --> G1{>= MaxRedirects?}
+    G1 -- yes --> ZE([ErrTooManyRedirects])
+    G1 -- no --> G2{prev https → next http && !loopback?}
+    G2 -- yes --> ZS([ErrCrossSchemeRedirect])
+    G2 -- no --> G3{origin external && next internal?}
+    G3 -- yes --> ZI([ErrInternalRedirect])
+    G3 -- no --> H[propagate UA across hop] --> D
+```
+
+## Why caller-side body cap?
+
+Body-size enforcement lives at the caller because:
+
+- The MCP JSON path is small and uses `httpx.MaxBodyBytes` (16 MiB) —
+  more than enough headroom.
+- The archive download path streams large payloads (up to 1 GiB by
+  policy) and has its own per-entry caps inside the tar/zip extractor
+  ([`packages/core-vcs.md`](core-vcs.md)).
+
+A single shared cap inside the client would either OOM-protect at the
+wrong size or break legitimate large fetches. Caller-side caps stay
+explicit at the use site.
+
+## Tests
+
+`httpx_test.go` covers:
+
+- UA default + `SetUserAgent` mutation
+- UA propagation through `NewRequest`
+- Context-timeout takes precedence over `Client.Timeout`
+- Redirect cap fires
+- `isLoopback` and `isInternal` classifiers (RFC1918, link-local,
+  IMDS at 169.254.169.254, etc.)
+
+## Related
+
+- [`packages/urlx.md`](urlx.md) — pre-fetch URL validation
+- [`commands/sync.md`](../commands/sync.md) — main consumer

--- a/docs/packages/installscript.md
+++ b/docs/packages/installscript.md
@@ -1,0 +1,44 @@
+# `internal/installscript`
+
+> Renders the `curl | sh` installer payload that the gaal landing
+> page serves. Pure Go templating; no I/O.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `Render(opts Options) ([]byte, error)` | Generate the install script for a given OS / arch / version |
+| `Options` | Inputs: target OS, arch, version, optional checksum |
+
+## Why it lives in `internal`
+
+The install script is the **only** artefact gaal produces aside from
+its binary, so its content is part of the supply chain. Keeping it as
+a Go package (rather than a static asset) means:
+
+- The version string and download URLs are typed values, not regex
+  substitutions.
+- Tests can render the script and execute snippets in a sandbox.
+- The release pipeline can call `Render` directly without re-implementing
+  the URL scheme.
+
+## Flow
+
+```mermaid
+flowchart LR
+    A[release pipeline] --> B[installscript.Render opts]
+    B --> C[load embedded template]
+    C --> D[execute with opts]
+    D --> E[bytes ready to publish at install.gaal.dev]
+```
+
+## Tests
+
+Cover OS/arch coverage, version interpolation, and (by snapshotting the
+output) protect against accidental edits to the canonical install
+flow.
+
+## Related
+
+- `cmd/version.go` — same `Version` constant referenced in the rendered
+  script.

--- a/docs/packages/logger.md
+++ b/docs/packages/logger.md
@@ -1,0 +1,54 @@
+# `internal/logger`
+
+> Console + JSON file slog handlers. One TTY mutex coordinates the
+> spinner and console output so they never interleave.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `New(opts Options) *slog.Logger` | Build a logger with the requested handlers |
+| `Options` | `Level`, `LogFile`, `NoColor` |
+| `ConsoleHandler` | Compact, ANSI-coloured stderr handler with TTY auto-detection |
+| `teeHandler` | Fan-out to multiple handlers (used when `--log-file` is set) |
+| `ttyMu *sync.Mutex` | Shared with the runner spinner to prevent line interleave |
+
+## Handlers
+
+| Handler | Destination | Format |
+|---------|-------------|--------|
+| `ConsoleHandler` | `stderr` | Compact, colourised (ANSI), TTY-aware |
+| `slog.JSONHandler` | file (`--log-file`) | JSON Lines with `host` and `time` fields |
+
+The log file is written via `secfile.OpenAppend` so it lands `0o600`
+(see [`packages/secfile.md`](secfile.md)).
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[cmd.setupLogger] --> B{--log-file set?}
+    B -- no --> C[ConsoleHandler only]
+    B -- yes --> D[teeHandler: ConsoleHandler + JSONHandler]
+    C --> E[slog.SetDefault]
+    D --> E
+    E --> F[every log call routes through SetDefault]
+
+    subgraph TTY coordination
+      G[runner spinner] --> H[ttyMu.Lock]
+      I[ConsoleHandler.Handle] --> H
+      H --> J[exclusive write to stderr]
+    end
+```
+
+## Why a shared mutex?
+
+Without coordination, a slog `Info` call landing while the pterm
+spinner is mid-tick would clobber the spinner's carriage-return-based
+animation, leaving stray tty escape sequences in the user's terminal.
+The shared `ttyMu` is acquired by both writers so they take turns.
+
+## Related
+
+- [`packages/runner.md`](runner.md) — the spinner side of the mutex
+- [`packages/secfile.md`](secfile.md) — log file permission

--- a/docs/packages/mcp.md
+++ b/docs/packages/mcp.md
@@ -1,0 +1,111 @@
+# `internal/mcp`
+
+> MCP entry upsert. Reads / writes JSON or TOML agent configuration
+> files preserving every key the user owns; handles inline and remote
+> sources.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `NewManager(mcps []ConfigMcp, home, stateDir string) *Manager` | Construct |
+| `Manager.Sync(ctx) error` | Upsert every entry into its target file |
+| `Manager.Prune(ctx) error` | Remove entries no longer in config (gated per-target by `prune: true`) |
+| `Manager.Status(ctx) []Status` | Per-entry `{Name, Target, Present, Dirty, Err}` |
+
+## Source modes
+
+| Mode | Description |
+|------|-------------|
+| `inline:` | Full server definition in YAML (`command`, `args`, `env`) |
+| `source:` | Remote URL returning a JSON document (full `mcpServers` map or a single entry) |
+
+Validated via [`packages/urlx.md`](urlx.md) before any HTTP call.
+
+## Codec selection
+
+```mermaid
+flowchart TD
+    A[mergeIntoTarget target, name, entry] --> B{ext .toml?}
+    B -- yes --> C[tomlCodec]
+    B -- no --> D[jsonCodec]
+
+    subgraph json
+      D --> D1[ReadServers: read-as-ordered tokens]
+      D1 --> D2[Upsert servers map]
+      D2 --> D3[WriteServers preserving top-level key order]
+    end
+
+    subgraph toml
+      C --> C1[toml.Unmarshal whole doc]
+      C1 --> C2[Upsert mcp_servers table]
+      C2 --> C3[toml.Marshal whole doc]
+    end
+
+    D3 --> E[secfile.Write atomic 0o600]
+    C3 --> E
+```
+
+## Order-preserving JSON codec (PR #203 / #122)
+
+The Codex agent's `~/.codex/config.toml` carries unrelated keys
+alongside `mcp_servers` (`model`, `sandbox`, `[analytics]`…) that must
+survive a round-trip — that's a regular concern in JSON-based agents
+too where `claude_desktop` adds `feature_flags`, `default_model`, etc.
+
+`jsonCodec` walks the top-level object via `json.Decoder.Token()` so
+key order is preserved exactly. Only the `mcpServers` block is
+rewritten; every other key is emitted verbatim.
+
+## Atomic write (PR #202 / #120)
+
+Every codec ends in `secfile.Write(path, bytes)` — temp file →
+fsync → rename → chmod 0o600. See [`packages/secfile.md`](secfile.md).
+
+## Remote source fetch (PR #205 / #123)
+
+Remote `source:` URLs go through [`packages/httpx.md`](httpx.md):
+
+- `urlx.ValidateRemoteFetchURL` — scheme allowlist
+- `httpx.Client` — TLS 1.2 minimum, redirect SSRF defence, 5-min
+  timeout
+- `io.LimitReader(resp.Body, MaxBodyBytes+1)` — 16 MiB cap on the JSON
+  response
+
+## Target resolution
+
+```mermaid
+flowchart LR
+    A[ConfigMcp] --> B{target field set?}
+    B -- yes --> C[deprecated: use as-is, warn]
+    B -- no --> D[expand agents + global → per-agent target]
+    D --> D1{agents == ['*']?}
+    D1 -- yes --> D2[agent.Names]
+    D1 -- no --> D3[explicit list]
+    D2 --> E[for each agent: ProjectMCPConfigPath or GlobalMCPConfigPath]
+    D3 --> E
+```
+
+## Prune opt-in (PR #199 / #142)
+
+`Manager.Prune` deletes entries from a target file only when at least
+one config entry pointing at that target carries `prune: true`. This
+prevents `gaal sync --prune` from wiping manually-curated entries the
+user never told gaal to manage.
+
+## Tests
+
+`manager_test.go` covers:
+
+- inline and remote source modes
+- JSON and TOML codec round-trip with extra keys preserved
+- prune opt-in behaviour (with and without `prune: true`)
+- snapshot writes
+- legacy `target:` warning
+
+## Related
+
+- [`packages/secfile.md`](secfile.md), [`packages/urlx.md`](urlx.md),
+  [`packages/httpx.md`](httpx.md) — write + fetch primitives
+- [`packages/core-agent.md`](core-agent.md) — target path resolution
+- [`commands/sync.md`](../commands/sync.md#3--mcpmanagersync-sequential-per-entry) — high-level flow

--- a/docs/packages/repo.md
+++ b/docs/packages/repo.md
@@ -1,0 +1,73 @@
+# `internal/repo`
+
+> Repository manager. Drives `internal/core/vcs` backends in parallel,
+> one goroutine per `repositories:` entry.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `NewManager(repos map[string]ConfigRepo, stateDir string) *Manager` | Construct |
+| `Manager.Sync(ctx) error` | Clone-or-update every repo; errors aggregated with `errors.Join` |
+| `Manager.Status(ctx) []Status` | Per-repo status (`Cloned`, `Dirty`, `Current`, `Err`) |
+| `Status` | Shape: `Path`, `Type`, `URL`, `Version`, `Current`, `Cloned`, `Dirty`, `Err` |
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[Manager.Sync ctx] --> B[fan-out: one goroutine per repo]
+    B --> C[vcs.New cfg.Type]
+    C --> D{IsCloned path?}
+    D -- no --> E[backend.Clone ctx, cfg.URL, path, cfg.Version]
+    D -- yes --> F[backend.Update ctx, path, cfg.Version]
+    E --> G[errCh]
+    F --> G
+    G --> H[wg.Wait → errors.Join]
+
+    A2[Manager.Status ctx] --> B2[fan-out goroutines]
+    B2 --> C2[vcs.New]
+    C2 --> D2[backend.IsCloned]
+    D2 --> E2[backend.CurrentVersion]
+    E2 --> F2[backend.HasChanges]
+    F2 --> G2[Status slice]
+```
+
+## Backend selection
+
+| `cfg.Type` | Backend | Notes |
+|-----------|---------|-------|
+| `git` | `VcsGit` (full clone) | go-git, pure Go |
+| `hg` | `VcsMercurial` | subprocess, requires `hg` |
+| `svn` | `VcsSVN` | subprocess, requires `svn` + `svnversion` |
+| `bzr` | `VcsBazaar` | subprocess, requires `bzr` |
+| `tar`, `zip` | `VcsArchive` | HTTP fetch + stdlib extract |
+
+`Manager` itself never picks shallow mode — that's reserved for
+`internal/skill` (which keeps a depth-1 cache). Repos defined under
+`repositories:` always get full history (or full archive expansion)
+because the user typically wants to use them as live source trees.
+
+## Why parallel?
+
+Repos are independent: each one has its own remote, its own version,
+its own destination path. Sequencing them serially would make a
+multi-repo sync wall-clock-bound by the slowest network roundtrip.
+The fan-out is bounded only by `len(repos)` — there is no goroutine
+pool today, by design (most users have a handful of repos, not
+hundreds).
+
+## Errors
+
+A single repo failure (network drop, auth error, broken VCS state)
+does **not** abort the rest of the sync. All goroutines run to
+completion; errors are collected via the buffered channel and joined
+via `errors.Join`. The caller (`engine.RunOnce`) surfaces the joined
+error to the user along with the partial-success summary.
+
+## Related
+
+- [`packages/core-vcs.md`](core-vcs.md) — backends.
+- [`commands/sync.md`](../commands/sync.md) — main consumer.
+- [`packages/discover.md`](discover.md) — how `Status` is used to
+  detect drift in `gaal status`.

--- a/docs/packages/runner.md
+++ b/docs/packages/runner.md
@@ -1,0 +1,66 @@
+# `internal/runner`
+
+> Subprocess execution adapter. Maps `os/exec` output to the active
+> log level and runs a TTY spinner when stderr is interactive.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `Run(ctx, label, dir, name string, args ...string) error` | Execute `name args...` in `dir`; show a spinner while running on a TTY |
+
+## Behaviour by log level
+
+| Level | Behaviour |
+|-------|-----------|
+| `DEBUG` (`--verbose`) | stdout + stderr logged line-by-line via `slog.Debug`; no spinner |
+| `INFO` (default) | output captured silently; spinner ticks; on failure stderr is emitted via `slog.Error` |
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[runner.Run ctx, label, dir, name, args] --> B[exec.CommandContext]
+    B --> C[wire stdout, stderr pipes]
+    C --> D{slog level}
+    D -- debug --> E[goroutine drains pipes → slog.Debug per line]
+    D -- info --> F[capture buffers]
+    F --> G{stderr is TTY?}
+    G -- yes --> H[acquire logger.ttyMu]
+    G -- no --> I[no spinner]
+    H --> J[pterm spinner running label]
+    I --> K[cmd.Run]
+    J --> K
+    K --> L{exit ok?}
+    L -- yes --> M[spinner success / done]
+    L -- no --> N[slog.Error captured stderr]
+    M --> Z([return nil])
+    N --> Z2([return err])
+```
+
+## Why coordinate with the logger?
+
+A `slog` call landing mid-spinner would corrupt the carriage-return
+animation. `runner` and `logger` share `ttyMu` so only one writer
+touches stderr at a time. See [`packages/logger.md`](logger.md).
+
+## Consumers
+
+| Caller | Use |
+|--------|-----|
+| `internal/core/vcs/hg.go`, `svn.go`, `bzr.go` | Wrap subprocess calls to those VCS binaries |
+
+## Tests
+
+`runner_test.go` covers:
+
+- Successful exit with INFO and DEBUG levels (no goroutine leaks)
+- Failure with stderr emission
+- Context cancellation propagation
+- Spinner mutex acquisition (with a stub TTY)
+
+## Related
+
+- [`packages/logger.md`](logger.md) — the other half of `ttyMu`
+- [`packages/core-vcs.md`](core-vcs.md) — every subprocess VCS backend
+  goes through `runner`

--- a/docs/packages/secfile.md
+++ b/docs/packages/secfile.md
@@ -1,0 +1,78 @@
+# `internal/secfile`
+
+> Atomic 0o600 file writes for anything that may hold secrets — MCP env
+> tokens, telemetry state, log records, gaal config.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `Mode os.FileMode = 0o600` | Permission bits applied to all writes |
+| `Write(path string, data []byte) error` | Atomic write: temp file in same dir → fsync → rename → chmod 0o600 |
+| `OpenAppend(path string) (*os.File, error)` | Open for append-write with 0o600; tightens existing files via Chmod |
+
+## Why atomic?
+
+`os.WriteFile` truncates the destination first. A crash mid-write leaves
+a half-written file the next read will treat as authoritative — and for
+JSON / TOML configs, that means the agent stops working until the user
+investigates.
+
+PR #202 (#120) made `Write` atomic via the temp-file + `os.Rename`
+pattern that POSIX guarantees as atomic on the same filesystem:
+
+```mermaid
+flowchart LR
+    A[secfile.Write path, data] --> B[os.CreateTemp parent, base.gaal-tmp-*]
+    B --> C[Write data to tmp]
+    C --> D[Chmod tmp 0o600]
+    D --> E[Sync tmp → fsync to disk]
+    E --> F[Close tmp]
+    F --> G[os.Rename tmp → path]
+    G --> Z([success])
+
+    B -. err .-> FB[fallback: direct os.WriteFile path]
+    FB --> Z
+```
+
+The fallback to direct `WriteFile` happens only when the temp file
+cannot be created in the destination's parent (e.g. read-only or
+permission denied). This is logged via `slog.Warn` so the user can
+investigate, but the write still completes — old behaviour, just not
+atomic.
+
+## Why `0o600`?
+
+Configuration files written by gaal can contain:
+
+- MCP server `env` blocks holding API tokens.
+- Telemetry state (consent and machine ID).
+- Log records that may include URLs or paths the user considers
+  sensitive (PR for #114 redacts credentials, but path-leak is still
+  conceivable).
+
+Tightening to owner-read/write closes the surprise where a previously-
+created `0o644` config file stays world-readable forever even after
+gaal updates it. PR #115 wired in the `Chmod` step to tighten existing
+files on every write.
+
+## Consumers
+
+| Caller | Why |
+|--------|-----|
+| `internal/mcp/codec.go` | Atomic upsert of agent JSON / TOML config files |
+| `internal/engine/ops/init.go` | First-time write of `gaal.yaml` (also for `--force` backups) |
+| `internal/telemetry` | Append-write for the telemetry log + state file |
+| `internal/logger` | Log file (`--log-file`) |
+
+## Tests
+
+- Round-trip a write and read it back.
+- Chmod tightening verified by `Stat().Mode()` after a `0o644` rewrite.
+- Fallback path covered by setting the parent directory unwritable
+  before the call (Linux only).
+
+## Related
+
+- [`commands/sync.md`](../commands/sync.md) — every write the sync
+  performs goes through this package.

--- a/docs/packages/skill.md
+++ b/docs/packages/skill.md
@@ -1,0 +1,120 @@
+# `internal/skill`
+
+> Skill manager: resolve sources, discover `SKILL.md` files, filter by
+> `select:`, install atomically into the right agent directories.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `NewManager(skills []ConfigSkill, cacheDir, home, workDir, stateDir string, force bool) *Manager` | Construct |
+| `Manager.Sync(ctx) error` | Resolve + install every skill from every source |
+| `Manager.Prune(ctx) error` | Remove on-disk skills no longer declared |
+| `Manager.Status(ctx) []Status` | Per-source × per-agent status (`Installed`, `Missing`, `Modified`) |
+| `Manager.SourcePaths() []string` | Absolute local paths for every configured skill source (for FS-scan filtering) |
+
+## Source lifecycle
+
+```mermaid
+flowchart TD
+    A[Manager.Sync ctx] --> B[for each ConfigSkill]
+    B --> C[resolveSource]
+    C --> C1{local path?}
+    C1 -- yes --> C1a[expand ~/, return path]
+    C1 -- no --> C1b[urlToCacheKey → cacheDir/key]
+    C1b --> C1c{IsCloned?}
+    C1c -- no --> C1d[NewShallow git Clone depth=1]
+    C1c -- yes --> C1e[NewShallow git Update — hard-reset to origin HEAD]
+    C1a --> D[discoverSkills]
+    C1d --> D
+    C1e --> D
+    D --> E[filterSkills via select:]
+    E --> F[resolveAgents — `[*]` → detected installed]
+    F --> G[for each agent × skill: installSkill]
+    G --> H[mkdir staging .gaal-skill-tmp-*]
+    H --> I[walkDir src → copyFile staging]
+    I --> J[RemoveAll dst → Rename staging dst]
+    J --> K[writeSkillSnapshot dst]
+```
+
+## Atomic install (PR #204 / #121)
+
+`installSkill` stages the entire copy under a sibling temp directory
+then atomically swaps:
+
+```
+parent/
+├── target-skill/                      ← previous content (untouched)
+└── .gaal-skill-tmp-XXXXXXXX/          ← staging — the new content
+                                          (renamed → target-skill on success)
+```
+
+A crash mid-copy leaves either the previous skill intact or the new
+one fully installed — never a half-written tree the next sync would
+treat as up-to-date. Files removed upstream disappear because `dst`
+is replaced wholesale.
+
+## Frontmatter parsing (PR #197 / #133)
+
+`SKILL.md` files start with a YAML frontmatter block:
+
+```markdown
+---
+name: my-skill
+description: A short blurb.
+---
+
+# Body...
+```
+
+`scan.go` uses `yaml.Unmarshal` over a CRLF-tolerant frontmatter
+extractor — replaces the previous hand-rolled `strings.Cut(":")`
+parser that misbehaved on quoted values, multi-line strings, and
+escaped colons.
+
+## Name validation (PR #195 / #131)
+
+`isSafeSkillDirName` rejects:
+
+- Empty names, `.`, `..`
+- Names containing path separators (`/`, `\`)
+- Anything `filepath.Clean` rewrites (would imply traversal)
+
+Applied to both directory names and frontmatter `name:` fields so a
+malicious source cannot escape its install root.
+
+## File mode (PR #196 / #132)
+
+`copyFile` masks the source mode to `0o644` (or `0o755` if the source
+has the exec bit set). This drops setuid/setgid/sticky bits and group
+write permissions that a malicious archive might carry.
+
+## Local skill cache layout
+
+| OS | Cache root | Full path |
+|----|------------|-----------|
+| Linux | `$XDG_CACHE_HOME` or `~/.cache` | `~/.cache/gaal/skills/<key>/` |
+| macOS | `~/Library/Caches` | `~/Library/Caches/gaal/skills/<key>/` |
+| Windows | `%LocalAppData%` | `%LocalAppData%\gaal\skills\<key>\` |
+
+Sandbox-aware: in `--sandbox <dir>` mode, the entire cache lives under
+`<dir>`.
+
+## Installation scope
+
+| `global: false` (default) | `global: true` |
+|---------------------------|----------------|
+| `<workDir>/<agent.ProjectSkillsDir>/` | `<home>/<agent.GlobalSkillsDir>/` |
+| Versionable alongside the project | Shared across all projects |
+
+The agent path is resolved via `agent.SkillDir(name, global, home)` —
+see [`packages/core-agent.md`](core-agent.md). Some agents share a
+`generic` skills tree (`.agents/skills`) — the redirect happens
+transparently inside `SkillDir`.
+
+## Related
+
+- [`packages/core-vcs.md`](core-vcs.md) — backends used to clone / update sources
+- [`packages/core-agent.md`](core-agent.md) — agent registry and path expansion
+- [`packages/discover.md`](discover.md) — snapshot writer for drift detection
+- [`commands/sync.md`](../commands/sync.md#2--skillmanagersync-sequential-per-source) — high-level flow

--- a/docs/packages/telemetry.md
+++ b/docs/packages/telemetry.md
@@ -1,0 +1,87 @@
+# `internal/telemetry`
+
+> Anonymous usage telemetry. Consent-gated, append-only, batched on
+> shutdown.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `Init(cfg, promptFn, version, isInit) (*Telemetry, error)` | Reads consent state, prompts on first run, returns the active recorder |
+| `Track(event string)` | Record a named event (no payload) |
+| `TrackError(event string, err error)` | Record a typed error event; the error is normalised to a class — never the raw message — to prevent path / URL leakage (PR for #111) |
+| `TrackFirstSync(durationMillis int64)` | Specialised event for the first successful sync after `gaal init` |
+| `Custom(key, value string)` | Attach a free-form annotation to the current invocation |
+| `FlushConsent()` | Persist updated consent state (called by `PersistentPostRunE`) |
+| `Shutdown()` | Drain pending events to the on-disk log |
+
+## Consent model
+
+Telemetry is opt-in:
+
+| State | Behaviour |
+|-------|-----------|
+| `telemetry: true` (global or user config) | Every event recorded |
+| `telemetry: false` | Recorder is a no-op |
+| Unset on first run | TTY-aware prompt; non-TTY defaults to **off** |
+
+The `telemetry` key carries `gaal:"maxscope=user"`: a workspace
+`gaal.yaml` cannot silently re-enable telemetry if the user has opted
+out at the user / global level. See [`docs/config.md`](../config.md#scope-restriction-policy).
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[cmd.PersistentPreRunE] --> B[telemetry.Init cfg, promptFn, Version, isInit]
+    B --> C{state file exists?}
+    C -- yes --> D[load consent, machineID]
+    C -- no --> E[generate machineID, prompt if TTY]
+    D --> F[recorder]
+    E --> F
+    F --> G[command runs]
+    G --> H[telemetry.Track / TrackError calls]
+    H --> I[buffer in-memory]
+    G --> J[cmd.PersistentPostRunE]
+    J --> K[FlushConsent]
+    J --> L[Shutdown — drain to log]
+    L --> M[secfile.OpenAppend ~/.local/state/gaal/telemetry.jsonl]
+```
+
+## On-disk layout
+
+| File | Purpose | Permission |
+|------|---------|-----------|
+| `~/.local/state/gaal/telemetry.json` | Consent state + machine ID | 0o600 (`secfile.Write`) |
+| `~/.local/state/gaal/telemetry.jsonl` | Append-only event log | 0o600 (`secfile.OpenAppend`) |
+
+In `--sandbox` mode both paths resolve under the sandbox root.
+
+## Why never `err.Error()`?
+
+`TrackError` deliberately discards the error message and records only
+the **class** (e.g. `git.clone.auth_required`, `mcp.parse_error`). Raw
+error messages frequently include URLs, file paths, or token fragments
+that the user has not consented to sharing. PR for #111 made this the
+default behaviour everywhere.
+
+## Why post-run flush?
+
+`PersistentPostRunE` runs even when `RunE` returns an error wrapped in
+`cmd.ExitCodeError{Code, Cause}`. This gives consent persistence and
+event flush a guaranteed exit path — fixes #109 (where `os.Exit` in
+several commands skipped post-run hooks entirely).
+
+## Tests
+
+- Consent prompt behaviour (TTY vs. non-TTY)
+- maxscope policy enforcement
+- `TrackError` strips raw message, keeps class
+- Round-trip read / write of state
+
+## Related
+
+- [`packages/secfile.md`](secfile.md) — atomic writes for the state
+  and log files
+- [`docs/config.md`](../config.md#scope-restriction-policy) — scope
+  policy that protects the consent decision

--- a/docs/packages/tools.md
+++ b/docs/packages/tools.md
@@ -1,0 +1,63 @@
+# `internal/tools`
+
+> External-tool PATH probe. Sources declare which binaries they
+> require; `tools.Check` looks each one up so `gaal sync` can warn
+> early and `gaal doctor` can fail loud.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `Tool struct{ Name, Hint string }` | One required binary; `Hint` is the install suggestion shown to the user |
+| `Entry struct{ Tool Tool; Source string }` | Binary attributed back to the config source that needs it |
+| `Status struct{ Entry Entry; Found bool; Path string }` | One row in the probe result |
+| `Collect(cfg *config.Config) []Entry` | Walk the config and gather the deduplicated tool list |
+| `Check(entries []Entry) []Status` | `exec.LookPath` each tool, return statuses |
+
+## What declares a tool?
+
+| Source | Tools |
+|--------|-------|
+| `repositories` of type `hg` / `svn` / `bzr` | `hg` / `svn` (+ `svnversion`) / `bzr` |
+| `skills` with non-git VCS sources | the corresponding VCS binary |
+| MCP entries with `command:` fields | _not_ collected (those run as agent subprocesses, not gaal subprocesses) |
+
+The `tar` and `zip` types use the Go standard library — no external
+binary required.
+
+## Flow
+
+```mermaid
+flowchart LR
+    A[config.Config] --> B[tools.Collect cfg]
+    B --> C[walk repositories, skills]
+    C --> D[per type → required Tool plus Source attribution]
+    D --> E[dedup by Name]
+    E --> F[Entry slice]
+    F --> G[tools.Check entries]
+    G --> H[exec.LookPath per tool]
+    H --> I[Status slice with Found and Path]
+```
+
+## Consumers
+
+| Caller | Use |
+|--------|-----|
+| `cmd/sync.go::warnMissingTools` | One-line stderr banner before sync runs (never blocks) |
+| `cmd/doctor.go` (via `ops.RunDoctor.checkTools`) | Authoritative health check; missing-tool with no fallback → exit 2 |
+
+## Why never block sync?
+
+The probe is heuristic — a user might have installed a tool to a
+non-standard PATH that `gaal` is invoked with. Hard-failing sync at the
+probe stage would be a false positive that the per-entry failure (when
+the binary actually fails to run) would have caught anyway.
+
+`gaal doctor` is the authoritative health check: it runs the same
+probe but treats missing tools as actionable findings (exit 1
+warnings, exit 2 errors when no fallback exists).
+
+## Related
+
+- [`commands/doctor.md`](../commands/doctor.md) — full doctor flow
+- [`commands/sync.md`](../commands/sync.md#tooling-probe) — banner placement

--- a/docs/packages/urlx.md
+++ b/docs/packages/urlx.md
@@ -1,0 +1,86 @@
+# `internal/urlx`
+
+> URL validation and credential redaction. The single place that
+> decides whether a URL is allowed in either of the two threat models
+> (remote fetch vs. VCS clone), and the single place that strips
+> userinfo before logging.
+
+## Public API
+
+| Symbol | Description |
+|--------|-------------|
+| `ValidateRemoteFetchURL(rawurl string) error` | Allowed schemes for HTTP fetches: `https://` (any host), `http://` (loopback only). Used by `mcp` and `vcs.archive`. |
+| `ValidateRepoURL(rawurl string) error` | Allowed schemes for VCS clones: `https://`, `ssh://`, `git://`; `http://`, `svn://`, `bzr://` for loopback only; SCP-style git URLs (`user@host:path`); empty scheme = local path |
+| `Redact(rawurl string) string` | Strip `userinfo` from the URL so it is safe to log or surface in errors |
+
+## Threat model
+
+| Concern | Defence |
+|---------|---------|
+| `file://`, `gopher://`, `dict://`, `ftp://` reaching `http.DefaultClient` | Both validators reject |
+| SSRF to internal hosts (RFC1918, link-local, AWS IMDS at 169.254.169.254) | `http://` rejected unless loopback |
+| Credentials in URLs leaking into logs / telemetry | `Redact` strips `userinfo` |
+| Public-network `svn://` / `bzr://` (cleartext daemon protocols) | Allowed only for loopback (CI fixtures); widening requires explicit security review |
+
+## Flow
+
+```mermaid
+flowchart TD
+    subgraph ValidateRemoteFetchURL
+      A1[rawurl] --> A2[url.Parse]
+      A2 --> A3{scheme}
+      A3 -- https --> OK1([allow])
+      A3 -- http --> A4{loopback host?}
+      A4 -- yes --> OK1
+      A4 -- no --> ZH([reject http+nonloopback])
+      A3 -- "" --> ZE([reject missing scheme])
+      A3 -- other --> ZS([reject scheme])
+    end
+
+    subgraph ValidateRepoURL
+      B1[rawurl] --> B2{SCP-style git?}
+      B2 -- yes --> OK2([allow])
+      B2 -- no --> B3[url.Parse]
+      B3 --> B4{scheme}
+      B4 -- https/ssh/git --> OK2
+      B4 -- http/svn/bzr --> B5{loopback host?}
+      B5 -- yes --> OK2
+      B5 -- no --> ZL([reject])
+      B4 -- "" --> OK2
+      B4 -- other --> ZO([reject])
+    end
+```
+
+## Loopback detection (`isLoopbackHost`)
+
+Accepts: `localhost`, `127.0.0.0/8`, `::1`, bracketed IPv6 (`[::1]`),
+optional trailing `:port`. The check is **literal** — no DNS lookup —
+so it cannot race against the actual connection.
+
+## Redaction
+
+`Redact("https://user:secret@example.com/path?q=1#frag")` →
+`"https://example.com/path?q=1#frag"`.
+
+PR #114 routes every log line that mentions a URL through `Redact`.
+
+## Consumers
+
+| Caller | Validator used |
+|--------|---------------|
+| `internal/mcp/manager.go` (remote source) | `ValidateRemoteFetchURL` |
+| `internal/core/vcs/archive.go` (HTTP archive) | `ValidateRemoteFetchURL` |
+| `internal/core/vcs/git.go` (`Clone`) | `ValidateRepoURL` |
+| `internal/core/vcs/{hg,svn,bzr}.go` (`Clone`) | `ValidateRepoURL` |
+| Anywhere that logs a URL | `Redact` |
+
+## Tests
+
+`scheme_test.go` covers each rejection rule; `redact_test.go` exercises
+the userinfo strip cases (with/without password, IPv6, query/fragment
+preservation).
+
+## Related
+
+- [`packages/httpx.md`](httpx.md) — the HTTP client paired with these
+  validators.


### PR DESCRIPTION
## Summary
Adds two new doc subdirectories that mirror the runtime structure of gaal so a reader can navigate either by what they're trying to do (\`commands/\`) or by what they're trying to understand in the codebase (\`packages/\`).

### \`docs/commands/\` — one page per CLI verb
\`sync\`, \`status\`, \`info\`, \`init\`, \`audit\`, \`agents\`, \`doctor\`, \`migrate\`, \`schema\`, \`version\` plus an index README. Each page covers:
- usage + flags
- exit codes (incl. \`cmd.ExitCodeError\` semantics)
- end-to-end execution flow as a \`mermaid\` flowchart (same style as issue #152)
- side effects: every path the command reads or writes
- links to the relevant package docs

[\`commands/sync.md\`](https://github.com/getgaal/gaal/blob/docs/commands-and-packages/docs/commands/sync.md) is the deepest write-up — covers planner-vs-apply, parallel repo fan-out, the skill-cache layout per OS, atomic install / merge / extract, snapshot writes, prune gating, service-mode failure cap, cancellation, and the tooling probe.

### \`docs/packages/\` — one page per internal package
Includes the four support packages introduced by the recent reliability batch (\`httpx\`, \`secfile\`, \`telemetry\`, \`tools\`, \`urlx\`). Pages defer to the existing top-level pillar docs (\`config.md\`, \`core.md\`, \`discover.md\`) rather than duplicating them, and add:
- public-API tables
- dependency graphs
- recent-fix notes (PR / issue refs from the #109-#142 batch)
- runtime flow diagrams

### Drift fixed in the existing top-level docs
\`docs/architecture.md\`:
- Adds \`httpx\`, \`installscript\`, \`secfile\`, \`telemetry\`, \`tools\`, \`urlx\` to the package tree and points at the new subdirs.
- Drops the stale \`--yes\` flag from the migrate row (PR #185 / #141).
- Updates the repo-manager paragraph to reference the new package docs and #124 for the archive-update tracking.

## Pillars alignment
Reviewed the existing pillars and confirmed recent work doesn't add or change pillars:
- **Config**: 6 pillars (Config / Scope Policy / Schema / Validation / Platform / Template) intact.
- **Core**: 2 pillars (VCS / Agent Registry) intact.
- **Discover**: snapshot drift heuristic unchanged.

Recent PRs (#185-#207) are bug fixes / hardening within these pillars; package-level pages note them under \"Recent fixes worth knowing\".

## Test plan
- [x] All links resolve (\`grep\` audit)
- [x] \`go build ./...\` and \`go test ./...\` pass (no code changed; sanity check)
- [x] Manual render of the mermaid diagrams via GitHub Markdown preview