### PR TITLE
refactor(skill,mcp): consume agent.Behavior for per-agent warnings (#208)

### DIFF
--- a/internal/core/agent/behavior.go
+++ b/internal/core/agent/behavior.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"sort"
 )
 
 // Scope identifies the kind of resource a [Behavior.Validate] call is
@@ -157,4 +158,65 @@ func behaviorFromInfo(name string, info Info) Behavior {
 		SupportsMCPProject: info.ProjectMCPConfigFile != "",
 		SupportedPlatforms: info.SupportedPlatforms,
 	}
+}
+
+// Group pairs a [Scope] with the list of agent names that operate at
+// that scope. Used by [CollectWarnings] to fan validation across the
+// project + global scopes a manager touches in a single sync.
+type Group struct {
+	Scope  Scope
+	Agents []string
+}
+
+// CollectWarnings runs [Behavior.Validate] for every (scope, agent)
+// combination in groups and returns the resulting warnings deduped by
+// (Code, Agent) and sorted by Code then Agent for stable output.
+//
+// Each agents slice may contain "*" which expands to every registered
+// agent (one entry per name in [Names]). Empty slices contribute no
+// warnings. Unknown agent names are silently ignored — the registry
+// already warns on those at lookup time.
+//
+// Dedup is by (Code, Agent), not (Code, Agent, Scope): the same fact
+// (e.g. claude-desktop unsupported on linux) only fires once across the
+// project + global scopes a single sync touches.
+func CollectWarnings(goos string, groups ...Group) []Warning {
+	slog.Debug("collecting agent behaviour warnings", "groups", len(groups), "goos", goos)
+	seen := map[string]struct{}{}
+	var out []Warning
+	for _, g := range groups {
+		for _, name := range expandAgents(g.Agents) {
+			b, ok := BehaviorFor(name)
+			if !ok {
+				continue
+			}
+			for _, w := range b.Validate(g.Scope, goos) {
+				key := string(w.Code) + ":" + w.Agent
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				seen[key] = struct{}{}
+				out = append(out, w)
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Code != out[j].Code {
+			return out[i].Code < out[j].Code
+		}
+		return out[i].Agent < out[j].Agent
+	})
+	return out
+}
+
+// expandAgents returns the list of agent names to validate. A single
+// "*" entry expands to every registered agent (sorted, for stable
+// output); anything else is returned as-is.
+func expandAgents(agents []string) []string {
+	if len(agents) == 1 && agents[0] == "*" {
+		all := Names()
+		sort.Strings(all)
+		return all
+	}
+	return agents
 }

--- a/internal/core/agent/behavior_test.go
+++ b/internal/core/agent/behavior_test.go
@@ -234,3 +234,101 @@ func TestBehaviorFor_ClaudeDesktopOnLinux_EmitsBothWarnings(t *testing.T) {
 		t.Error("expected WarnSkillsUnsupported for claude-desktop")
 	}
 }
+
+// ── CollectWarnings ─────────────────────────────────────────────────────────
+
+func TestCollectWarnings_Empty(t *testing.T) {
+	if got := agent.CollectWarnings("linux"); len(got) != 0 {
+		t.Errorf("no groups should yield no warnings, got %d", len(got))
+	}
+}
+
+func TestCollectWarnings_DedupesAcrossScopes(t *testing.T) {
+	// claude-desktop in both skill-global and skill-project on linux
+	// must emit each fact exactly once (WarnUnsupportedPlatform +
+	// WarnSkillsUnsupported), not duplicated per scope.
+	got := agent.CollectWarnings("linux",
+		agent.Group{Scope: agent.ScopeSkillGlobal, Agents: []string{"claude-desktop"}},
+		agent.Group{Scope: agent.ScopeSkillProject, Agents: []string{"claude-desktop"}},
+	)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 deduped warnings, got %d: %+v", len(got), got)
+	}
+	codes := map[agent.WarningCode]int{}
+	for _, w := range got {
+		codes[w.Code]++
+	}
+	if codes[agent.WarnUnsupportedPlatform] != 1 {
+		t.Errorf("WarnUnsupportedPlatform count = %d, want 1", codes[agent.WarnUnsupportedPlatform])
+	}
+	if codes[agent.WarnSkillsUnsupported] != 1 {
+		t.Errorf("WarnSkillsUnsupported count = %d, want 1", codes[agent.WarnSkillsUnsupported])
+	}
+}
+
+func TestCollectWarnings_ExpandsWildcard(t *testing.T) {
+	// "*" must surface claude-desktop's behaviour warnings on linux.
+	got := agent.CollectWarnings("linux",
+		agent.Group{Scope: agent.ScopeSkillGlobal, Agents: []string{"*"}},
+	)
+	foundSkills := false
+	foundPlatform := false
+	for _, w := range got {
+		if w.Agent == "claude-desktop" {
+			switch w.Code {
+			case agent.WarnSkillsUnsupported:
+				foundSkills = true
+			case agent.WarnUnsupportedPlatform:
+				foundPlatform = true
+			}
+		}
+	}
+	if !foundSkills {
+		t.Error("wildcard expansion should surface WarnSkillsUnsupported for claude-desktop")
+	}
+	if !foundPlatform {
+		t.Error("wildcard expansion should surface WarnUnsupportedPlatform for claude-desktop on linux")
+	}
+}
+
+func TestCollectWarnings_SilentForHappyAgents(t *testing.T) {
+	// claude-code on linux carries no behaviour warnings.
+	got := agent.CollectWarnings("linux",
+		agent.Group{Scope: agent.ScopeSkillProject, Agents: []string{"claude-code", "codex"}},
+		agent.Group{Scope: agent.ScopeMCPGlobal, Agents: []string{"claude-code"}},
+	)
+	if len(got) != 0 {
+		t.Errorf("expected no warnings, got %+v", got)
+	}
+}
+
+func TestCollectWarnings_UnknownAgentIgnored(t *testing.T) {
+	got := agent.CollectWarnings("linux",
+		agent.Group{Scope: agent.ScopeSkillProject, Agents: []string{"no-such-agent-xyz"}},
+	)
+	if len(got) != 0 {
+		t.Errorf("unknown agent must contribute no warnings, got %+v", got)
+	}
+}
+
+func TestCollectWarnings_StableOrder(t *testing.T) {
+	// Two runs of the same input must produce identical output. With
+	// wildcard expansion this is the riskiest sort path.
+	first := agent.CollectWarnings("linux",
+		agent.Group{Scope: agent.ScopeSkillGlobal, Agents: []string{"*"}},
+	)
+	for i := 0; i < 3; i++ {
+		next := agent.CollectWarnings("linux",
+			agent.Group{Scope: agent.ScopeSkillGlobal, Agents: []string{"*"}},
+		)
+		if len(next) != len(first) {
+			t.Fatalf("run %d: length drift %d != %d", i, len(next), len(first))
+		}
+		for j := range first {
+			if first[j].Code != next[j].Code || first[j].Agent != next[j].Agent {
+				t.Errorf("run %d slot %d: order drift first=(%s,%s) next=(%s,%s)",
+					i, j, first[j].Code, first[j].Agent, next[j].Code, next[j].Agent)
+			}
+		}
+	}
+}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -119,27 +119,42 @@ func (m *Manager) resolvedMCPs() []config.ConfigMcp {
 // or local environment but aren't tied to a single sync entry. Runs at most
 // once per Manager (gated by warnOnce) so the messages don't repeat across
 // resolvedMCPs calls from Sync, Status, and Prune.
+//
+// Per-agent behavioural constraints (unsupported platforms, project/global
+// MCP scope missing) come from [agent.CollectWarnings] — no hard-coded
+// agent names live here. The legacy-file check below is filesystem-state
+// based, not agent-name based, and is intentionally kept out of Behavior.
 func (m *Manager) emitConfigWarnings() {
-	m.warnClaudeDesktopOnLinux()
+	m.emitBehaviorWarnings()
 	m.warnLegacyClaudeDesktopJSON()
 }
 
-// warnClaudeDesktopOnLinux flags MCP entries that target the claude-desktop
-// agent on Linux. Claude Desktop is officially macOS- and Windows-only; gaal
-// would write to ~/Library/Application Support/Claude/ which the (community)
-// Linux builds, if any, do not consume.
-func (m *Manager) warnClaudeDesktopOnLinux() {
-	if runtime.GOOS != "linux" {
-		return
-	}
+// emitBehaviorWarnings groups the configured MCP entries by scope and
+// asks the agent registry for the behaviour mismatches that apply.
+//
+// Entries using the deprecated `target:` field are skipped here — they
+// bypass agent resolution entirely (a separate deprecation warning fires
+// inside resolvedMCPs). Entries with neither `target:` nor `agents:` are
+// also skipped.
+func (m *Manager) emitBehaviorWarnings() {
+	var projectAgents, globalAgents []string
 	for _, mc := range m.mcps {
-		for _, a := range mc.Agents {
-			if a == "claude-desktop" || a == "*" {
-				slog.Warn("mcp: claude-desktop is officially macOS- and Windows-only — sync targets ~/Library/Application Support/Claude/ which has no effect on Linux",
-					"hint", "remove claude-desktop from agents:, or list agents explicitly without it")
-				return
-			}
+		if mc.Target != "" || len(mc.Agents) == 0 {
+			continue
 		}
+		if mc.Global {
+			globalAgents = append(globalAgents, mc.Agents...)
+		} else {
+			projectAgents = append(projectAgents, mc.Agents...)
+		}
+	}
+	warnings := agent.CollectWarnings(runtime.GOOS,
+		agent.Group{Scope: agent.ScopeMCPProject, Agents: projectAgents},
+		agent.Group{Scope: agent.ScopeMCPGlobal, Agents: globalAgents},
+	)
+	for _, w := range warnings {
+		slog.Warn("mcp: "+w.Msg,
+			"agent", w.Agent, "scope", w.Scope, "code", w.Code, "hint", w.Hint)
 	}
 }
 

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -116,17 +116,15 @@ func (m *Manager) resolvedMCPs() []config.ConfigMcp {
 }
 
 // emitConfigWarnings surfaces issues that depend on the user's MCP config
-// or local environment but aren't tied to a single sync entry. Runs at most
-// once per Manager (gated by warnOnce) so the messages don't repeat across
-// resolvedMCPs calls from Sync, Status, and Prune.
+// but aren't tied to a single sync entry. Runs at most once per Manager
+// (gated by warnOnce) so the messages don't repeat across resolvedMCPs
+// calls from Sync, Status, and Prune.
 //
 // Per-agent behavioural constraints (unsupported platforms, project/global
 // MCP scope missing) come from [agent.CollectWarnings] — no hard-coded
-// agent names live here. The legacy-file check below is filesystem-state
-// based, not agent-name based, and is intentionally kept out of Behavior.
+// agent names live here.
 func (m *Manager) emitConfigWarnings() {
 	m.emitBehaviorWarnings()
-	m.warnLegacyClaudeDesktopJSON()
 }
 
 // emitBehaviorWarnings groups the configured MCP entries by scope and
@@ -156,24 +154,6 @@ func (m *Manager) emitBehaviorWarnings() {
 		slog.Warn("mcp: "+w.Msg,
 			"agent", w.Agent, "scope", w.Scope, "code", w.Code, "hint", w.Hint)
 	}
-}
-
-// warnLegacyClaudeDesktopJSON detects the file gaal used to write under the
-// (incorrect) claude-code path: ~/.config/claude/claude_desktop_config.json.
-// Neither Claude Code (~/.claude.json) nor Claude Desktop (macOS:
-// ~/Library/Application Support/Claude/, Windows: %APPDATA%\Claude\) reads
-// it, so users carrying it from older gaal versions can safely delete it.
-func (m *Manager) warnLegacyClaudeDesktopJSON() {
-	if m.home == "" {
-		return
-	}
-	legacy := filepath.Join(m.home, ".config", "claude", "claude_desktop_config.json")
-	if _, err := os.Stat(legacy); err != nil {
-		return
-	}
-	slog.Warn("mcp: stale ~/.config/claude/claude_desktop_config.json detected — neither Claude Code nor Claude Desktop reads this path; safe to delete",
-		"path", legacy,
-		"hint", "Claude Code now writes ~/.claude.json; Claude Desktop uses ~/Library/Application Support/Claude/")
 }
 
 // Sync applies every MCP configuration entry. A failure on one entry does not

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -1076,7 +1076,13 @@ func TestWarnLegacyClaudeDesktopJSON_SilentWhenAbsent(t *testing.T) {
 	}
 }
 
-func TestWarnClaudeDesktopOnLinux_FiresForExplicitTarget(t *testing.T) {
+// ── behaviour warnings (via internal/core/agent) ───────────────────────────
+
+// TestEmitBehaviorWarnings_FiresForExplicitClaudeDesktop is the regression
+// for #208 / former TestWarnClaudeDesktopOnLinux_FiresForExplicitTarget:
+// on Linux, an MCP entry targeting claude-desktop must produce
+// WarnUnsupportedPlatform via the data-driven Behavior registry.
+func TestEmitBehaviorWarnings_FiresForExplicitClaudeDesktop(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Linux-only assertion; behavior intentionally differs on macOS/Windows")
 	}
@@ -1086,14 +1092,17 @@ func TestWarnClaudeDesktopOnLinux_FiresForExplicitTarget(t *testing.T) {
 	}
 	out := captureSlog(t, func() {
 		m := NewManager(mcps, "/home/u", "")
-		m.warnClaudeDesktopOnLinux()
+		m.emitBehaviorWarnings()
 	})
-	if !strings.Contains(out, "claude-desktop is officially macOS- and Windows-only") {
-		t.Errorf("expected linux unsupported warning, got: %s", out)
+	if !strings.Contains(out, "code=unsupported_platform") {
+		t.Errorf("expected unsupported_platform warning code, got: %s", out)
+	}
+	if !strings.Contains(out, "agent=claude-desktop") {
+		t.Errorf("expected agent=claude-desktop attribute, got: %s", out)
 	}
 }
 
-func TestWarnClaudeDesktopOnLinux_FiresForWildcardAgents(t *testing.T) {
+func TestEmitBehaviorWarnings_FiresForWildcardAgents(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Linux-only assertion")
 	}
@@ -1103,27 +1112,67 @@ func TestWarnClaudeDesktopOnLinux_FiresForWildcardAgents(t *testing.T) {
 	}
 	out := captureSlog(t, func() {
 		m := NewManager(mcps, "/home/u", "")
-		m.warnClaudeDesktopOnLinux()
+		m.emitBehaviorWarnings()
 	})
-	if !strings.Contains(out, "claude-desktop") {
-		t.Errorf("expected warning for wildcard agents on Linux, got: %s", out)
+	if !strings.Contains(out, "code=unsupported_platform") || !strings.Contains(out, "agent=claude-desktop") {
+		t.Errorf("expected wildcard expansion to surface unsupported_platform for claude-desktop, got: %s", out)
 	}
 }
 
-func TestWarnClaudeDesktopOnLinux_SilentForOtherAgents(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("Linux-only assertion")
-	}
+func TestEmitBehaviorWarnings_SilentForHappyAgents(t *testing.T) {
 	mcps := []config.ConfigMcp{
 		{Name: "x", Agents: []string{"claude-code", "codex"}, Global: true,
 			Inline: &config.ConfigMcpItem{Command: "node"}},
 	}
 	out := captureSlog(t, func() {
 		m := NewManager(mcps, "/home/u", "")
-		m.warnClaudeDesktopOnLinux()
+		m.emitBehaviorWarnings()
 	})
-	if strings.Contains(out, "claude-desktop") {
-		t.Errorf("expected no warning for non-claude-desktop agents, got: %s", out)
+	if strings.Contains(out, "code=unsupported_platform") {
+		t.Errorf("expected no platform warning for happy agents, got: %s", out)
+	}
+	if strings.Contains(out, "code=mcp_global_unsupported") || strings.Contains(out, "code=mcp_project_unsupported") {
+		t.Errorf("expected no MCP-scope warnings for claude-code / codex, got: %s", out)
+	}
+}
+
+// TestEmitBehaviorWarnings_DedupesAcrossScopes regresses the
+// pre-refactor behaviour where the same (Code, Agent) pair logged once
+// per matching entry. Multiple claude-desktop entries across both
+// scopes must produce one platform warning, not three.
+func TestEmitBehaviorWarnings_DedupesAcrossScopes(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only assertion")
+	}
+	mcps := []config.ConfigMcp{
+		{Name: "a", Agents: []string{"claude-desktop"}, Global: true, Inline: &config.ConfigMcpItem{Command: "node"}},
+		{Name: "b", Agents: []string{"claude-desktop"}, Global: false, Inline: &config.ConfigMcpItem{Command: "node"}},
+		{Name: "c", Agents: []string{"claude-desktop"}, Global: false, Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(mcps, "/home/u", "")
+		m.emitBehaviorWarnings()
+	})
+	if got := strings.Count(out, "code=unsupported_platform"); got != 1 {
+		t.Errorf("expected unsupported_platform to fire exactly once across scopes, fired %d times: %s", got, out)
+	}
+}
+
+// TestEmitBehaviorWarnings_FiresMCPProjectUnsupported asserts the new
+// project-scope MCP warning that was not surfaced before #208 — e.g.
+// windsurf has no project MCP config, so a `global: false` entry is a
+// silent no-op the user should be told about.
+func TestEmitBehaviorWarnings_FiresMCPProjectUnsupported(t *testing.T) {
+	mcps := []config.ConfigMcp{
+		{Name: "x", Agents: []string{"windsurf"}, Global: false,
+			Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(mcps, "/home/u", "")
+		m.emitBehaviorWarnings()
+	})
+	if !strings.Contains(out, "code=mcp_project_unsupported") || !strings.Contains(out, "agent=windsurf") {
+		t.Errorf("expected mcp_project_unsupported for windsurf, got: %s", out)
 	}
 }
 

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -1046,36 +1046,6 @@ func captureSlog(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-func TestWarnLegacyClaudeDesktopJSON_DetectsStaleFile(t *testing.T) {
-	home := t.TempDir()
-	stale := filepath.Join(home, ".config", "claude", "claude_desktop_config.json")
-	if err := os.MkdirAll(filepath.Dir(stale), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(stale, []byte("{}"), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	out := captureSlog(t, func() {
-		m := NewManager(nil, home, "")
-		m.warnLegacyClaudeDesktopJSON()
-	})
-	if !strings.Contains(out, "stale ~/.config/claude/claude_desktop_config.json") {
-		t.Errorf("expected legacy warning, got: %s", out)
-	}
-}
-
-func TestWarnLegacyClaudeDesktopJSON_SilentWhenAbsent(t *testing.T) {
-	home := t.TempDir() // no legacy file present
-	out := captureSlog(t, func() {
-		m := NewManager(nil, home, "")
-		m.warnLegacyClaudeDesktopJSON()
-	})
-	if strings.Contains(out, "stale") {
-		t.Errorf("expected no warning when legacy file is absent, got: %s", out)
-	}
-}
-
 // ── behaviour warnings (via internal/core/agent) ───────────────────────────
 
 // TestEmitBehaviorWarnings_FiresForExplicitClaudeDesktop is the regression
@@ -1177,21 +1147,21 @@ func TestEmitBehaviorWarnings_FiresMCPProjectUnsupported(t *testing.T) {
 }
 
 func TestEmitConfigWarnings_FiresOncePerManager(t *testing.T) {
-	home := t.TempDir()
-	stale := filepath.Join(home, ".config", "claude", "claude_desktop_config.json")
-	os.MkdirAll(filepath.Dir(stale), 0o755)
-	os.WriteFile(stale, []byte("{}"), 0o644)
-
+	// windsurf has no project MCP — sync.Once must ensure the
+	// resulting mcp_project_unsupported warning fires once even though
+	// Sync, Status, and Prune each call resolvedMCPs.
+	mcps := []config.ConfigMcp{
+		{Name: "x", Agents: []string{"windsurf"}, Global: false,
+			Inline: &config.ConfigMcpItem{Command: "node"}},
+	}
 	out := captureSlog(t, func() {
-		m := NewManager(nil, home, "")
-		// Multiple resolvedMCPs calls (Sync, Status, Prune all use it) must
-		// not duplicate the warning.
+		m := NewManager(mcps, "/home/u", "")
 		_ = m.resolvedMCPs()
 		_ = m.resolvedMCPs()
 		_ = m.resolvedMCPs()
 	})
-	count := strings.Count(out, "stale ~/.config/claude/claude_desktop_config.json")
+	count := strings.Count(out, "code=mcp_project_unsupported")
 	if count != 1 {
-		t.Errorf("expected legacy warning to fire exactly once, fired %d times", count)
+		t.Errorf("expected warning to fire exactly once, fired %d times", count)
 	}
 }

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -9,10 +9,12 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
 	"gaal/internal/config"
+	"gaal/internal/core/agent"
 	"gaal/internal/core/vcs"
 	"gaal/internal/discover"
 	"gaal/internal/urlx"
@@ -141,25 +143,34 @@ func (m *Manager) Sync(ctx context.Context) error {
 // emitConfigWarnings surfaces issues that depend on the user's skill config
 // but aren't tied to a single source. Runs at most once per Manager (gated
 // by warnOnce) so the messages don't repeat across Sync and Status.
+//
+// Per-agent behavioural constraints (skills unsupported, platform
+// restrictions) come from [agent.CollectWarnings] — no hard-coded agent
+// names live here.
 func (m *Manager) emitConfigWarnings() {
-	m.warnOnce.Do(m.warnSkillsTargetingClaudeDesktop)
+	m.warnOnce.Do(m.emitBehaviorWarnings)
 }
 
-// warnSkillsTargetingClaudeDesktop fires when any skill entry targets the
-// claude-desktop agent (explicitly or via the "*" wildcard). Claude Desktop
-// has no on-disk SKILL.md feature — that's a Claude Code CLI–only capability
-// — so the install would land in ~/.agents/skills/ (the generic convention)
-// where Claude Desktop never reads. Better to tell the user upfront than to
-// report a green ✓ for a no-op.
-func (m *Manager) warnSkillsTargetingClaudeDesktop() {
+// emitBehaviorWarnings groups the configured skill entries by scope and
+// asks the agent registry for the behaviour mismatches that apply. One
+// log line per unique (Code, Agent), so wildcard expansion does not
+// produce one warning per matching agent.
+func (m *Manager) emitBehaviorWarnings() {
+	var projectAgents, globalAgents []string
 	for _, sc := range m.skills {
-		for _, a := range sc.Agents {
-			if a == "claude-desktop" || a == "*" {
-				slog.Warn("skill: claude-desktop has no on-disk SKILL.md feature — entries targeting it will install under ~/.agents/skills (or .agents/skills) which Claude Desktop does not read",
-					"hint", "skills are a Claude Code CLI feature; remove claude-desktop from agents:, or list agents explicitly without it")
-				return
-			}
+		if sc.Global {
+			globalAgents = append(globalAgents, sc.Agents...)
+		} else {
+			projectAgents = append(projectAgents, sc.Agents...)
 		}
+	}
+	warnings := agent.CollectWarnings(runtime.GOOS,
+		agent.Group{Scope: agent.ScopeSkillProject, Agents: projectAgents},
+		agent.Group{Scope: agent.ScopeSkillGlobal, Agents: globalAgents},
+	)
+	for _, w := range warnings {
+		slog.Warn("skill: "+w.Msg,
+			"agent", w.Agent, "scope", w.Scope, "code", w.Code, "hint", w.Hint)
 	}
 }
 

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -925,7 +925,7 @@ func TestPrune_NoOpWhenAllManaged(t *testing.T) {
 	}
 }
 
-// ── claude-desktop warning ──────────────────────────────────────────────────
+// ── behaviour warnings (via internal/core/agent) ───────────────────────────
 
 // captureSlog redirects slog output to a buffer for the duration of fn.
 func captureSlog(t *testing.T, fn func()) string {
@@ -938,43 +938,72 @@ func captureSlog(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-func TestWarnSkillsTargetingClaudeDesktop_FiresForExplicitTarget(t *testing.T) {
+// TestEmitBehaviorWarnings_FiresForExplicitClaudeDesktop is the regression
+// for #208 / former TestWarnSkillsTargetingClaudeDesktop_FiresForExplicitTarget:
+// declaring claude-desktop as a skill target must produce
+// WarnSkillsUnsupported via the data-driven Behavior registry.
+func TestEmitBehaviorWarnings_FiresForExplicitClaudeDesktop(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: "owner/repo", Agents: []string{"claude-desktop"}, Global: true},
 	}
 	out := captureSlog(t, func() {
 		m := NewManager(skills, t.TempDir(), "/home/u", t.TempDir(), t.TempDir(), false)
-		m.warnSkillsTargetingClaudeDesktop()
+		m.emitConfigWarnings()
 	})
-	if !strings.Contains(out, "claude-desktop has no on-disk SKILL.md feature") {
-		t.Errorf("expected claude-desktop skills warning, got: %s", out)
+	if !strings.Contains(out, "code=skills_unsupported") {
+		t.Errorf("expected skills_unsupported warning code in log, got: %s", out)
+	}
+	if !strings.Contains(out, "agent=claude-desktop") {
+		t.Errorf("expected agent=claude-desktop attribute in log, got: %s", out)
 	}
 }
 
-func TestWarnSkillsTargetingClaudeDesktop_FiresForWildcardAgents(t *testing.T) {
+func TestEmitBehaviorWarnings_FiresForWildcardAgents(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: "owner/repo", Agents: []string{"*"}, Global: true},
 	}
 	out := captureSlog(t, func() {
 		m := NewManager(skills, t.TempDir(), "/home/u", t.TempDir(), t.TempDir(), false)
-		m.warnSkillsTargetingClaudeDesktop()
+		m.emitConfigWarnings()
 	})
-	if !strings.Contains(out, "claude-desktop") {
-		t.Errorf("expected warning for wildcard agents, got: %s", out)
+	if !strings.Contains(out, "code=skills_unsupported") || !strings.Contains(out, "agent=claude-desktop") {
+		t.Errorf("expected wildcard expansion to surface claude-desktop skills_unsupported, got: %s", out)
 	}
 }
 
-func TestWarnSkillsTargetingClaudeDesktop_SilentForOtherAgents(t *testing.T) {
+func TestEmitBehaviorWarnings_SilentForHappyAgents(t *testing.T) {
 	skills := []config.ConfigSkill{
 		{Source: "owner/repo", Agents: []string{"claude-code", "codex"}, Global: true},
 		{Source: "owner/other", Agents: []string{"cursor"}, Global: false},
 	}
 	out := captureSlog(t, func() {
 		m := NewManager(skills, t.TempDir(), "/home/u", t.TempDir(), t.TempDir(), false)
-		m.warnSkillsTargetingClaudeDesktop()
+		m.emitConfigWarnings()
 	})
-	if strings.Contains(out, "claude-desktop") {
-		t.Errorf("expected no warning for non-claude-desktop agents, got: %s", out)
+	if strings.Contains(out, "code=skills_unsupported") {
+		t.Errorf("expected no skills_unsupported warning for non-claude-desktop agents, got: %s", out)
+	}
+	if strings.Contains(out, "code=unsupported_platform") {
+		t.Errorf("expected no platform warning for happy agents, got: %s", out)
+	}
+}
+
+// TestEmitBehaviorWarnings_DedupesAcrossScopes is a regression for the
+// pre-refactor behaviour where multiple skill entries targeting
+// claude-desktop produced multiple identical log lines. The new system
+// dedupes by (Code, Agent) regardless of how many entries match.
+func TestEmitBehaviorWarnings_DedupesAcrossScopes(t *testing.T) {
+	skills := []config.ConfigSkill{
+		{Source: "a/x", Agents: []string{"claude-desktop"}, Global: true},
+		{Source: "a/y", Agents: []string{"claude-desktop"}, Global: false},
+		{Source: "a/z", Agents: []string{"claude-desktop"}, Global: false},
+	}
+	out := captureSlog(t, func() {
+		m := NewManager(skills, t.TempDir(), "/home/u", t.TempDir(), t.TempDir(), false)
+		m.emitConfigWarnings()
+	})
+	if got := strings.Count(out, "code=skills_unsupported"); got != 1 {
+		t.Errorf("expected skills_unsupported to fire exactly once across scopes, fired %d times: %s", got, out)
 	}
 }
 
@@ -990,7 +1019,7 @@ func TestEmitConfigWarnings_FiresOncePerManager(t *testing.T) {
 		m.emitConfigWarnings()
 		m.emitConfigWarnings()
 	})
-	count := strings.Count(out, "claude-desktop has no on-disk SKILL.md feature")
+	count := strings.Count(out, "code=skills_unsupported")
 	if count != 1 {
 		t.Errorf("expected warning to fire exactly once, fired %d times", count)
 	}


### PR DESCRIPTION
## Summary

Closes #208. **Stacked on top of #222** — GitHub will retarget this PR at \`main\` automatically once #222 merges.

Replaces the hard-coded agent-name checks the issue called out with calls into the data-driven \`Behavior\` registry introduced in #222, and removes a stale legacy-file warning that no longer earns its keep.

## Changes

### Call-site migration

- **\`internal/skill/manager.go\`** — delete \`warnSkillsTargetingClaudeDesktop\`. \`emitConfigWarnings\` now groups \`m.skills\` by global/project, builds two \`agent.Group\` inputs, and emits one \`slog.Warn\` per (Code, Agent) the registry reports.
- **\`internal/mcp/manager.go\`** — delete \`warnClaudeDesktopOnLinux\` AND \`warnLegacyClaudeDesktopJSON\`. The first becomes \`emitBehaviorWarnings\` using the same group/expand/validate pattern. The second was a 13-day-old migration breadcrumb (shipped in #93 on 2026-05-02) for a stale file no agent reads — pre-1.0, harmless to leave on disk, not worth a stat() + log line on every sync. Entries using the deprecated \`target:\` field are skipped for behaviour checks: they bypass agent resolution by design and already log their own deprecation warning.

### New shared helper

\`agent.CollectWarnings(goos string, groups ...agent.Group) []agent.Warning\` (in [internal/core/agent/behavior.go](internal/core/agent/behavior.go)) centralises:
- \`\"*\"\` wildcard expansion to \`Names()\`
- per-(scope, agent) \`Validate()\` invocation
- dedup by (Code, Agent) — same fact never repeats across scopes
- stable sort by (Code, Agent)

Both managers call it the same way so wildcard, dedup, and ordering semantics stay aligned.

### Newly-surfaced warnings (regressions guarded by tests)

The refactor doesn't only refactor — it lights up rules the old hard-coded checks never had:

| Code | Agent(s) affected | Trigger |
|------|-------------------|---------|
| \`mcp_project_unsupported\` | antigravity, claude-desktop, cline, goose, windsurf, zencoder | project-scope MCP entry against an agent with no project MCP file |
| \`mcp_global_unsupported\` | generic (etc.) | global-scope MCP entry against an agent with no global MCP file |
| \`skills_unsupported\` | claude-desktop | any skill entry |
| \`unsupported_platform\` | claude-desktop on linux | any entry on linux |

Existing user configs that hit these cases used to silently no-op; they now fire one log line each.

## Tests

- **\`internal/core/agent/behavior_test.go\`** — new \`CollectWarnings\` cases: dedup-across-scopes, wildcard expansion, happy-path silence, unknown-agent ignored, stable order across repeat runs.
- **\`internal/skill/manager_test.go\`** — the three former \`TestWarnSkillsTargetingClaudeDesktop_*\` cases now assert on the \`WarningCode\` set in the log attributes (\`code=skills_unsupported\`, \`agent=claude-desktop\`) rather than a fixed message string. \`TestEmitConfigWarnings_FiresOncePerManager\` preserved. New \`TestEmitBehaviorWarnings_DedupesAcrossScopes\` locks in the dedup contract.
- **\`internal/mcp/manager_test.go\`** — same shape for the linux-platform case. \`TestWarnLegacyClaudeDesktopJSON_*\` deleted along with the helper. \`TestEmitConfigWarnings_FiresOncePerManager\` rewritten to trip on \`mcp_project_unsupported\` (windsurf, OS-independent) — sync.Once contract preserved. New \`TestEmitBehaviorWarnings_FiresMCPProjectUnsupported\` locks in a newly-surfaced rule.

## Test plan

- [x] \`make build\` succeeds; schema regenerates cleanly.
- [x] \`make test\` — all packages green.
- [x] \`make lint\` — \`gofmt\` + \`go vet\` clean.
- [x] \`go test -cover ./internal/core/agent/...\` — \`behavior.go\`: \`Validate\`/\`BehaviorFor\`/\`behaviorFromInfo\`/\`expandAgents\` at 100%, \`CollectWarnings\` at 94.7%.
- [ ] Cross-platform CI on macOS + Windows.