### PR TITLE
Support native HTTP MCP headers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -309,11 +309,14 @@ For `git` sources the cache uses a **shallow clone** (`depth=1`) with a **hard-r
 
 ## Package `internal/mcp`
 
-Each MCP entry is **upserted** into the target JSON file under the `mcpServers.<name>` key. Existing keys not managed by gaal are preserved. The write is atomic: temp file + `os.Rename()`.
+Each MCP entry is **upserted** into the target agent config. JSON-based targets
+use the `mcpServers.<name>` key. Codex TOML targets use `mcp_servers.<name>`.
+Existing keys not managed by gaal are preserved. The write is atomic: temp file
+and `os.Rename()`.
 
 | Source mode | Description |
 |-------------|-------------|
-| `inline:` | Full server definition in YAML (command, args, env) |
+| `inline:` | Full server definition in YAML (stdio `command`/`args`/`env`, or HTTP `type`/`url`/`headers`) |
 | `source:` | Remote URL returning `{"mcpServers": {...}}` JSON |
 
 ---

--- a/docs/config.md
+++ b/docs/config.md
@@ -287,7 +287,8 @@ Key validation rules applied to `Config` structs:
 | `ConfigMcp.Name` | `required` |
 | `ConfigMcp.Target` | _(deprecated)_ explicit path; prefer `agents` + `global` |
 | `ConfigMcp.Source` | `required_without=Inline` |
-| `ConfigMcpItem.Command` | `required` |
+| `ConfigMcpItem.Command` | required for stdio inline MCPs |
+| `ConfigMcpItem.URL` | required for http/sse inline MCPs |
 
 ### Relationship with `internal/config`
 

--- a/docs/packages/mcp.md
+++ b/docs/packages/mcp.md
@@ -17,7 +17,7 @@
 
 | Mode | Description |
 |------|-------------|
-| `inline:` | Full server definition in YAML (`command`, `args`, `env`) |
+| `inline:` | Full server definition in YAML (stdio `command`/`args`/`env`, or HTTP `type`/`url`/`headers`) |
 | `source:` | Remote URL returning a JSON document (full `mcpServers` map or a single entry) |
 
 Validated via [`packages/urlx.md`](urlx.md) before any HTTP call.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -70,7 +70,7 @@ skills:
     global: true                        # user-wide install (~/.copilot/skills, etc.)
 
 # ── MCP Servers ───────────────────────────────────────────────────────────────
-# Upsert MCP server entries into agent JSON config files.
+# Upsert MCP server entries into agent config files.
 # Existing entries are preserved; only the named key is updated.
 mcps:
   - name: filesystem
@@ -86,6 +86,18 @@ mcps:
     inline:
       command: uvx
       args: [mcp-server-filesystem, /home/user/projects]
+
+  - name: memory-mcp
+    agents: ["codex", "claude-code"]
+    global: true
+    inline:
+      type: http
+      url: https://memory.example.com/mcp
+      headers:
+        CF-Access-Client-Id:
+          env: CF_ACCESS_CLIENT_ID
+        CF-Access-Client-Secret:
+          env: CF_ACCESS_CLIENT_SECRET
 ```
 
 ### Configuration reference

--- a/example.gaal.yaml
+++ b/example.gaal.yaml
@@ -95,6 +95,9 @@ skills:
 #
 # source: URL to a remote JSON file containing an mcpServers document.
 # inline: define the server entry directly in this file.
+#         Stdio entries use command/args/env. HTTP entries use type/url/headers.
+#         For HTTP header secrets, set headers.<name>.env to an environment
+#         variable name; gaal writes the env reference, not the secret value.
 # agents: list of agent identifiers (or ["*"] to target all agents).
 #         The target JSON file is resolved automatically from the agent registry.
 # global: true  → write to the agent's global MCP config (global_mcp_config_file)
@@ -141,6 +144,19 @@ mcps:
       args:
         - -y
         - "@modelcontextprotocol/server-sequential-thinking"
+
+  # Native HTTP server with env-backed headers.
+  - name: memory-mcp
+    agents: ["codex", "claude-code"]
+    global: true
+    inline:
+      type: http
+      url: https://memory.example.com/mcp
+      headers:
+        CF-Access-Client-Id:
+          env: CF_ACCESS_CLIENT_ID
+        CF-Access-Client-Secret:
+          env: CF_ACCESS_CLIENT_SECRET
 
 # ─────────────────────────────────────────────────────────────────────────────
 # tools

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -77,9 +77,41 @@ type ConfigMcp struct {
 
 // ConfigMcpItem is an inline MCP server specification.
 type ConfigMcpItem struct {
-	Command string            `yaml:"command"        json:"command"         jsonschema:"description=Executable to launch the MCP server process" validate:"required"`
-	Args    []string          `yaml:"args,omitempty" json:"args,omitempty"  jsonschema:"description=Command-line arguments passed to the command"`
-	Env     map[string]string `yaml:"env,omitempty"  json:"env,omitempty"   jsonschema:"description=Additional environment variables injected into the server process"`
+	Type    string                     `yaml:"type,omitempty"    json:"type,omitempty"     jsonschema:"description=MCP transport type; defaults to stdio when command is set, or http when url is set"`
+	Command string                     `yaml:"command,omitempty" json:"command,omitempty"  jsonschema:"description=Executable to launch the MCP stdio server process"`
+	Args    []string                   `yaml:"args,omitempty"    json:"args,omitempty"     jsonschema:"description=Command-line arguments passed to the stdio command"`
+	Env     map[string]string          `yaml:"env,omitempty"     json:"env,omitempty"      jsonschema:"description=Additional environment variables injected into the stdio server process"`
+	URL     string                     `yaml:"url,omitempty"     json:"url,omitempty"      jsonschema:"description=Endpoint for an MCP HTTP or SSE server"`
+	Headers map[string]ConfigMcpHeader `yaml:"headers,omitempty" json:"headers,omitempty"  jsonschema:"description=HTTP headers for remote MCP servers; use env to reference secret environment variables"`
+}
+
+// ConfigMcpHeader is one HTTP header value for a remote MCP server.
+// Value is written as a static header. Env writes only the environment variable
+// name where the target agent supports env-backed headers.
+type ConfigMcpHeader struct {
+	Value string `yaml:"value,omitempty" json:"value,omitempty" jsonschema:"description=Static header value; avoid for secrets"`
+	Env   string `yaml:"env,omitempty"   json:"env,omitempty"   jsonschema:"description=Environment variable name that supplies the header value"`
+}
+
+// UnmarshalYAML accepts HTTP headers as either a scalar static value or an
+// explicit mapping. Secrets should use the mapping form with env.
+func (h *ConfigMcpHeader) UnmarshalYAML(node *yaml.Node) error {
+	slog.Debug("decoding mcp header", "line", node.Line, "kind", node.Kind)
+	switch node.Kind {
+	case yaml.ScalarNode:
+		h.Value = node.Value
+		return nil
+	case yaml.MappingNode:
+		type rawHeader ConfigMcpHeader
+		var raw rawHeader
+		if err := node.Decode(&raw); err != nil {
+			return err
+		}
+		*h = ConfigMcpHeader(raw)
+		return nil
+	default:
+		return fmt.Errorf("line %d: expected header value or mapping", node.Line)
+	}
 }
 
 // LevelConfigs holds each configuration level as loaded from disk, before
@@ -349,7 +381,48 @@ func (c *Config) deduplicate() {
 
 func (c *Config) validate() error {
 	slog.Debug("validating config", "repos", len(c.Repositories), "skills", len(c.Skills), "mcps", len(c.MCPs))
-	return schema.Validate(c)
+	if err := schema.Validate(c); err != nil {
+		return err
+	}
+	return c.validateMCPItems()
+}
+
+func (c *Config) validateMCPItems() error {
+	slog.Debug("validating mcp inline items", "count", len(c.MCPs))
+	for _, mc := range c.MCPs {
+		if mc.Inline == nil {
+			continue
+		}
+		typ := mc.Inline.Type
+		if typ == "" {
+			if mc.Inline.URL != "" {
+				typ = "http"
+			} else {
+				typ = "stdio"
+			}
+		}
+		switch typ {
+		case "stdio":
+			if mc.Inline.Command == "" {
+				return fmt.Errorf("mcp %q: inline.command is required for stdio MCP servers", mc.Name)
+			}
+		case "http", "sse":
+			if mc.Inline.URL == "" {
+				return fmt.Errorf("mcp %q: inline.url is required for %s MCP servers", mc.Name, typ)
+			}
+		default:
+			return fmt.Errorf("mcp %q: inline.type must be one of [stdio http sse], got %q", mc.Name, typ)
+		}
+		for name, header := range mc.Inline.Headers {
+			if header.Value != "" && header.Env != "" {
+				return fmt.Errorf("mcp %q: inline.headers.%s cannot set both value and env", mc.Name, name)
+			}
+			if header.Value == "" && header.Env == "" {
+				return fmt.Errorf("mcp %q: inline.headers.%s must set value or env", mc.Name, name)
+			}
+		}
+	}
+	return nil
 }
 
 // ── ConfigSkill methods ───────────────────────────────────────────────────────

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -276,6 +276,84 @@ mcps:
 	}
 }
 
+func TestLoad_MCPInlineHTTPWithHeaderEnv_IsValid(t *testing.T) {
+	p := writeYAML(t, `
+mcps:
+  - name: memory-mcp
+    target: /tmp/mcp.toml
+    inline:
+      type: http
+      url: https://memory.example.com/mcp
+      headers:
+        CF-Access-Client-Id:
+          env: CF_ACCESS_CLIENT_ID
+        CF-Access-Client-Secret:
+          env: CF_ACCESS_CLIENT_SECRET
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("expected no validation error for http mcp: %v", err)
+	}
+	got := cfg.MCPs[0].Inline.Headers["CF-Access-Client-Id"].Env
+	if got != "CF_ACCESS_CLIENT_ID" {
+		t.Errorf("header env = %q", got)
+	}
+}
+
+func TestLoad_MCPInlineHTTPWithStaticScalarHeader_IsValid(t *testing.T) {
+	p := writeYAML(t, `
+mcps:
+  - name: public-mcp
+    target: /tmp/mcp.json
+    inline:
+      type: http
+      url: https://public.example.com/mcp
+      headers:
+        X-Workspace: test
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("expected no validation error for scalar header: %v", err)
+	}
+	got := cfg.MCPs[0].Inline.Headers["X-Workspace"].Value
+	if got != "test" {
+		t.Errorf("header value = %q", got)
+	}
+}
+
+func TestLoad_ValidationError_MCPHeaderValueAndEnv(t *testing.T) {
+	p := writeYAML(t, `
+mcps:
+  - name: bad-mcp
+    target: /tmp/mcp.json
+    inline:
+      type: http
+      url: https://bad.example.com/mcp
+      headers:
+        Authorization:
+          value: static
+          env: AUTH_TOKEN
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected validation error for header with value and env")
+	}
+}
+
+func TestLoad_ValidationError_MCPHTTPWithoutURL(t *testing.T) {
+	p := writeYAML(t, `
+mcps:
+  - name: memory-mcp
+    target: /tmp/mcp.toml
+    inline:
+      type: http
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected validation error for http mcp without url")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Schema field
 // ---------------------------------------------------------------------------

--- a/internal/mcp/codec.go
+++ b/internal/mcp/codec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -239,9 +240,16 @@ func (tomlCodec) WriteServers(path string, servers map[string]serverEntry) error
 // decodeTOMLEntry converts a parsed TOML table into a serverEntry, normalising
 // the args slice (TOML decodes arrays as []any) and env table types.
 func decodeTOMLEntry(t map[string]any) serverEntry {
+	slog.Debug("decoding toml mcp entry", "fields", len(t))
 	var e serverEntry
+	if v, ok := t["type"].(string); ok {
+		e.Type = v
+	}
 	if v, ok := t["command"].(string); ok {
 		e.Command = v
+	}
+	if v, ok := t["url"].(string); ok {
+		e.URL = v
 	}
 	if rawArgs, ok := t["args"].([]any); ok {
 		e.Args = make([]string, 0, len(rawArgs))
@@ -259,15 +267,31 @@ func decodeTOMLEntry(t map[string]any) serverEntry {
 			}
 		}
 	}
+	if rawHeaders, ok := t["headers"].(map[string]any); ok && len(rawHeaders) > 0 {
+		e.Headers = decodeStringMap(rawHeaders)
+	}
+	if rawHeaders, ok := t["http_headers"].(map[string]any); ok && len(rawHeaders) > 0 {
+		e.HTTPHeaders = decodeStringMap(rawHeaders)
+	}
+	if rawHeaders, ok := t["env_http_headers"].(map[string]any); ok && len(rawHeaders) > 0 {
+		e.EnvHTTPHeaders = decodeStringMap(rawHeaders)
+	}
 	return e
 }
 
 // encodeTOMLEntry produces the inverse of decodeTOMLEntry, omitting empty
 // fields so the rendered TOML stays minimal.
 func encodeTOMLEntry(e serverEntry) map[string]any {
+	slog.Debug("encoding toml mcp entry", "type", e.Type, "command", e.Command != "", "url", e.URL != "")
 	out := map[string]any{}
+	if e.Type != "" {
+		out["type"] = e.Type
+	}
 	if e.Command != "" {
 		out["command"] = e.Command
+	}
+	if e.URL != "" {
+		out["url"] = e.URL
 	}
 	if len(e.Args) > 0 {
 		args := make([]any, len(e.Args))
@@ -282,6 +306,35 @@ func encodeTOMLEntry(e serverEntry) map[string]any {
 			env[k] = v
 		}
 		out["env"] = env
+	}
+	if len(e.Headers) > 0 {
+		out["headers"] = encodeStringMap(e.Headers)
+	}
+	if len(e.HTTPHeaders) > 0 {
+		out["http_headers"] = encodeStringMap(e.HTTPHeaders)
+	}
+	if len(e.EnvHTTPHeaders) > 0 {
+		out["env_http_headers"] = encodeStringMap(e.EnvHTTPHeaders)
+	}
+	return out
+}
+
+func decodeStringMap(raw map[string]any) map[string]string {
+	slog.Debug("decoding string map", "count", len(raw))
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+func encodeStringMap(in map[string]string) map[string]any {
+	slog.Debug("encoding string map", "count", len(in))
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
 	}
 	return out
 }

--- a/internal/mcp/codec_test.go
+++ b/internal/mcp/codec_test.go
@@ -191,6 +191,61 @@ func TestTOMLCodec_PreservesEnv(t *testing.T) {
 	}
 }
 
+func TestTOMLCodec_PreservesHTTPHeaderEnvMappings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	in := map[string]serverEntry{
+		"memory-mcp": {
+			URL: "https://memory.example.com/mcp",
+			EnvHTTPHeaders: map[string]string{
+				"CF-Access-Client-Id":     "CF_ACCESS_CLIENT_ID",
+				"CF-Access-Client-Secret": "CF_ACCESS_CLIENT_SECRET",
+			},
+		},
+	}
+	c := tomlCodec{}
+	if err := c.WriteServers(path, in); err != nil {
+		t.Fatalf("WriteServers: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	rendered := string(data)
+	for _, forbidden := range []string{"client-id-value", "client-secret-value"} {
+		if strings.Contains(rendered, forbidden) {
+			t.Fatalf("rendered config leaked secret value %q:\n%s", forbidden, rendered)
+		}
+	}
+	for _, want := range []string{
+		`url = 'https://memory.example.com/mcp'`,
+		`CF-Access-Client-Id = 'CF_ACCESS_CLIENT_ID'`,
+		`CF-Access-Client-Secret = 'CF_ACCESS_CLIENT_SECRET'`,
+		"env_http_headers",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered TOML missing %q:\n%s", want, rendered)
+		}
+	}
+
+	out, err := c.ReadServers(path)
+	if err != nil {
+		t.Fatalf("ReadServers: %v", err)
+	}
+	got := out["memory-mcp"]
+	if got.URL != "https://memory.example.com/mcp" {
+		t.Errorf("url = %q", got.URL)
+	}
+	if got.EnvHTTPHeaders["CF-Access-Client-Id"] != "CF_ACCESS_CLIENT_ID" {
+		t.Errorf("env header id not preserved: %+v", got.EnvHTTPHeaders)
+	}
+	if got.EnvHTTPHeaders["CF-Access-Client-Secret"] != "CF_ACCESS_CLIENT_SECRET" {
+		t.Errorf("env header secret not preserved: %+v", got.EnvHTTPHeaders)
+	}
+}
+
 // End-to-end via mergeIntoTarget --------------------------------------------
 
 func TestMergeIntoTarget_TOMLDispatch(t *testing.T) {

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 
 	"gaal/internal/config"
@@ -24,9 +25,14 @@ import (
 // serverEntry mirrors the MCP server JSON structure used by Claude Desktop,
 // VS Code and other compatible clients.
 type serverEntry struct {
-	Command string            `json:"command,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
+	Type           string            `json:"type,omitempty"`
+	Command        string            `json:"command,omitempty"`
+	Args           []string          `json:"args,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+	URL            string            `json:"url,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	HTTPHeaders    map[string]string `json:"http_headers,omitempty"`
+	EnvHTTPHeaders map[string]string `json:"env_http_headers,omitempty"`
 }
 
 // mcpServersDoc is the top-level document shape most MCP clients expect.
@@ -175,12 +181,8 @@ func (m *Manager) syncOne(ctx context.Context, mc config.ConfigMcp) error {
 
 	switch {
 	case mc.Inline != nil:
-		slog.DebugContext(ctx, "mcp inline definition", "name", mc.Name, "command", mc.Inline.Command)
-		entry = serverEntry{
-			Command: mc.Inline.Command,
-			Args:    mc.Inline.Args,
-			Env:     mc.Inline.Env,
-		}
+		slog.DebugContext(ctx, "mcp inline definition", "name", mc.Name, "type", mc.Inline.Type, "command", mc.Inline.Command, "url", urlx.Redact(mc.Inline.URL))
+		entry = inlineServerEntry(mc.Inline, strings.EqualFold(extOf(mc.Target), ".toml"))
 
 	case mc.Source != "":
 		slog.DebugContext(ctx, "mcp remote source", "name", mc.Name, "url", urlx.Redact(mc.Source))
@@ -380,11 +382,7 @@ func (m *Manager) Status(_ context.Context) []Status {
 			st.Present = true
 			// For inline configs we can detect divergence without I/O.
 			if mc.Inline != nil {
-				want := serverEntry{
-					Command: mc.Inline.Command,
-					Args:    mc.Inline.Args,
-					Env:     mc.Inline.Env,
-				}
+				want := inlineServerEntry(mc.Inline, strings.EqualFold(extOf(mc.Target), ".toml"))
 				st.Dirty = !serverEntryEqual(stored, want)
 			}
 		}
@@ -398,7 +396,14 @@ func (m *Manager) Status(_ context.Context) []Status {
 // serverEntryEqual reports whether two serverEntry values are semantically equal.
 // Nil and empty slices/maps are treated as equivalent.
 func serverEntryEqual(a, b serverEntry) bool {
+	slog.Debug("comparing mcp server entries")
+	if a.Type != b.Type {
+		return false
+	}
 	if a.Command != b.Command {
+		return false
+	}
+	if a.URL != b.URL {
 		return false
 	}
 	if len(a.Args) != len(b.Args) {
@@ -414,6 +419,72 @@ func serverEntryEqual(a, b serverEntry) bool {
 	}
 	for k, v := range a.Env {
 		if b.Env[k] != v {
+			return false
+		}
+	}
+	return stringMapEqual(a.Headers, b.Headers) &&
+		stringMapEqual(a.HTTPHeaders, b.HTTPHeaders) &&
+		stringMapEqual(a.EnvHTTPHeaders, b.EnvHTTPHeaders)
+}
+
+func inlineServerEntry(item *config.ConfigMcpItem, tomlTarget bool) serverEntry {
+	slog.Debug("building inline mcp server entry", "type", item.Type, "toml", tomlTarget, "url", urlx.Redact(item.URL))
+	entry := serverEntry{
+		Command: item.Command,
+		Args:    item.Args,
+		Env:     item.Env,
+		URL:     item.URL,
+	}
+	typ := item.Type
+	if typ == "" {
+		if item.URL != "" {
+			typ = "http"
+		} else {
+			typ = "stdio"
+		}
+	}
+	if !tomlTarget && typ != "stdio" {
+		entry.Type = typ
+	}
+	if len(item.Headers) == 0 {
+		return entry
+	}
+	if tomlTarget {
+		entry.HTTPHeaders = map[string]string{}
+		entry.EnvHTTPHeaders = map[string]string{}
+		for name, header := range item.Headers {
+			if header.Env != "" {
+				entry.EnvHTTPHeaders[name] = header.Env
+				continue
+			}
+			entry.HTTPHeaders[name] = header.Value
+		}
+		if len(entry.HTTPHeaders) == 0 {
+			entry.HTTPHeaders = nil
+		}
+		if len(entry.EnvHTTPHeaders) == 0 {
+			entry.EnvHTTPHeaders = nil
+		}
+		return entry
+	}
+	entry.Headers = map[string]string{}
+	for name, header := range item.Headers {
+		if header.Env != "" {
+			entry.Headers[name] = "${" + header.Env + "}"
+			continue
+		}
+		entry.Headers[name] = header.Value
+	}
+	return entry
+}
+
+func stringMapEqual(a, b map[string]string) bool {
+	slog.Debug("comparing string maps", "left", len(a), "right", len(b))
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
 			return false
 		}
 	}
@@ -435,10 +506,26 @@ func LoadServers(configFile string) (map[string]config.ConfigMcpItem, error) {
 	}
 	out := make(map[string]config.ConfigMcpItem, len(servers))
 	for name, s := range servers {
+		headers := make(map[string]config.ConfigMcpHeader, len(s.Headers)+len(s.HTTPHeaders)+len(s.EnvHTTPHeaders))
+		for k, v := range s.Headers {
+			headers[k] = config.ConfigMcpHeader{Value: v}
+		}
+		for k, v := range s.HTTPHeaders {
+			headers[k] = config.ConfigMcpHeader{Value: v}
+		}
+		for k, v := range s.EnvHTTPHeaders {
+			headers[k] = config.ConfigMcpHeader{Env: v}
+		}
+		if len(headers) == 0 {
+			headers = nil
+		}
 		out[name] = config.ConfigMcpItem{
+			Type:    s.Type,
 			Command: s.Command,
 			Args:    s.Args,
 			Env:     s.Env,
+			URL:     s.URL,
+			Headers: headers,
 		}
 	}
 	return out, nil

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -176,6 +176,87 @@ func TestManager_Sync_Inline(t *testing.T) {
 	}
 }
 
+func TestManager_Sync_InlineHTTPToCodexTOML(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "config.toml")
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "memory-mcp",
+			Target: target,
+			Inline: &config.ConfigMcpItem{
+				Type: "http",
+				URL:  "https://memory.example.com/mcp",
+				Headers: map[string]config.ConfigMcpHeader{
+					"CF-Access-Client-Id":     {Env: "CF_ACCESS_CLIENT_ID"},
+					"CF-Access-Client-Secret": {Env: "CF_ACCESS_CLIENT_SECRET"},
+				},
+			},
+		},
+	}
+	m := NewManager(mcps, "", "")
+	if err := m.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	rendered := string(data)
+	for _, want := range []string{
+		`url = 'https://memory.example.com/mcp'`,
+		`CF-Access-Client-Id = 'CF_ACCESS_CLIENT_ID'`,
+		`CF-Access-Client-Secret = 'CF_ACCESS_CLIENT_SECRET'`,
+		"env_http_headers",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered TOML missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, ".http_headers]") {
+		t.Errorf("env-backed headers should not be rendered as static http_headers:\n%s", rendered)
+	}
+}
+
+func TestManager_Sync_InlineHTTPToJSON(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "mcp.json")
+	mcps := []config.ConfigMcp{
+		{
+			Name:   "memory-mcp",
+			Target: target,
+			Inline: &config.ConfigMcpItem{
+				Type: "http",
+				URL:  "https://memory.example.com/mcp",
+				Headers: map[string]config.ConfigMcpHeader{
+					"CF-Access-Client-Id":     {Env: "CF_ACCESS_CLIENT_ID"},
+					"CF-Access-Client-Secret": {Env: "CF_ACCESS_CLIENT_SECRET"},
+				},
+			},
+		},
+	}
+	m := NewManager(mcps, "", "")
+	if err := m.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	servers, err := codecFor(target).ReadServers(target)
+	if err != nil {
+		t.Fatalf("ReadServers: %v", err)
+	}
+	got := servers["memory-mcp"]
+	if got.Type != "http" {
+		t.Errorf("type = %q, want http", got.Type)
+	}
+	if got.URL != "https://memory.example.com/mcp" {
+		t.Errorf("url = %q", got.URL)
+	}
+	if got.Headers["CF-Access-Client-Id"] != "${CF_ACCESS_CLIENT_ID}" {
+		t.Errorf("header id = %q", got.Headers["CF-Access-Client-Id"])
+	}
+	if got.Headers["CF-Access-Client-Secret"] != "${CF_ACCESS_CLIENT_SECRET}" {
+		t.Errorf("header secret = %q", got.Headers["CF-Access-Client-Secret"])
+	}
+}
+
 func TestManager_Sync_NoSourceOrInline(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "bad", Target: filepath.Join(t.TempDir(), "mcp.json")},


### PR DESCRIPTION
## Summary

- Adds transport-aware inline MCP config fields for HTTP/SSE servers (`type`, `url`, `headers`) while preserving existing stdio `command`/`args`/`env` configs.
- Renders env-backed HTTP headers for Codex as `env_http_headers`, so generated config stores environment variable names instead of secret values.
- Renders JSON MCP targets with native HTTP `type`, `url`, and `headers` entries using env placeholders.
- Updates examples/docs and adds coverage for HTTP config validation, Codex TOML rendering, JSON rendering, and backwards-compatible stdio behavior.

Closes #215.

## Validation

- `go test ./internal/config ./internal/mcp`
- `make build`
- `make test`

## Secret handling

No Cloudflare Access credential values are included. The examples and tests only use placeholder environment variable names such as `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET`.
