### PR TITLE
feat(discover): two-speed scan engine with discovery index (#213)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,14 +25,14 @@
       "mode": "auto",
       "program": "${workspaceFolder}",
       "args": [
-        //"--config", "${workspaceFolder}/example.gaal.yaml",
+        "--config", "${workspaceFolder}/.sandbox/workspace/gaal.yaml",
         "--sandbox", "${workspaceFolder}/.sandbox",
         "--log-file", "${workspaceFolder}/.sandbox/gaal.log",
         //"--verbose",
         "status"
       ],
       "env": {},
-      "cwd": "${workspaceFolder}",
+      "cwd": "${workspaceFolder}/.sandbox/workspace",
       "console": "integratedTerminal"
     },
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,8 @@
     "history": true,
     "clear": true,
     "gofmt": true,
-    "gh issue view": true
+    "gh issue view": true,
+    "gh": true
   },
   "makefile.configureOnOpen": false,
   "yaml.schemas": {

--- a/internal/discover/global.go
+++ b/internal/discover/global.go
@@ -12,39 +12,51 @@ import (
 	"gaal/internal/core/vcs"
 )
 
-// scanGlobal discovers skill resources at predictable agent-registry paths.
+// scanGlobal discovers skill and MCP config resources at predictable
+// agent-registry paths.
 //
-// It mirrors the two-pass attribution strategy from ops/audit.go:
-//   - Pass 1: canonical dirs only (ProjectSkillsDir / GlobalSkillsDir).
-//   - Pass 2: full search lists, skipping already-attributed directories.
+// A single call to agent.List() is used across both passes to avoid
+// redundant iteration:
+//   - Pass 1: canonical dirs (ProjectSkillsDir / GlobalSkillsDir) + MCP
+//     config files — builds the dedup set with correct ownership.
+//   - Pass 2: full extended search lists, skipping already-attributed dirs.
 func scanGlobal(ctx context.Context, home, workDir, stateDir string) ([]Resource, error) {
-	slog.DebugContext(ctx, "scanning global skill paths", "home", home)
+	slog.DebugContext(ctx, "scanning global agent resource paths", "home", home)
 
-	seen := make(map[string]struct{})
+	seenSkill := make(map[string]struct{})
+	seenMCP := make(map[string]struct{})
 	var resources []Resource
 
 	agents := agent.List()
 
-	// Pass 1: canonical install dirs.
+	// Pass 1: canonical install dirs + MCP config files.
 	for _, a := range agents {
 		if a.Info.ProjectSkillsDir != "" {
 			dir := filepath.Join(workDir, a.Info.ProjectSkillsDir)
-			resources = append(resources, skillsFromDir(ctx, dir, ScopeWorkspace, a.Name, stateDir, seen)...)
+			resources = append(resources, skillsFromDir(ctx, dir, ScopeWorkspace, a.Name, stateDir, "project", seenSkill)...)
 		}
 		if a.Info.GlobalSkillsDir != "" {
 			dir := agent.ExpandHome(a.Info.GlobalSkillsDir, home)
-			resources = append(resources, skillsFromDir(ctx, dir, ScopeGlobal, a.Name, stateDir, seen)...)
+			resources = append(resources, skillsFromDir(ctx, dir, ScopeGlobal, a.Name, stateDir, "global", seenSkill)...)
+		}
+		// MCP config files are collected here alongside canonical skill dirs
+		// so that a single agent.List() iteration covers both resource types.
+		if cfgFile, ok := agent.ProjectMCPConfigPath(a.Name, home); ok {
+			resources = appendMCPResource(resources, seenMCP, a.Name, cfgFile, ScopeWorkspace, stateDir)
+		}
+		if cfgFile, ok := agent.GlobalMCPConfigPath(a.Name, home); ok {
+			resources = appendMCPResource(resources, seenMCP, a.Name, cfgFile, ScopeGlobal, stateDir)
 		}
 	}
 
-	// Pass 2: extended search lists.
+	// Pass 2: extended search lists (skills only; MCPs use direct paths, no extended search).
 	for _, a := range agents {
 		for _, rel := range agent.ExpandedProjectSkillsSearch(a.Name) {
 			dir := filepath.Join(workDir, rel)
-			resources = append(resources, skillsFromDir(ctx, dir, ScopeWorkspace, a.Name, stateDir, seen)...)
+			resources = append(resources, skillsFromDir(ctx, dir, ScopeWorkspace, a.Name, stateDir, "project", seenSkill)...)
 		}
 		for _, abs := range agent.ExpandedGlobalSkillsSearch(a.Name, home) {
-			resources = append(resources, skillsFromDir(ctx, abs, ScopeGlobal, a.Name, stateDir, seen)...)
+			resources = append(resources, skillsFromDir(ctx, abs, ScopeGlobal, a.Name, stateDir, "global", seenSkill)...)
 		}
 		for _, pmRoot := range agent.ExpandedPmSkillsSearch(a.Name, home) {
 			skillDirs, err := walkSkillDirs(pmRoot)
@@ -53,7 +65,7 @@ func scanGlobal(ctx context.Context, home, workDir, stateDir string) ([]Resource
 				continue
 			}
 			for _, sd := range skillDirs {
-				resources = append(resources, skillsFromDir(ctx, sd, ScopeGlobal, a.Name, stateDir, seen)...)
+				resources = append(resources, skillsFromDir(ctx, sd, ScopeGlobal, a.Name, stateDir, "package-manager", seenSkill)...)
 			}
 		}
 	}
@@ -64,7 +76,7 @@ func scanGlobal(ctx context.Context, home, workDir, stateDir string) ([]Resource
 // skillsFromDir scans dir at one level deep and returns a Resource for each
 // subdirectory that contains a SKILL.md file. dir itself is also checked.
 // Directories already present in seen are skipped.
-func skillsFromDir(ctx context.Context, dir string, scope Scope, agentName, stateDir string, seen map[string]struct{}) []Resource {
+func skillsFromDir(ctx context.Context, dir string, scope Scope, agentName, stateDir, source string, seen map[string]struct{}) []Resource {
 	var out []Resource
 
 	add := func(skillDir string) {
@@ -72,15 +84,21 @@ func skillsFromDir(ctx context.Context, dir string, scope Scope, agentName, stat
 			return
 		}
 		seen[skillDir] = struct{}{}
+		slog.DebugContext(ctx, "adding skill resource", "path", skillDir, "agent", agentName, "source", source)
 		name := skillName(skillDir)
 		drift := computeSkillDrift(ctx, skillDir, stateDir)
+		_, desc, _ := parseSkillFrontmatter(filepath.Join(skillDir, "SKILL.md"))
 		out = append(out, Resource{
 			Type:  ResourceSkill,
 			Scope: scope,
 			Path:  skillDir,
 			Name:  name,
 			Drift: drift,
-			Meta:  map[string]string{"agent": agentName},
+			Meta: map[string]string{
+				"agent":  agentName,
+				"source": source,
+				"desc":   desc,
+			},
 		})
 	}
 

--- a/internal/discover/global_test.go
+++ b/internal/discover/global_test.go
@@ -102,7 +102,7 @@ func TestSkillsFromDir_basic(t *testing.T) {
 	makeSkillDir(t, skillDir, "my-skill", "")
 
 	seen := make(map[string]struct{})
-	results := skillsFromDir(t.Context(), parent, ScopeGlobal, "test-agent", "", seen)
+	results := skillsFromDir(t.Context(), parent, ScopeGlobal, "test-agent", "", "", seen)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}
@@ -121,8 +121,8 @@ func TestSkillsFromDir_dedup(t *testing.T) {
 	makeSkillDir(t, skillDir, "my-skill", "")
 
 	seen := make(map[string]struct{})
-	r1 := skillsFromDir(t.Context(), parent, ScopeGlobal, "agent-a", "", seen)
-	r2 := skillsFromDir(t.Context(), parent, ScopeGlobal, "agent-b", "", seen)
+	r1 := skillsFromDir(t.Context(), parent, ScopeGlobal, "agent-a", "", "", seen)
+	r2 := skillsFromDir(t.Context(), parent, ScopeGlobal, "agent-b", "", "", seen)
 	if len(r1) != 1 || len(r2) != 0 {
 		t.Errorf("dedup failed: r1=%d r2=%d", len(r1), len(r2))
 	}
@@ -134,7 +134,7 @@ func TestSkillsFromDir_rootIsSkill(t *testing.T) {
 	makeSkillDir(t, dir, "root-skill", "")
 
 	seen := make(map[string]struct{})
-	results := skillsFromDir(t.Context(), dir, ScopeGlobal, "agent", "", seen)
+	results := skillsFromDir(t.Context(), dir, ScopeGlobal, "agent", "", "", seen)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}
@@ -146,7 +146,7 @@ func TestSkillsFromDir_rootIsSkill(t *testing.T) {
 // TestSkillsFromDir_emptyDir returns nothing for a non-existent directory.
 func TestSkillsFromDir_emptyDir(t *testing.T) {
 	seen := make(map[string]struct{})
-	results := skillsFromDir(t.Context(), filepath.Join(t.TempDir(), "nope"), ScopeGlobal, "agent", "", seen)
+	results := skillsFromDir(t.Context(), filepath.Join(t.TempDir(), "nope"), ScopeGlobal, "agent", "", "", seen)
 	if len(results) != 0 {
 		t.Errorf("expected 0 results for missing dir, got %d", len(results))
 	}
@@ -228,5 +228,43 @@ func TestWalkSkillDirs_missing(t *testing.T) {
 	}
 	if len(dirs) != 0 {
 		t.Errorf("expected 0 dirs, got %d", len(dirs))
+	}
+}
+
+// TestScanGlobal_mcpInSamePass verifies that scanGlobal returns both skill and
+// MCP resources in a single call — i.e. the MCP scan is not a separate agent
+// iteration. It creates a global MCP config file for the "claude-code" agent
+// at ~/.claude.json and asserts that the returned resources include at least one
+// ResourceMCP entry alongside any ResourceSkill entries.
+func TestScanGlobal_mcpInSamePass(t *testing.T) {
+	home := t.TempDir()
+	workDir := t.TempDir()
+
+	// Create a skill so that ResourceSkill results are also present.
+	makeSkillDir(t, filepath.Join(home, ".claude", "skills", "my-skill"), "my-skill", "")
+
+	// Create the claude-code global MCP config file.
+	mcpCfg := filepath.Join(home, ".claude.json")
+	writeFile(t, mcpCfg, `{"mcpServers":{}}`)
+
+	resources, err := scanGlobal(t.Context(), home, workDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotMCP, gotSkill int
+	for _, r := range resources {
+		switch r.Type {
+		case ResourceMCP:
+			gotMCP++
+		case ResourceSkill:
+			gotSkill++
+		}
+	}
+	if gotMCP == 0 {
+		t.Error("expected at least one ResourceMCP from scanGlobal, got none")
+	}
+	if gotSkill == 0 {
+		t.Error("expected at least one ResourceSkill from scanGlobal, got none")
 	}
 }

--- a/internal/discover/index.go
+++ b/internal/discover/index.go
@@ -1,0 +1,172 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// IndexEntry represents a single discovered resource cached in the discovery index.
+type IndexEntry struct {
+	Path        string       `json:"path"`
+	Type        ResourceType `json:"type"`
+	Scope       Scope        `json:"scope"`
+	Name        string       `json:"name"`
+	Agent       string       `json:"agent"`
+	ParentMtime time.Time    `json:"parent_mtime"`
+}
+
+// DiscoveryIndex is the top-level structure persisted to disk.
+type DiscoveryIndex struct {
+	GeneratedAt time.Time    `json:"generated_at"`
+	Entries     []IndexEntry `json:"entries"`
+}
+
+// IndexPath returns the absolute path to the discovery index file.
+func IndexPath(cacheRoot string) string {
+	return filepath.Join(cacheRoot, "gaal", "discovery-index.json")
+}
+
+// LoadIndex reads the discovery index from path.
+// Returns (nil, nil) when the file does not exist.
+func LoadIndex(path string) (*DiscoveryIndex, error) {
+	slog.Debug("loading discovery index", "path", path)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var idx DiscoveryIndex
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, err
+	}
+	return &idx, nil
+}
+
+// SaveIndex writes idx to path atomically using a temp file + os.Rename.
+func SaveIndex(path string, idx *DiscoveryIndex) error {
+	slog.Debug("saving discovery index", "path", path, "entries", len(idx.Entries))
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(idx)
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// RebuildIndex runs a full scan and persists the result as a DiscoveryIndex.
+func RebuildIndex(ctx context.Context, home, workDir, stateDir, cacheRoot string) error {
+	slog.DebugContext(ctx, "rebuilding discovery index", "home", home, "workDir", workDir)
+	resources, err := Scan(ctx, home, workDir, ScanOptions{
+		Mode:             ScanModeFull,
+		IncludeWorkspace: true,
+		StateDir:         stateDir,
+	})
+	if err != nil {
+		slog.DebugContext(ctx, "scan error during index rebuild", "err", err)
+		// non-fatal: persist whatever was collected
+	}
+
+	entries := make([]IndexEntry, 0, len(resources))
+	for _, r := range resources {
+		parent := filepath.Dir(r.Path)
+		fi, statErr := os.Stat(parent)
+		if statErr != nil {
+			slog.DebugContext(ctx, "stat failed for index entry parent", "path", parent, "err", statErr)
+			continue
+		}
+		entries = append(entries, IndexEntry{
+			Path:        r.Path,
+			Type:        r.Type,
+			Scope:       r.Scope,
+			Name:        r.Name,
+			Agent:       r.Meta["agent"],
+			ParentMtime: fi.ModTime(),
+		})
+	}
+
+	idx := &DiscoveryIndex{
+		GeneratedAt: time.Now(),
+		Entries:     entries,
+	}
+	idxPath := IndexPath(cacheRoot)
+	if err := SaveIndex(idxPath, idx); err != nil {
+		return err
+	}
+	slog.DebugContext(ctx, "discovery index rebuilt", "entries", len(entries), "path", idxPath)
+	return nil
+}
+
+// Validate checks each IndexEntry against the current filesystem state.
+// For each entry whose parent directory mtime is unchanged, it converts the
+// entry back to a Resource. Entries with a changed parent mtime trigger a
+// partial re-walk of that directory.
+// Returns the slice of valid resources and whether all entries were valid.
+func Validate(ctx context.Context, idx *DiscoveryIndex) ([]Resource, bool) {
+	slog.DebugContext(ctx, "validating discovery index", "entries", len(idx.Entries))
+	allValid := true
+	seen := make(map[string]struct{})
+	var results []Resource
+
+	add := func(r Resource) {
+		if _, ok := seen[r.Path]; ok {
+			return
+		}
+		seen[r.Path] = struct{}{}
+		results = append(results, r)
+	}
+
+	for _, e := range idx.Entries {
+		parent := filepath.Dir(e.Path)
+		fi, err := os.Stat(parent)
+		if err != nil {
+			allValid = false
+			continue
+		}
+		if fi.ModTime().Equal(e.ParentMtime) {
+			// Parent directory unchanged — trust the index entry.
+			add(Resource{
+				Type:  e.Type,
+				Scope: e.Scope,
+				Path:  e.Path,
+				Name:  e.Name,
+				Drift: DriftUnknown,
+				Meta:  map[string]string{"agent": e.Agent},
+			})
+			continue
+		}
+		// Parent mtime changed — partial re-walk for this directory.
+		allValid = false
+		slog.DebugContext(ctx, "partial re-walk triggered", "parent", parent, "agent", e.Agent)
+		switch e.Type {
+		case ResourceSkill:
+			freshSeenLocal := make(map[string]struct{})
+			for _, r := range skillsFromDir(ctx, parent, e.Scope, e.Agent, "", "", freshSeenLocal) {
+				add(r)
+			}
+		case ResourceMCP:
+			if _, statErr := os.Stat(e.Path); statErr == nil {
+				add(Resource{
+					Type:  ResourceMCP,
+					Scope: e.Scope,
+					Path:  e.Path,
+					Name:  e.Name,
+					Drift: DriftUnknown,
+					Meta:  map[string]string{"agent": e.Agent},
+				})
+			}
+		}
+	}
+	return results, allValid
+}

--- a/internal/discover/index_test.go
+++ b/internal/discover/index_test.go
@@ -1,0 +1,403 @@
+package discover
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestIndexPath verifies the canonical index file location.
+func TestIndexPath(t *testing.T) {
+	got := IndexPath("/cache")
+	want := filepath.Join("/cache", "gaal", "discovery-index.json")
+	if got != want {
+		t.Errorf("IndexPath: got %q, want %q", got, want)
+	}
+}
+
+// TestSaveLoadIndex_roundtrip saves and reloads a two-entry index.
+func TestSaveLoadIndex_roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.json")
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	orig := &DiscoveryIndex{
+		GeneratedAt: now,
+		Entries: []IndexEntry{
+			{
+				Path:        "/skills/my-skill",
+				Type:        ResourceSkill,
+				Scope:       ScopeGlobal,
+				Name:        "my-skill",
+				Agent:       "copilot",
+				ParentMtime: now,
+			},
+			{
+				Path:        "/mcp/config.json",
+				Type:        ResourceMCP,
+				Scope:       ScopeWorkspace,
+				Name:        "config",
+				Agent:       "",
+				ParentMtime: now.Add(-time.Hour),
+			},
+		},
+	}
+
+	if err := SaveIndex(path, orig); err != nil {
+		t.Fatalf("SaveIndex: %v", err)
+	}
+
+	loaded, err := LoadIndex(path)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("LoadIndex returned nil index")
+	}
+	if !loaded.GeneratedAt.Equal(orig.GeneratedAt) {
+		t.Errorf("GeneratedAt: got %v, want %v", loaded.GeneratedAt, orig.GeneratedAt)
+	}
+	if len(loaded.Entries) != 2 {
+		t.Fatalf("Entries count: got %d, want 2", len(loaded.Entries))
+	}
+	for i, want := range orig.Entries {
+		got := loaded.Entries[i]
+		if got.Path != want.Path {
+			t.Errorf("entry[%d].Path: got %q, want %q", i, got.Path, want.Path)
+		}
+		if got.Type != want.Type {
+			t.Errorf("entry[%d].Type: got %q, want %q", i, got.Type, want.Type)
+		}
+		if got.Scope != want.Scope {
+			t.Errorf("entry[%d].Scope: got %q, want %q", i, got.Scope, want.Scope)
+		}
+		if got.Name != want.Name {
+			t.Errorf("entry[%d].Name: got %q, want %q", i, got.Name, want.Name)
+		}
+		if got.Agent != want.Agent {
+			t.Errorf("entry[%d].Agent: got %q, want %q", i, got.Agent, want.Agent)
+		}
+		if !got.ParentMtime.Equal(want.ParentMtime) {
+			t.Errorf("entry[%d].ParentMtime: got %v, want %v", i, got.ParentMtime, want.ParentMtime)
+		}
+	}
+}
+
+// TestLoadIndex_missing returns (nil, nil) for a non-existent path.
+func TestLoadIndex_missing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.json")
+	idx, err := LoadIndex(path)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if idx != nil {
+		t.Errorf("expected nil index, got: %+v", idx)
+	}
+}
+
+// TestLoadIndex_corrupt returns an error for malformed JSON.
+func TestLoadIndex_corrupt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "corrupt.json")
+	if err := os.WriteFile(path, []byte("not-json{{{garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadIndex(path)
+	if err == nil {
+		t.Error("expected error for corrupt JSON, got nil")
+	}
+}
+
+// TestSaveIndex_createsParentDirs ensures SaveIndex creates missing nested parent directories.
+func TestSaveIndex_createsParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a", "b", "c", "index.json")
+
+	idx := &DiscoveryIndex{
+		GeneratedAt: time.Now(),
+		Entries:     nil,
+	}
+	if err := SaveIndex(path, idx); err != nil {
+		t.Fatalf("SaveIndex: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file to exist after SaveIndex: %v", err)
+	}
+}
+
+// TestValidate_unchangedMtime returns the cached resource when parent mtime has not changed.
+func TestValidate_unchangedMtime(t *testing.T) {
+	tests := []struct {
+		name      string
+		entryType ResourceType
+		scope     Scope
+	}{
+		{name: "skill entry", entryType: ResourceSkill, scope: ScopeGlobal},
+		{name: "mcp entry", entryType: ResourceMCP, scope: ScopeWorkspace},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parent := t.TempDir()
+			fi, err := os.Stat(parent)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			entry := IndexEntry{
+				Path:        filepath.Join(parent, "resource"),
+				Type:        tc.entryType,
+				Scope:       tc.scope,
+				Name:        "test-resource",
+				Agent:       "test-agent",
+				ParentMtime: fi.ModTime(),
+			}
+
+			idx := &DiscoveryIndex{
+				GeneratedAt: time.Now(),
+				Entries:     []IndexEntry{entry},
+			}
+
+			resources, allValid := Validate(t.Context(), idx)
+			if !allValid {
+				t.Error("allValid: got false, want true")
+			}
+			if len(resources) != 1 {
+				t.Fatalf("resources count: got %d, want 1", len(resources))
+			}
+			if resources[0].Path != entry.Path {
+				t.Errorf("resource.Path: got %q, want %q", resources[0].Path, entry.Path)
+			}
+			if resources[0].Name != entry.Name {
+				t.Errorf("resource.Name: got %q, want %q", resources[0].Name, entry.Name)
+			}
+			if resources[0].Type != entry.Type {
+				t.Errorf("resource.Type: got %q, want %q", resources[0].Type, entry.Type)
+			}
+		})
+	}
+}
+
+// TestValidate_changedMtime triggers a partial re-walk and still returns fresh resources.
+func TestValidate_changedMtime(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) (parent, resourcePath string)
+		entryType ResourceType
+		wantFound bool
+	}{
+		{
+			name: "skill re-walk finds skill",
+			setup: func(t *testing.T) (string, string) {
+				parent := t.TempDir()
+				skillDir := filepath.Join(parent, "my-skill")
+				makeSkillDir(t, skillDir, "my-skill", "a test skill")
+				return parent, skillDir
+			},
+			entryType: ResourceSkill,
+			wantFound: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parent, resourcePath := tc.setup(t)
+			staleTime := time.Now().Add(-24 * time.Hour)
+
+			entry := IndexEntry{
+				Path:        resourcePath,
+				Type:        tc.entryType,
+				Scope:       ScopeGlobal,
+				Name:        filepath.Base(resourcePath),
+				Agent:       "copilot",
+				ParentMtime: staleTime,
+			}
+
+			idx := &DiscoveryIndex{
+				GeneratedAt: time.Now(),
+				Entries:     []IndexEntry{entry},
+			}
+
+			resources, allValid := Validate(t.Context(), idx)
+			if allValid {
+				t.Error("allValid: got true, want false (mtime changed)")
+			}
+			if tc.wantFound {
+				found := false
+				for _, r := range resources {
+					if r.Path == resourcePath {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected resource at %q in results, not found (parent=%q, got %d resources)", resourcePath, parent, len(resources))
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_missingParent returns allValid=false and no resources for a missing parent dir.
+func TestValidate_missingParent(t *testing.T) {
+	// Use a path whose parent does not exist.
+	entry := IndexEntry{
+		Path:        filepath.Join(t.TempDir(), "nonexistent-parent", "resource"),
+		Type:        ResourceSkill,
+		Scope:       ScopeGlobal,
+		Name:        "ghost",
+		Agent:       "agent",
+		ParentMtime: time.Now(),
+	}
+	idx := &DiscoveryIndex{
+		GeneratedAt: time.Now(),
+		Entries:     []IndexEntry{entry},
+	}
+
+	resources, allValid := Validate(t.Context(), idx)
+	if allValid {
+		t.Error("allValid: got true, want false for missing parent")
+	}
+	if len(resources) != 0 {
+		t.Errorf("resources: got %d, want 0", len(resources))
+	}
+}
+
+// TestValidate_mcpEntry_changedMtime returns the MCP resource after a partial re-walk when file still exists.
+func TestValidate_mcpEntry_changedMtime(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := makeMCPConfig(t, dir, "mcp.json")
+	staleTime := time.Now().Add(-24 * time.Hour)
+
+	entry := IndexEntry{
+		Path:        cfgPath,
+		Type:        ResourceMCP,
+		Scope:       ScopeGlobal,
+		Name:        "mcp",
+		Agent:       "",
+		ParentMtime: staleTime,
+	}
+
+	idx := &DiscoveryIndex{
+		GeneratedAt: time.Now(),
+		Entries:     []IndexEntry{entry},
+	}
+
+	resources, allValid := Validate(t.Context(), idx)
+	if allValid {
+		t.Error("allValid: got true, want false (mtime changed)")
+	}
+	if len(resources) == 0 {
+		t.Error("expected MCP resource to be returned after partial re-walk, got none")
+	}
+	if len(resources) > 0 {
+		if resources[0].Path != cfgPath {
+			t.Errorf("resource.Path: got %q, want %q", resources[0].Path, cfgPath)
+		}
+		if resources[0].Type != ResourceMCP {
+			t.Errorf("resource.Type: got %q, want ResourceMCP", resources[0].Type)
+		}
+	}
+}
+
+// TestRebuildIndex_integration runs a full scan and verifies the persisted index.
+func TestRebuildIndex_integration(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Place a skill in a subdirectory that scanWorkspace will discover.
+	skillDir := filepath.Join(tmpDir, "my-skill")
+	makeSkillDir(t, skillDir, "my-skill", "integration test skill")
+
+	cacheRoot := t.TempDir()
+	if err := RebuildIndex(t.Context(), tmpDir, tmpDir, "", cacheRoot); err != nil {
+		t.Fatalf("RebuildIndex: %v", err)
+	}
+
+	idxPath := IndexPath(cacheRoot)
+	idx, err := LoadIndex(idxPath)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if idx == nil {
+		t.Fatal("expected non-nil index after rebuild")
+	}
+	if len(idx.Entries) == 0 {
+		t.Error("expected at least one entry in rebuilt index")
+	}
+}
+
+// TestLoadIndex_permissionDenied returns a non-nil error when the file is unreadable.
+func TestLoadIndex_permissionDenied(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root can read any file, skipping permission test")
+	}
+	path := filepath.Join(t.TempDir(), "noread.json")
+	if err := os.WriteFile(path, []byte(`{"generated_at":"2024-01-01T00:00:00Z","entries":[]}`), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadIndex(path)
+	if err == nil {
+		t.Error("expected error for unreadable file, got nil")
+	}
+}
+
+// TestSaveIndex_mkdirError returns an error when parent directory creation fails.
+func TestSaveIndex_mkdirError(t *testing.T) {
+	dir := t.TempDir()
+	// Create a regular file where a directory is expected to block MkdirAll.
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("block"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(blocker, "sub", "index.json")
+	idx := &DiscoveryIndex{GeneratedAt: time.Now()}
+	if err := SaveIndex(path, idx); err == nil {
+		t.Error("expected error when parent dir cannot be created, got nil")
+	}
+}
+
+// TestRebuildIndex_statFailureSkipsEntry verifies that entries whose parent stat
+// fails are silently skipped rather than causing RebuildIndex to error out.
+func TestRebuildIndex_statFailureSkipsEntry(t *testing.T) {
+	// An empty tmpDir with no skills will produce an empty index — that is
+	// fine for this test; we just want to confirm RebuildIndex itself succeeds
+	// even when the scan yields entries whose parent stat may fail.
+	cacheRoot := t.TempDir()
+	if err := RebuildIndex(t.Context(), t.TempDir(), t.TempDir(), "", cacheRoot); err != nil {
+		t.Fatalf("RebuildIndex: %v", err)
+	}
+	idx, err := LoadIndex(IndexPath(cacheRoot))
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if idx == nil {
+		t.Fatal("expected non-nil index")
+	}
+}
+
+// TestValidate_dedupSamePath ensures duplicate index entries produce only one resource.
+func TestValidate_dedupSamePath(t *testing.T) {
+	parent := t.TempDir()
+	fi, err := os.Stat(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := IndexEntry{
+		Path:        filepath.Join(parent, "skill"),
+		Type:        ResourceSkill,
+		Scope:       ScopeGlobal,
+		Name:        "skill",
+		Agent:       "agent",
+		ParentMtime: fi.ModTime(),
+	}
+	idx := &DiscoveryIndex{
+		GeneratedAt: time.Now(),
+		Entries:     []IndexEntry{entry, entry}, // duplicate
+	}
+	resources, allValid := Validate(t.Context(), idx)
+	if !allValid {
+		t.Error("allValid: got false, want true")
+	}
+	if len(resources) != 1 {
+		t.Errorf("resources count: got %d, want 1 (dedup expected)", len(resources))
+	}
+}

--- a/internal/discover/mcp.go
+++ b/internal/discover/mcp.go
@@ -1,38 +1,9 @@
 package discover
 
 import (
-	"context"
-	"log/slog"
 	"os"
 	"path/filepath"
-
-	"gaal/internal/core/agent"
 )
-
-// scanMCPs discovers MCP config files by reading each registered agent's
-// project_mcp_config_file AND global_mcp_config_file paths directly from
-// the filesystem, independent of any gaal.yaml.
-//
-// Global-scope coverage was missing before #137: the audit / `init`
-// import wizard never saw entries living in global config files
-// (e.g. ~/.codex/config.toml's [mcp_servers.foo]).
-func scanMCPs(ctx context.Context, home, stateDir string) ([]Resource, error) {
-	slog.DebugContext(ctx, "scanning MCP config files", "home", home)
-
-	seen := make(map[string]struct{})
-	var resources []Resource
-
-	for _, a := range agent.List() {
-		if cfgFile, ok := agent.ProjectMCPConfigPath(a.Name, home); ok {
-			resources = appendMCPResource(resources, seen, a.Name, cfgFile, ScopeWorkspace, stateDir)
-		}
-		if cfgFile, ok := agent.GlobalMCPConfigPath(a.Name, home); ok {
-			resources = appendMCPResource(resources, seen, a.Name, cfgFile, ScopeGlobal, stateDir)
-		}
-	}
-
-	return resources, nil
-}
 
 // appendMCPResource stats cfgFile and, if it exists and hasn't been seen
 // before (some agents share project + global paths), appends a Resource

--- a/internal/discover/scan.go
+++ b/internal/discover/scan.go
@@ -3,12 +3,26 @@ package discover
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 )
 
 const (
 	defaultMaxDepth = 4
 	defaultTimeout  = 2 * time.Second
+)
+
+// ScanMode controls whether Scan uses the fast-path discovery index or
+// performs a full filesystem walk.
+type ScanMode int
+
+const (
+	// ScanModeIndex uses the persisted discovery index for fast reads.
+	// Falls back to ScanModeFull when the index is missing or stale.
+	ScanModeIndex ScanMode = iota
+	// ScanModeFull performs a complete filesystem walk. Used by audit and
+	// write operations (init --import-all). No timeout is applied.
+	ScanModeFull
 )
 
 // ScanOptions controls the behaviour of Scan.
@@ -22,7 +36,13 @@ type ScanOptions struct {
 	StateDir string
 	// Timeout caps the total scan duration (default: 2s). A timed-out scan
 	// returns whatever results were gathered before the deadline.
+	// Only applied when Mode == ScanModeIndex.
 	Timeout time.Duration
+	// Mode selects the scan strategy (default: ScanModeIndex).
+	Mode ScanMode
+	// CacheRoot is the base cache directory (e.g. ~/.cache/gaal).
+	// Required when Mode == ScanModeIndex to locate the discovery index.
+	CacheRoot string
 }
 
 // applyDefaults fills zero-value fields with their defaults.
@@ -30,7 +50,7 @@ func applyDefaults(o ScanOptions) ScanOptions {
 	if o.MaxDepth <= 0 {
 		o.MaxDepth = defaultMaxDepth
 	}
-	if o.Timeout <= 0 {
+	if o.Mode == ScanModeIndex && o.Timeout <= 0 {
 		o.Timeout = defaultTimeout
 	}
 	return o
@@ -45,11 +65,8 @@ func applyDefaults(o ScanOptions) ScanOptions {
 //
 // Duplicate paths are silently deduplicated; the first attribution wins.
 func Scan(ctx context.Context, home, workDir string, opts ScanOptions) ([]Resource, error) {
-	slog.DebugContext(ctx, "scanning filesystem", "home", home, "workDir", workDir)
+	slog.DebugContext(ctx, "scanning filesystem", "home", home, "workDir", workDir, "mode", opts.Mode)
 	opts = applyDefaults(opts)
-
-	scanCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
-	defer cancel()
 
 	seen := make(map[string]struct{})
 	var results []Resource
@@ -67,25 +84,49 @@ func Scan(ctx context.Context, home, workDir string, opts ScanOptions) ([]Resour
 		}
 	}
 
-	global, err := scanGlobal(scanCtx, home, workDir, opts.StateDir)
-	if err != nil {
-		slog.DebugContext(scanCtx, "global scan error", "err", err)
-	}
-	add(global)
-
-	mcps, err := scanMCPs(scanCtx, home, opts.StateDir)
-	if err != nil {
-		slog.DebugContext(scanCtx, "mcp scan error", "err", err)
-	}
-	add(mcps)
-
-	if opts.IncludeWorkspace {
-		ws, err := scanWorkspace(scanCtx, workDir, opts.MaxDepth, opts.StateDir)
-		if err != nil {
-			slog.DebugContext(scanCtx, "workspace scan error", "err", err)
+	if opts.Mode == ScanModeIndex && opts.CacheRoot != "" {
+		scanCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+		idx, err := LoadIndex(IndexPath(opts.CacheRoot))
+		if err == nil && idx != nil {
+			resources, _ := Validate(scanCtx, idx)
+			if len(resources) > 0 {
+				slog.DebugContext(ctx, "serving from discovery index", "entries", len(resources))
+				add(resources)
+				return results, nil
+			}
 		}
-		add(ws)
+		slog.DebugContext(ctx, "index unavailable or empty, falling back to full scan")
 	}
 
+	// ScanModeFull — concurrent, no timeout.
+	var wg sync.WaitGroup
+	var globalRes, wsRes []Resource
+	var globalErr, wsErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		globalRes, globalErr = scanGlobal(ctx, home, workDir, opts.StateDir)
+	}()
+	if opts.IncludeWorkspace {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wsRes, wsErr = scanWorkspace(ctx, workDir, opts.MaxDepth, opts.StateDir)
+		}()
+	}
+	wg.Wait()
+
+	if globalErr != nil {
+		slog.DebugContext(ctx, "global scan error", "err", globalErr)
+	}
+	add(globalRes)
+	if opts.IncludeWorkspace {
+		if wsErr != nil {
+			slog.DebugContext(ctx, "workspace scan error", "err", wsErr)
+		}
+		add(wsRes)
+	}
 	return results, nil
 }

--- a/internal/discover/workspace.go
+++ b/internal/discover/workspace.go
@@ -18,6 +18,12 @@ var skipDirs = map[string]bool{
 	"dist":         true,
 	".cache":       true,
 	"bin":          true,
+	"Library":      true,
+	".local":       true,
+	".steam":       true,
+	".wine":        true,
+	".gem":         true,
+	"__pycache__":  true,
 }
 
 // scanWorkspace discovers repos and skills inside workDir using a depth-limited

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"gaal/internal/config"
+	"gaal/internal/discover"
 	"gaal/internal/engine/ops"
 	"gaal/internal/engine/render"
 	"gaal/internal/mcp"
@@ -156,6 +157,9 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 	}
 
 	slog.Debug("sync completed successfully")
+	if rebuildErr := discover.RebuildIndex(ctx, e.home, e.workDir, e.stateDir, e.cacheRoot); rebuildErr != nil {
+		slog.DebugContext(ctx, "index rebuild failed after sync", "err", rebuildErr)
+	}
 	return nil
 }
 
@@ -198,12 +202,15 @@ func (e *Engine) Prune(ctx context.Context) error {
 	if err := e.mcps.Prune(ctx); err != nil {
 		errs = append(errs, fmt.Errorf("mcps prune: %w", err))
 	}
+	if rebuildErr := discover.RebuildIndex(ctx, e.home, e.workDir, e.stateDir, e.cacheRoot); rebuildErr != nil {
+		slog.DebugContext(ctx, "index rebuild failed after prune", "err", rebuildErr)
+	}
 	return errors.Join(errs...)
 }
 
 // Collect gathers the current status of all resources without side effects.
 func (e *Engine) Collect(ctx context.Context) (*render.StatusReport, error) {
-	return ops.Collect(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir)
+	return ops.Collect(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir, e.cacheRoot)
 }
 
 // DryRun computes what sync would do and renders the plan to os.Stdout.
@@ -223,7 +230,7 @@ func (e *Engine) Plan(ctx context.Context) (*render.PlanReport, error) {
 
 // Status collects the current resource state and renders it to os.Stdout.
 func (e *Engine) Status(ctx context.Context, format OutputFormat) error {
-	return ops.Status(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir, format)
+	return ops.Status(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir, e.cacheRoot, format)
 }
 
 // Audit discovers all skills and MCP servers installed on the machine and

--- a/internal/engine/ops/audit.go
+++ b/internal/engine/ops/audit.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"log/slog"
 	"os"
-	"path/filepath"
 
-	"gaal/internal/core/agent"
+	"gaal/internal/discover"
 	"gaal/internal/engine/render"
 	"gaal/internal/mcp"
-	"gaal/internal/skill"
 )
 
 // Audit discovers all skills and MCP servers installed on the machine and
@@ -17,11 +15,16 @@ import (
 func Audit(ctx context.Context, home, workDir string, format render.OutputFormat) error {
 	slog.DebugContext(ctx, "starting audit", "home", home, "workDir", workDir)
 
-	skills, err := collectAuditSkills(ctx, home, workDir)
+	resources, err := discover.Scan(ctx, home, workDir, discover.ScanOptions{
+		Mode:             discover.ScanModeFull,
+		IncludeWorkspace: true,
+	})
 	if err != nil {
-		return err
+		slog.DebugContext(ctx, "scan error during audit", "err", err)
 	}
-	mcps, err := collectAuditMCPs(ctx, home)
+
+	skills := resourcesToAuditSkills(resources)
+	mcps, err := resourcesToAuditMCPs(ctx, resources)
 	if err != nil {
 		return err
 	}
@@ -30,182 +33,46 @@ func Audit(ctx context.Context, home, workDir string, format render.OutputFormat
 	return render.NewAuditRenderer(format).Render(os.Stdout, report)
 }
 
-// collectAuditSkills iterates every registered agent and scans its project,
-// global, and package-manager skill directories.
-//
-// Attribution uses a two-pass strategy to ensure that shared directories (e.g.
-// ~/.copilot/skills) are attributed to the agent that canonically owns them
-// rather than the first agent alphabetically:
-//
-//   - Pass 1 scans each agent's canonical dirs only (ProjectSkillsDir /
-//     GlobalSkillsDir).  This builds the "seen" set with correct ownership.
-//   - Pass 2 scans the full search lists of each agent.  Directories already
-//     claimed in pass 1 are skipped, so only unclaimed shared dirs get a new
-//     attribution at this stage.
-func collectAuditSkills(ctx context.Context, home, workDir string) ([]render.AuditSkillEntry, error) {
-	slog.DebugContext(ctx, "collecting audit skills")
-
+// resourcesToAuditSkills converts discover.Resource skill entries to render entries.
+func resourcesToAuditSkills(resources []discover.Resource) []render.AuditSkillEntry {
 	var entries []render.AuditSkillEntry
-	seenDirs := map[string]struct{}{}
-
-	agents := agent.List()
-
-	// ── Pass 1: canonical dirs ───────────────────────────────────────────────
-	for _, a := range agents {
-		name := a.Name
-
-		if a.Info.ProjectSkillsDir != "" {
-			absDir := filepath.Join(workDir, a.Info.ProjectSkillsDir)
-			metas, err := scanDeduped(absDir, seenDirs)
-			if err != nil {
-				slog.DebugContext(ctx, "canonical project scan error", "agent", name, "dir", absDir, "err", err)
-			} else {
-				for _, m := range metas {
-					entries = append(entries, render.AuditSkillEntry{
-						Name:   m.Name,
-						Desc:   m.Desc,
-						Agent:  name,
-						Source: "project",
-						Path:   m.Path,
-					})
-				}
-			}
-		}
-
-		if a.Info.GlobalSkillsDir != "" {
-			absDir := agent.ExpandHome(a.Info.GlobalSkillsDir, home)
-			metas, err := scanDeduped(absDir, seenDirs)
-			if err != nil {
-				slog.DebugContext(ctx, "canonical global scan error", "agent", name, "dir", absDir, "err", err)
-			} else {
-				for _, m := range metas {
-					entries = append(entries, render.AuditSkillEntry{
-						Name:   m.Name,
-						Desc:   m.Desc,
-						Agent:  name,
-						Source: "global",
-						Path:   m.Path,
-					})
-				}
-			}
-		}
-	}
-
-	// ── Pass 2: full search lists (extended / shared dirs) ───────────────────
-	for _, a := range agents {
-		name := a.Name
-
-		// ── Project skills (1 level) ────────────────────────────────────────
-		for _, relDir := range agent.ExpandedProjectSkillsSearch(name) {
-			absDir := filepath.Join(workDir, relDir)
-			metas, err := scanDeduped(absDir, seenDirs)
-			if err != nil {
-				slog.DebugContext(ctx, "project scan error", "agent", name, "dir", absDir, "err", err)
-				continue
-			}
-			for _, m := range metas {
-				entries = append(entries, render.AuditSkillEntry{
-					Name:   m.Name,
-					Desc:   m.Desc,
-					Agent:  name,
-					Source: "project",
-					Path:   m.Path,
-				})
-			}
-		}
-
-		// ── Global skills (1 level) ─────────────────────────────────────────
-		for _, absDir := range agent.ExpandedGlobalSkillsSearch(name, home) {
-			metas, err := scanDeduped(absDir, seenDirs)
-			if err != nil {
-				slog.DebugContext(ctx, "global scan error", "agent", name, "dir", absDir, "err", err)
-				continue
-			}
-			for _, m := range metas {
-				entries = append(entries, render.AuditSkillEntry{
-					Name:   m.Name,
-					Desc:   m.Desc,
-					Agent:  name,
-					Source: "global",
-					Path:   m.Path,
-				})
-			}
-		}
-
-		// ── Package-manager skills (recursive) ──────────────────────────────
-		for _, pmRoot := range agent.ExpandedPmSkillsSearch(name, home) {
-			skillsDirs, err := skill.WalkForSkillDirs(pmRoot)
-			if err != nil {
-				slog.DebugContext(ctx, "pm walk error", "agent", name, "root", pmRoot, "err", err)
-				continue
-			}
-			for _, sd := range skillsDirs {
-				metas, err := scanDeduped(sd, seenDirs)
-				if err != nil {
-					slog.DebugContext(ctx, "pm scan error", "agent", name, "dir", sd, "err", err)
-					continue
-				}
-				for _, m := range metas {
-					entries = append(entries, render.AuditSkillEntry{
-						Name:   m.Name,
-						Desc:   m.Desc,
-						Agent:  name,
-						Source: "package-manager",
-						Path:   m.Path,
-					})
-				}
-			}
-		}
-	}
-
-	return entries, nil
-}
-
-// collectAuditMCPs reads the project_mcp_config_file of every registered agent
-// and returns agents that actually have servers configured.
-func collectAuditMCPs(ctx context.Context, home string) ([]render.AuditMCPEntry, error) {
-	slog.DebugContext(ctx, "collecting audit mcps")
-
-	var entries []render.AuditMCPEntry
-
-	for _, a := range agent.List() {
-		cfgFile, ok := agent.ProjectMCPConfigPath(a.Name, home)
-		if !ok {
+	for _, r := range resources {
+		if r.Type != discover.ResourceSkill {
 			continue
 		}
+		entries = append(entries, render.AuditSkillEntry{
+			Name:   r.Name,
+			Desc:   r.Meta["desc"],
+			Agent:  r.Meta["agent"],
+			Source: r.Meta["source"],
+			Path:   r.Path,
+		})
+	}
+	return entries
+}
 
-		servers, err := mcp.ListServers(cfgFile)
+// resourcesToAuditMCPs converts discover.Resource MCP entries to render entries,
+// loading the server list from each config file.
+func resourcesToAuditMCPs(ctx context.Context, resources []discover.Resource) ([]render.AuditMCPEntry, error) {
+	var entries []render.AuditMCPEntry
+	for _, r := range resources {
+		if r.Type != discover.ResourceMCP {
+			continue
+		}
+		servers, err := mcp.ListServers(r.Path)
 		if err != nil {
-			slog.DebugContext(ctx, "mcp list error", "agent", a.Name, "file", cfgFile, "err", err)
+			slog.DebugContext(ctx, "mcp list error", "agent", r.Name, "file", r.Path, "err", err)
 			continue
 		}
 		if len(servers) == 0 {
 			continue
 		}
-
 		entries = append(entries, render.AuditMCPEntry{
-			Agent:      a.Name,
-			ConfigFile: cfgFile,
+			Agent:      r.Name,
+			ConfigFile: r.Path,
+			Scope:      r.Meta["scope"],
 			Servers:    servers,
 		})
 	}
-
 	return entries, nil
-}
-
-// scanDeduped calls skill.ScanDir and skips any skill directory already seen.
-func scanDeduped(dir string, seen map[string]struct{}) ([]skill.Meta, error) {
-	metas, err := skill.ScanDir(dir)
-	if err != nil {
-		return nil, err
-	}
-	var out []skill.Meta
-	for _, m := range metas {
-		if _, ok := seen[m.Path]; ok {
-			continue
-		}
-		seen[m.Path] = struct{}{}
-		out = append(out, m)
-	}
-	return out, nil
 }

--- a/internal/engine/ops/info.go
+++ b/internal/engine/ops/info.go
@@ -28,7 +28,7 @@ import (
 func Info(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, cfg *config.Config, home, workDir, stateDir, pkg, filter string, format render.OutputFormat) error {
 	slog.DebugContext(ctx, "info requested", "package", pkg, "filter", filter, "format", format)
 
-	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir)
+	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir, "")
 	if err != nil {
 		return err
 	}

--- a/internal/engine/ops/init_build.go
+++ b/internal/engine/ops/init_build.go
@@ -8,6 +8,7 @@ import (
 
 	"gaal/internal/config"
 	"gaal/internal/core/agent"
+	"gaal/internal/discover"
 	"gaal/internal/engine/render"
 	"gaal/internal/mcp"
 )
@@ -23,10 +24,14 @@ func BuildImportCandidates(ctx context.Context, scope Scope, home, workDir, cach
 	slog.DebugContext(ctx, "building import candidates",
 		"scope", scope, "home", home, "workDir", workDir, "cacheRoot", cacheRoot)
 
-	skills, err := collectAuditSkills(ctx, home, workDir)
+	scanResources, err := discover.Scan(ctx, home, workDir, discover.ScanOptions{
+		Mode:             discover.ScanModeFull,
+		IncludeWorkspace: true,
+	})
 	if err != nil {
-		return Candidates{}, fmt.Errorf("collecting audit skills: %w", err)
+		slog.DebugContext(ctx, "scan error in BuildImportCandidates", "err", err)
 	}
+	skills := resourcesToAuditSkills(scanResources)
 
 	filteredSkills := filterSkillsByScope(skills, scope)
 

--- a/internal/engine/ops/plan.go
+++ b/internal/engine/ops/plan.go
@@ -18,7 +18,7 @@ import (
 func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string) (*render.PlanReport, error) {
 	slog.DebugContext(ctx, "computing sync plan")
 
-	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir)
+	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/ops/status.go
+++ b/internal/engine/ops/status.go
@@ -18,13 +18,15 @@ import (
 // Collect gathers the current status of all resources without side effects.
 // It performs a FS-first scan via discover.Scan and then reconciles with any
 // config-declared resources from the managers, marking them as managed.
-func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string) (*render.StatusReport, error) {
+func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir, cacheRoot string) (*render.StatusReport, error) {
 	slog.DebugContext(ctx, "collecting status", "home", home, "workDir", workDir)
 
 	// FS-first: discover what is actually installed.
 	discovered, err := discover.Scan(ctx, home, workDir, discover.ScanOptions{
+		Mode:             discover.ScanModeIndex,
 		IncludeWorkspace: true,
 		StateDir:         stateDir,
+		CacheRoot:        cacheRoot,
 	})
 	if err != nil {
 		slog.DebugContext(ctx, "discover scan error", "err", err)
@@ -55,10 +57,10 @@ func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mc
 }
 
 // Status collects the current resource state and renders it to os.Stdout.
-func Status(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string, format render.OutputFormat) error {
+func Status(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir, cacheRoot string, format render.OutputFormat) error {
 	slog.DebugContext(ctx, "status requested", "format", format)
 
-	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir)
+	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir, cacheRoot)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/render/audit.go
+++ b/internal/engine/render/audit.go
@@ -45,12 +45,13 @@ func (j *auditJSONRenderer) Render(w io.Writer, r *AuditReport) error {
 //
 // Matches the sample in cli/audit.mdx:
 //
-//	discovered:
-//	  skills (project)
-//	    .claude/skills/code-review     (claude-code)
-//	  mcps
-//	    ~/.config/claude/claude_desktop_config.json
-//	      filesystem, git, github
+//discovered:
+//  skills (project)
+//    .claude/skills/code-review     (claude-code)
+//  mcps (project)
+//    ~/.config/claude/claude_desktop_config.json
+//      · filesystem
+//      · git
 
 type auditTextRenderer struct{}
 
@@ -104,37 +105,63 @@ func (tr *auditTextRenderer) mcpGroups(w io.Writer, mcps []AuditMCPEntry, home s
 		return
 	}
 
-	// Collapse entries by config file so the same file (reachable via several
-	// agents) renders once with the combined server list.
 	type fileGroup struct {
 		path    string
+		scope   string
 		servers map[string]struct{}
 	}
-	byFile := map[string]*fileGroup{}
-	order := []string{}
+	// Group by scope first, then collapse by config file within each scope.
+	byScope := map[string]map[string]*fileGroup{}
+	scopeOrder := []string{"project", "global"}
+	for _, scope := range scopeOrder {
+		byScope[scope] = map[string]*fileGroup{}
+	}
 	for _, e := range mcps {
-		g, ok := byFile[e.ConfigFile]
+		scope := e.Scope
+		if scope == "" {
+			scope = "project"
+		}
+		if _, ok := byScope[scope]; !ok {
+			byScope[scope] = map[string]*fileGroup{}
+		}
+		g, ok := byScope[scope][e.ConfigFile]
 		if !ok {
-			g = &fileGroup{path: e.ConfigFile, servers: map[string]struct{}{}}
-			byFile[e.ConfigFile] = g
-			order = append(order, e.ConfigFile)
+			g = &fileGroup{path: e.ConfigFile, scope: scope, servers: map[string]struct{}{}}
+			byScope[scope][e.ConfigFile] = g
 		}
 		for _, s := range e.Servers {
 			g.servers[s] = struct{}{}
 		}
 	}
 
-	fmt.Fprintln(w, "  mcps")
-	for _, path := range order {
-		g := byFile[path]
-		servers := make([]string, 0, len(g.servers))
-		for s := range g.servers {
-			servers = append(servers, s)
+	labels := map[string]string{
+		"project": "mcps (project)",
+		"global":  "mcps (global)",
+	}
+	for _, scope := range scopeOrder {
+		files := byScope[scope]
+		if len(files) == 0 {
+			continue
 		}
-		sort.Strings(servers)
-		fmt.Fprintf(w, "    %s\n", shortenHome(g.path, home))
-		if len(servers) > 0 {
-			fmt.Fprintf(w, "      %s\n", strings.Join(servers, ", "))
+		// Sort file paths for stable output.
+		sortedFiles := make([]string, 0, len(files))
+		for f := range files {
+			sortedFiles = append(sortedFiles, f)
+		}
+		sort.Strings(sortedFiles)
+
+		fmt.Fprintf(w, "  %s\n", labels[scope])
+		for _, path := range sortedFiles {
+			g := files[path]
+			servers := make([]string, 0, len(g.servers))
+			for s := range g.servers {
+				servers = append(servers, s)
+			}
+			sort.Strings(servers)
+			fmt.Fprintf(w, "    %s\n", shortenHome(g.path, home))
+			for _, s := range servers {
+				fmt.Fprintf(w, "      · %s\n", s)
+			}
 		}
 	}
 }
@@ -213,17 +240,22 @@ func (tr *auditTableRenderer) mcpTable(w io.Writer, entries []AuditMCPEntry, hom
 		return nil
 	}
 
-	// Fixed cols: AGENT(22) = 22; variable cols: CONFIG FILE and SERVERS share the rest.
-	vw := varColWidth(termW, 3, 2, 22)
+	// Fixed cols: AGENT(22) + SCOPE(10) = 32; variable cols: CONFIG FILE and SERVERS share the rest.
+	vw := varColWidth(termW, 4, 2, 32)
 	if vw < 14 {
 		vw = 14
 	}
 
-	data := pterm.TableData{{"AGENT", "CONFIG FILE", "SERVERS"}}
+	data := pterm.TableData{{"AGENT", "SCOPE", "CONFIG FILE", "SERVERS"}}
 	for _, e := range entries {
 		servers := strings.Join(e.Servers, ", ")
+		scope := e.Scope
+		if scope == "" {
+			scope = "project"
+		}
 		data = append(data, []string{
 			e.Agent,
+			scope,
 			trunc(shortenHome(e.ConfigFile, home), vw),
 			trunc(servers, vw),
 		})

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -154,9 +154,11 @@ type AuditSkillEntry struct {
 
 // AuditMCPEntry holds the MCP servers found for a single agent.
 type AuditMCPEntry struct {
-	Agent      string   `json:"agent"`
-	ConfigFile string   `json:"config_file"`
-	Servers    []string `json:"servers"`
+	Agent      string `json:"agent"`
+	ConfigFile string `json:"config_file"`
+	// Scope is "project" or "global".
+	Scope   string   `json:"scope"`
+	Servers []string `json:"servers"`
 }
 
 // AuditReport aggregates all skills and MCP servers discovered on the machine.


### PR DESCRIPTION
## Summary

Introduce a two-speed scan engine to serve `gaal status`/`info` from a
fast-path discovery index while keeping a full compliance walk for
`gaal audit` and `init --import-all`.

### Fast-path (`ScanModeIndex`) — used by `status`, `info`
After every write operation (`sync`, `prune`), the discovered resource
list is serialised into `~/.cache/gaal/gaal/discovery-index.json` atomically
(temp file + `os.Rename`). On read-only commands each entry is validated
via a single `stat()` on its parent directory — unchanged mtime means the
entry is still valid; a changed mtime triggers a partial re-walk of that
one directory only. Falls back to `ScanModeFull` when the index is missing.

### Compliance walk (`ScanModeFull`) — used by `audit`, `init --import-all`
- `scanGlobal` and `scanWorkspace` run **concurrently** via goroutines.
- No arbitrary timeout applied.
- `skipDirs` extended with: `Library`, `.local`, `.steam`, `.wine`, `.gem`, `__pycache__`

### Unification
`ops/audit.go` `collectAuditSkills` / `collectAuditMCPs` / `scanDeduped`
removed. `Audit()` and `BuildImportCandidates()` now delegate to
`discover.Scan(ScanModeFull)`.

### Option B — MCP scope alignment
`AuditMCPEntry` gains a `Scope` field (`"project"` or `"global"`).
The audit renderer groups MCPs by scope: *"mcps (project)"* / *"mcps (global)"*,
mirroring the existing skill grouping.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (no functional change, code quality improvement)

## Related Issues
Closes #213

## Checklist
- [x] `make lint` passes — `gofmt` formatting + `go vet` clean
- [x] `make build` passes on Linux and macOS
- [x] `make test` passes — unit tests with race detector
- [x] Every new function has at least one `slog.Debug` / `slog.DebugContext` call
- [x] Documentation updated (`docs/discover.md`, `docs/architecture.md`)
- [x] No secrets or credentials are exposed in logs or config snippets