### PR TITLE
feat(sync): pre-sync and post-sync hooks (#219)

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -101,6 +101,15 @@ func runSync(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	if err := eng.Hooks().RunPreSync(ctx, plan); err != nil {
+		fmt.Fprintln(os.Stderr, "⚠ pre-sync hook failed; aborting sync")
+		telemetry.TrackError("sync-hook-pre", err)
+		return err
+	}
+	if err := checkInterrupted(ctx); err != nil {
+		return err
+	}
+
 	start := time.Now()
 	if err := eng.RunOnce(ctx); err != nil {
 		telemetry.TrackError("sync", err)
@@ -134,6 +143,12 @@ func runSync(_ *cobra.Command, _ []string) error {
 		if rerr != nil {
 			slog.Debug("rendering sync summary failed", "err", rerr)
 		}
+	}
+
+	if err := eng.Hooks().RunPostSync(ctx, plan); err != nil {
+		fmt.Fprintln(os.Stderr, "⚠ post-sync hook failed")
+		telemetry.TrackError("sync-hook-post", err)
+		return err
 	}
 
 	telemetry.Track("sync")

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -294,6 +294,96 @@ silently filling logs forever. Successful iterations reset the counter.
 
 ---
 
+## Hooks
+
+User-defined commands can run before and after sync. The shape is
+**exec-form**: `command + args[]`, no shell. The same `gaal.yaml`
+therefore works on Linux, macOS, and Windows; users who need pipes or
+redirection invoke a script by path instead.
+
+```yaml
+hooks:
+  pre-sync:
+    - name: "snapshot working copies"
+      command: ./scripts/backup.sh
+      os: [linux, darwin]
+      timeout: 1m
+      continue_on_error: true
+  post-sync:
+    - command: git
+      args: ["-C", "~/.claude", "pull"]
+```
+
+### Execution order
+
+```mermaid
+flowchart LR
+    A[gaal sync] --> B[plan]
+    B --> C[pre-sync hooks]
+    C --> D{ok?}
+    D -- no --> Z1([abort: pre-sync failed])
+    D -- yes --> E[RunOnce]
+    E --> F{ok?}
+    F -- no --> Z2([exit 2: sync error, skip post-sync])
+    F -- yes --> G[--prune?]
+    G --> H[summary]
+    H --> I[post-sync hooks]
+    I --> J([exit 0])
+```
+
+- **pre-sync** runs before any resource is touched. A non-zero exit
+  aborts the sync, unless the hook sets `continue_on_error: true`.
+- **post-sync** runs only when sync and any `--prune` succeeded.
+  Skipped on every error path — the issue requirement that hooks fire
+  strictly on success.
+- Hooks run sequentially in declared order. Cross-config-level layering
+  is concat: workspace-level hooks fire after user-level hooks at the
+  same phase.
+
+### Cross-platform notes
+
+- Tokens `~/`, `$VAR`, `${VAR}` in `args`, `cwd`, and `env` values are
+  expanded against the host environment at run time, so a single config
+  file can target multiple machines.
+- The optional `os: [linux, darwin, windows]` filter skips a hook on
+  platforms where it doesn't apply. Values are matched case-insensitively
+  against Go's `runtime.GOOS`.
+- The `command` field is **not** shell-interpolated. Use a script if you
+  need pipes, redirections, or globs.
+
+### Hook environment payload
+
+Every hook inherits gaal's environment plus:
+
+| Variable | Value |
+|----------|-------|
+| `GAAL_HOOK_PHASE` | `pre-sync` or `post-sync` |
+| `GAAL_PLANNED_REPOS` / `GAAL_CHANGED_REPOS` | newline-separated repo paths that would change / did change |
+| `GAAL_PLANNED_SKILLS` / `GAAL_CHANGED_SKILLS` | newline-separated `agent:source` rows |
+| `GAAL_PLANNED_MCPS` / `GAAL_CHANGED_MCPS` | newline-separated MCP names |
+| `GAAL_HAS_CHANGES` | `1` if the plan touches any resource, else `0` |
+| `GAAL_HAS_ERRORS` | `1` if the plan saw errors, else `0` |
+
+Both the `PLANNED_*` and `CHANGED_*` variables carry the same payload —
+the framing exists so a hook can self-document whether it cares about
+intent vs. outcome. An empty list is the empty string, so shells can
+test with `[[ -z "$GAAL_CHANGED_MCPS" ]] && exit 0`.
+
+### Service mode
+
+Hooks fire on every iteration. A failing hook never breaks the daemon
+loop — pre-sync failure skips that iteration's sync; post-sync failure
+is logged but the loop continues. This matches the rest of service-mode
+error handling: log and recover, don't exit.
+
+### Dry-run
+
+`gaal sync --dry-run` lists hooks under `pre-sync hooks` and `post-sync
+hooks` sections with one row per hook, marker `>` for "would run" and
+`-` for "skipped" (e.g. by an `os:` filter). The hook is never invoked.
+
+---
+
 ## Tooling probe
 
 Before running, `warnMissingTools(cfg)` prints a stderr banner listing
@@ -325,6 +415,7 @@ that would otherwise come later. See [`packages/tools.md`](../packages/tools.md)
 | Agent MCP config (e.g. `~/.claude.json`, `~/.codex/config.toml`, `~/.cursor/mcp.json`) | upsert (atomic 0o600 write) | `internal/mcp` |
 | `~/.cache/gaal/state/<key>.json` (snapshot index) | write | `internal/discover` |
 | `~/.local/state/gaal/telemetry.jsonl` (when consented) | append (0o600) | `internal/telemetry` |
+| arbitrary, via `hooks:` declarations | exec subprocess | `internal/engine/hooks` |
 
 In `--sandbox <dir>` mode, every `~/...` path above is rewritten under
 `<dir>/...` via `applyOptions`. Real user state is untouched.

--- a/docs/config.md
+++ b/docs/config.md
@@ -111,6 +111,9 @@ Config
 ├── Skills        []ConfigSkill
 ├── MCPs          []ConfigMcp
 │                   └── Inline  *ConfigMcpItem
+├── Hooks         *ConfigHooks
+│                   ├── PreSync  []ConfigHook
+│                   └── PostSync []ConfigHook
 ├── Telemetry     *bool          gaal:"maxscope=user"
 └── SourcePath    string         yaml:"-"  (runtime only)
 ```
@@ -139,6 +142,7 @@ Per-field merge rules:
 | `repositories` | Map merge — source entry wins on key conflict |
 | `skills` | Upsert by `Source` — source entry replaces the existing entry with the same `Source` |
 | `mcps` | Upsert by `Name` — source entry replaces the existing entry with the same `Name` |
+| `hooks` | Append — higher-priority hooks run *after* lower-priority ones at the same phase, so workspace-level hooks fire last |
 
 Intra-file duplicates (same `Source` or `Name` within a single file) are
 silently dropped, keeping the first occurrence. Cross-level deduplication

--- a/example.gaal.yaml
+++ b/example.gaal.yaml
@@ -185,3 +185,53 @@ tools:
     hint: "cargo install rtk"
   - name: fnm                # Fast Node manager
     hint: "https://github.com/Schniz/fnm#installation"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# hooks
+#
+# Run user-defined commands before and after every successful sync. Hooks
+# use exec-form (command + args[]) so they remain portable across Linux,
+# macOS, and Windows — no shell is involved.
+#
+# pre-sync runs before any resource is touched. A non-zero exit aborts the
+#          sync (unless continue_on_error: true). Use for backups, gating
+#          checks, etc. Pre-sync hooks see GAAL_PLANNED_REPOS,
+#          GAAL_PLANNED_SKILLS, GAAL_PLANNED_MCPS env vars describing what
+#          sync intends to change.
+#
+# post-sync runs only when sync (and any --prune) succeeded. Skipped on any
+#          sync error. Post-sync hooks see GAAL_CHANGED_REPOS,
+#          GAAL_CHANGED_SKILLS, GAAL_CHANGED_MCPS env vars (newline-separated
+#          lists) describing what actually changed.
+#
+# Fields:
+#   name              — optional label shown in logs and dry-run output
+#   command           — executable; found on PATH unless given as a path
+#   args              — list of arguments. ~/, $VAR, ${VAR} are expanded.
+#   cwd               — working directory; defaults to gaal's workdir
+#   os                — restrict to [linux | darwin | windows]; empty = all
+#   timeout           — Go duration string, e.g. "30s", "2m". Default 5m.
+#   continue_on_error — true → log a warning and keep going on non-zero exit
+#   env               — extra environment variables for this hook
+# ─────────────────────────────────────────────────────────────────────────────
+hooks:
+  pre-sync:
+    - name: "snapshot working copies"
+      command: ./scripts/backup.sh
+      os: [linux, darwin]
+      timeout: 1m
+      continue_on_error: true
+
+  post-sync:
+    # Keep ~/.claude in sync with the dotclaude working copy after gaal
+    # has updated everything else. Runs on every OS.
+    - name: "pull dotclaude into ~/.claude"
+      command: git
+      args: ["-C", "~/.claude", "pull"]
+
+    # Reload an MCP-using agent only when the MCP config actually changed.
+    - name: "kick claude-code on mcp changes"
+      command: sh
+      args: ["-c", "test -n \"$GAAL_CHANGED_MCPS\" && pkill -HUP -f claude-code || true"]
+      os: [linux, darwin]
+      continue_on_error: true

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/invopop/jsonschema"
 	"gopkg.in/yaml.v3"
@@ -13,6 +14,11 @@ import (
 	"gaal/internal/config/platform"
 	"gaal/internal/config/schema"
 )
+
+// DefaultHookTimeout is the timeout applied when a hook does not declare one.
+// Long enough to cover slow git pulls and most install scripts, short enough
+// that a wedged hook does not stall an interactive sync indefinitely.
+const DefaultHookTimeout = 5 * time.Minute
 
 // ── Structures ────────────────────────────────────────────────────────────────
 
@@ -25,11 +31,54 @@ type Config struct {
 	Skills       []ConfigSkill         `yaml:"skills"       json:"skills,omitempty"       jsonschema:"description=Skill sources to install into agent skill directories"   validate:"dive"`
 	MCPs         []ConfigMcp           `yaml:"mcps"         json:"mcps,omitempty"         jsonschema:"description=MCP server configuration entries to merge"             validate:"dive"`
 	Tools        []ConfigTool          `yaml:"tools,omitempty" json:"tools,omitempty"    jsonschema:"description=CLI tools expected to be on PATH; gaal doctor/sync report any missing ones" validate:"dive"`
+	Hooks        *ConfigHooks          `yaml:"hooks,omitempty" json:"hooks,omitempty" jsonschema:"description=User-defined commands to run before and after sync"`
 	Telemetry    *bool                 `yaml:"telemetry,omitempty" json:"telemetry,omitempty" jsonschema:"description=Opt-in anonymous usage telemetry (true/false)" gaal:"maxscope=user"`
 
 	// SourcePath is populated at runtime by Load and never written to disk.
 	// It holds the path of the file this Config was loaded from.
 	SourcePath string `yaml:"-" json:"-" jsonschema:"-"`
+}
+
+// ConfigHooks groups user-defined commands that gaal runs around the sync
+// pipeline. pre-sync hooks run before any resource is touched; post-sync hooks
+// run only after a successful sync.
+type ConfigHooks struct {
+	PreSync  []ConfigHook `yaml:"pre-sync,omitempty"  json:"pre-sync,omitempty"  jsonschema:"description=Commands to run before sync. A non-zero exit aborts the sync (unless continue_on_error is true)." validate:"dive"`
+	PostSync []ConfigHook `yaml:"post-sync,omitempty" json:"post-sync,omitempty" jsonschema:"description=Commands to run after a successful sync. Skipped when sync had errors."                          validate:"dive"`
+}
+
+// ConfigHook is one user-defined command invoked by gaal at a hook point.
+//
+// Hooks use exec-form (command + args[]) so they remain portable across
+// Linux, macOS, and Windows. No shell is involved: tokens are passed
+// verbatim, and metacharacters like '|' or '>' are not interpreted. Users
+// who need shell features should invoke a script by path.
+//
+// Path-like tokens ('~/...', '$VAR', '${VAR}') in Args, Cwd, and Env values
+// are expanded at run time against the host environment.
+type ConfigHook struct {
+	Name            string            `yaml:"name,omitempty"              json:"name,omitempty"              jsonschema:"description=Optional human-readable label shown in logs and dry-run output"`
+	Command         string            `yaml:"command"                     json:"command"                     jsonschema:"description=Executable to run. Looked up on PATH unless an absolute or ~-rooted path is given." validate:"required"`
+	Args            []string          `yaml:"args,omitempty"              json:"args,omitempty"              jsonschema:"description=Arguments passed to command. Tokens beginning with ~ are home-expanded; $VAR and ${VAR} are env-expanded."`
+	Cwd             string            `yaml:"cwd,omitempty"               json:"cwd,omitempty"               jsonschema:"description=Working directory for the hook process. Defaults to gaal's working directory."`
+	OS              []string          `yaml:"os,omitempty"                json:"os,omitempty"                jsonschema:"description=Restrict to these GOOS values; empty list means all platforms,enum=linux,enum=darwin,enum=windows"`
+	Timeout         string            `yaml:"timeout,omitempty"           json:"timeout,omitempty"           jsonschema:"description=Per-hook timeout as a Go duration string (e.g. \"30s\", \"2m\"). Default 5m."`
+	ContinueOnError bool              `yaml:"continue_on_error,omitempty" json:"continue_on_error,omitempty" jsonschema:"description=When true a non-zero exit logs a warning and does not abort the remaining hooks or, for pre-sync, the sync itself."`
+	Env             map[string]string `yaml:"env,omitempty"               json:"env,omitempty"               jsonschema:"description=Extra environment variables for this hook. Merged on top of the inherited environment."`
+}
+
+// EffectiveTimeout returns the hook's parsed timeout, or DefaultHookTimeout
+// when Timeout is empty. Callers should only invoke this after validateHooks
+// has run, which guarantees the value parses cleanly.
+func (h ConfigHook) EffectiveTimeout() time.Duration {
+	if h.Timeout == "" {
+		return DefaultHookTimeout
+	}
+	d, err := time.ParseDuration(h.Timeout)
+	if err != nil || d <= 0 {
+		return DefaultHookTimeout
+	}
+	return d
 }
 
 // ConfigRepo is a vcstool-compatible repository entry.
@@ -368,6 +417,18 @@ func (c *Config) mergeFrom(src *Config, scope ConfigScope) {
 			c.Tools = append(c.Tools, tl)
 		}
 	}
+
+	if src.Hooks != nil {
+		if c.Hooks == nil {
+			c.Hooks = &ConfigHooks{}
+		}
+		// Higher-priority levels append their hooks after lower-priority ones.
+		// Pre-sync from a higher level still runs after pre-sync from a lower
+		// level; users layering a workspace config can rely on their hooks
+		// firing last. No keyed dedup: hook commands are not identity-bearing.
+		c.Hooks.PreSync = append(c.Hooks.PreSync, src.Hooks.PreSync...)
+		c.Hooks.PostSync = append(c.Hooks.PostSync, src.Hooks.PostSync...)
+	}
 }
 
 // deduplicate removes duplicate entries within this Config, keeping the first
@@ -384,7 +445,56 @@ func (c *Config) validate() error {
 	if err := schema.Validate(c); err != nil {
 		return err
 	}
-	return c.validateMCPItems()
+	if err := c.validateMCPItems(); err != nil {
+		return err
+	}
+	return c.validateHooks()
+}
+
+// validHookOS enumerates the GOOS values gaal will match against runtime.GOOS
+// when deciding whether to run a hook. Values from the user's YAML are
+// lower-cased before comparison.
+var validHookOS = map[string]struct{}{
+	"linux":   {},
+	"darwin":  {},
+	"windows": {},
+}
+
+func (c *Config) validateHooks() error {
+	if c.Hooks == nil {
+		return nil
+	}
+	if err := validateHookList("pre-sync", c.Hooks.PreSync); err != nil {
+		return err
+	}
+	return validateHookList("post-sync", c.Hooks.PostSync)
+}
+
+func validateHookList(phase string, hooks []ConfigHook) error {
+	for i, h := range hooks {
+		label := fmt.Sprintf("hooks.%s[%d]", phase, i)
+		if h.Name != "" {
+			label = fmt.Sprintf("hooks.%s[%d] (%s)", phase, i, h.Name)
+		}
+		if h.Command == "" {
+			return fmt.Errorf("%s: command is required", label)
+		}
+		for _, osName := range h.OS {
+			if _, ok := validHookOS[osName]; !ok {
+				return fmt.Errorf("%s: os value %q is not one of [linux darwin windows]", label, osName)
+			}
+		}
+		if h.Timeout != "" {
+			d, err := time.ParseDuration(h.Timeout)
+			if err != nil {
+				return fmt.Errorf("%s: timeout %q is not a valid Go duration (e.g. \"30s\", \"2m\"): %w", label, h.Timeout, err)
+			}
+			if d < 0 {
+				return fmt.Errorf("%s: timeout must be non-negative (got %s)", label, d)
+			}
+		}
+	}
+	return nil
 }
 
 func (c *Config) validateMCPItems() error {

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -637,6 +637,29 @@ func TestMergeFrom_SchemaSrcWins(t *testing.T) {
 	}
 }
 
+func TestMergeFrom_HooksConcatenateInPriorityOrder(t *testing.T) {
+	low := &Config{Hooks: &ConfigHooks{
+		PreSync:  []ConfigHook{{Name: "low-pre", Command: "true"}},
+		PostSync: []ConfigHook{{Name: "low-post", Command: "true"}},
+	}}
+	high := &Config{Hooks: &ConfigHooks{
+		PreSync:  []ConfigHook{{Name: "high-pre", Command: "true"}},
+		PostSync: []ConfigHook{{Name: "high-post", Command: "true"}},
+	}}
+	merged := &Config{}
+	merged.mergeFrom(low, ScopeGlobal)
+	merged.mergeFrom(high, ScopeWorkspace)
+	if merged.Hooks == nil {
+		t.Fatal("expected merged hooks")
+	}
+	if got := len(merged.Hooks.PreSync); got != 2 {
+		t.Fatalf("expected 2 pre-sync hooks, got %d", got)
+	}
+	if merged.Hooks.PreSync[0].Name != "low-pre" || merged.Hooks.PreSync[1].Name != "high-pre" {
+		t.Errorf("ordering: %+v", merged.Hooks.PreSync)
+	}
+}
+
 func TestMergeFrom_SchemaDstPreservedWhenSrcNil(t *testing.T) {
 	v1 := 1
 	dst := &Config{Schema: &v1}
@@ -1312,3 +1335,95 @@ tools:
 
 // Ensure fmt is used (suppress unused import).
 var _ = fmt.Sprintf
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+func TestLoad_Hooks_Valid(t *testing.T) {
+	p := writeYAML(t, `
+schema: 1
+hooks:
+  pre-sync:
+    - name: "backup"
+      command: ./scripts/backup.sh
+      timeout: 30s
+  post-sync:
+    - command: git
+      args: ["-C", "~/.claude", "pull"]
+      os: [linux, darwin]
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Hooks == nil {
+		t.Fatal("expected hooks block to be parsed")
+	}
+	if len(cfg.Hooks.PreSync) != 1 || cfg.Hooks.PreSync[0].Name != "backup" {
+		t.Errorf("pre-sync: %+v", cfg.Hooks.PreSync)
+	}
+	if got := cfg.Hooks.PreSync[0].EffectiveTimeout(); got != 30*1_000_000_000 { // 30s
+		t.Errorf("timeout: want 30s, got %s", got)
+	}
+	if len(cfg.Hooks.PostSync) != 1 || cfg.Hooks.PostSync[0].Command != "git" {
+		t.Errorf("post-sync: %+v", cfg.Hooks.PostSync)
+	}
+	if want := []string{"-C", "~/.claude", "pull"}; !sliceEq(cfg.Hooks.PostSync[0].Args, want) {
+		t.Errorf("args: want %v, got %v", want, cfg.Hooks.PostSync[0].Args)
+	}
+}
+
+func TestLoad_Hooks_MissingCommand_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+schema: 1
+hooks:
+  post-sync:
+    - name: "no command"
+`)
+	if _, err := Load(p); err == nil {
+		t.Fatal("expected validation error when command is missing")
+	}
+}
+
+func TestLoad_Hooks_InvalidOS_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+schema: 1
+hooks:
+  post-sync:
+    - command: true
+      os: [linux, plan9]
+`)
+	_, err := Load(p)
+	if err == nil {
+		t.Fatal("expected validation error for unsupported os value")
+	}
+	if !strings.Contains(err.Error(), "plan9") {
+		t.Errorf("error should mention bad os value; got %v", err)
+	}
+}
+
+func TestLoad_Hooks_InvalidTimeout_Rejected(t *testing.T) {
+	p := writeYAML(t, `
+schema: 1
+hooks:
+  post-sync:
+    - command: true
+      timeout: "ten seconds"
+`)
+	if _, err := Load(p); err == nil {
+		t.Fatal("expected validation error for unparseable timeout")
+	}
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"gaal/internal/config"
+	"gaal/internal/engine/hooks"
 	"gaal/internal/engine/ops"
 	"gaal/internal/engine/render"
 	"gaal/internal/mcp"
@@ -75,6 +76,7 @@ type Engine struct {
 	repos     *repo.Manager
 	skills    *skill.Manager
 	mcps      *mcp.Manager
+	hooks     *hooks.Manager
 	home      string
 	workDir   string
 	cacheRoot string
@@ -116,12 +118,18 @@ func NewWithOptions(cfg *config.Config, opts Options) *Engine {
 		repos:     repo.NewManager(cfg.Repositories, stateDir),
 		skills:    skill.NewManager(cfg.Skills, cacheDir, home, workDir, stateDir, opts.Force),
 		mcps:      mcp.NewManager(cfg.MCPs, home, stateDir),
+		hooks:     hooks.NewManager(cfg.Hooks, workDir, home, ""),
 		home:      home,
 		workDir:   workDir,
 		cacheRoot: cacheRoot,
 		stateDir:  stateDir,
 	}
 }
+
+// Hooks exposes the engine's hook manager so callers (cmd/sync) can run
+// pre-sync and post-sync hooks at the right moments. It is never nil but
+// may have no hooks declared.
+func (e *Engine) Hooks() *hooks.Manager { return e.hooks }
 
 // RunOnce performs a single synchronisation pass.
 func (e *Engine) RunOnce(ctx context.Context) error {
@@ -160,13 +168,14 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 }
 
 // RunService runs synchronisation in a loop until the context is cancelled.
+// Each iteration runs pre-sync hooks, then sync, then post-sync hooks (only
+// if sync succeeded). Hook failures are logged but never break the loop —
+// a daemon that exits on a transient hook error would be hostile to users.
 func (e *Engine) RunService(ctx context.Context, interval time.Duration) error {
 	slog.Info("service mode started", "interval", interval)
 
 	// Run immediately on startup.
-	if err := e.RunOnce(ctx); err != nil {
-		slog.Error("initial sync failed", "err", err)
-	}
+	e.serviceIteration(ctx)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -178,10 +187,26 @@ func (e *Engine) RunService(ctx context.Context, interval time.Duration) error {
 			return nil
 		case t := <-ticker.C:
 			slog.Info("periodic sync triggered", "time", t)
-			if err := e.RunOnce(ctx); err != nil {
-				slog.Error("periodic sync failed", "err", err)
-			}
+			e.serviceIteration(ctx)
 		}
+	}
+}
+
+func (e *Engine) serviceIteration(ctx context.Context) {
+	plan, planErr := e.Plan(ctx)
+	if planErr != nil {
+		slog.Error("plan failed", "err", planErr)
+	}
+	if err := e.hooks.RunPreSync(ctx, plan); err != nil {
+		slog.Error("pre-sync hooks failed; skipping sync this iteration", "err", err)
+		return
+	}
+	if err := e.RunOnce(ctx); err != nil {
+		slog.Error("periodic sync failed; skipping post-sync hooks", "err", err)
+		return
+	}
+	if err := e.hooks.RunPostSync(ctx, plan); err != nil {
+		slog.Error("post-sync hooks failed", "err", err)
 	}
 }
 
@@ -210,7 +235,18 @@ func (e *Engine) Collect(ctx context.Context) (*render.StatusReport, error) {
 // It returns the plan so the caller can inspect HasChanges / HasErrors for
 // exit code logic.
 func (e *Engine) DryRun(ctx context.Context, format OutputFormat) (*render.PlanReport, error) {
-	return ops.RenderPlan(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir, format)
+	plan, err := e.Plan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	renderer, err := render.NewPlanRenderer(format)
+	if err != nil {
+		return nil, err
+	}
+	if err := renderer.Render(os.Stdout, plan); err != nil {
+		return nil, err
+	}
+	return plan, nil
 }
 
 // Plan computes the sync plan without rendering it. It is the same planner
@@ -218,7 +254,12 @@ func (e *Engine) DryRun(ctx context.Context, format OutputFormat) (*render.PlanR
 // summary can report past-tense verbs ("cloned", "installed", "upserted")
 // for each managed resource.
 func (e *Engine) Plan(ctx context.Context) (*render.PlanReport, error) {
-	return ops.SyncPlan(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir)
+	plan, err := ops.SyncPlan(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir)
+	if err != nil {
+		return nil, err
+	}
+	plan.Hooks = e.hooks.Plan()
+	return plan, nil
 }
 
 // Status collects the current resource state and renders it to os.Stdout.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -190,6 +190,50 @@ func TestRunOnce_ErrorAccumulation(t *testing.T) {
 	}
 }
 
+func TestPlan_IncludesHookEntries(t *testing.T) {
+	cfg := &config.Config{
+		Hooks: &config.ConfigHooks{
+			PreSync: []config.ConfigHook{
+				{Name: "pre", Command: "true"},
+			},
+			PostSync: []config.ConfigHook{
+				{Name: "post", Command: "true"},
+			},
+		},
+	}
+	e := NewWithOptions(cfg, Options{StateDir: t.TempDir()})
+	plan, err := e.Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plan.Hooks) != 2 {
+		t.Fatalf("expected 2 hook entries in plan, got %d (%+v)", len(plan.Hooks), plan.Hooks)
+	}
+	var names []string
+	for _, h := range plan.Hooks {
+		names = append(names, h.Name)
+	}
+	wantSet := map[string]bool{"pre": false, "post": false}
+	for _, n := range names {
+		if _, ok := wantSet[n]; ok {
+			wantSet[n] = true
+		}
+	}
+	for n, seen := range wantSet {
+		if !seen {
+			t.Errorf("hook %q missing from plan (got %v)", n, names)
+		}
+	}
+}
+
+func TestHooks_ReturnsManager(t *testing.T) {
+	cfg := &config.Config{}
+	e := New(cfg)
+	if e.Hooks() == nil {
+		t.Fatal("Hooks() returned nil")
+	}
+}
+
 func TestStatus_WithRepoError(t *testing.T) {
 	// Unknown repo type causes repos.Status to return an error status entry.
 	cfg := &config.Config{

--- a/internal/engine/hooks/env.go
+++ b/internal/engine/hooks/env.go
@@ -17,14 +17,14 @@ import (
 // detect "ran with no changes" by checking [[ -z "$GAAL_CHANGED_REPOS" ]].
 func planEnv(plan *render.PlanReport) map[string]string {
 	env := map[string]string{
-		"GAAL_CHANGED_REPOS":   "",
-		"GAAL_CHANGED_SKILLS":  "",
-		"GAAL_CHANGED_MCPS":    "",
-		"GAAL_PLANNED_REPOS":   "",
-		"GAAL_PLANNED_SKILLS":  "",
-		"GAAL_PLANNED_MCPS":    "",
-		"GAAL_HAS_CHANGES":     "0",
-		"GAAL_HAS_ERRORS":      "0",
+		"GAAL_CHANGED_REPOS":  "",
+		"GAAL_CHANGED_SKILLS": "",
+		"GAAL_CHANGED_MCPS":   "",
+		"GAAL_PLANNED_REPOS":  "",
+		"GAAL_PLANNED_SKILLS": "",
+		"GAAL_PLANNED_MCPS":   "",
+		"GAAL_HAS_CHANGES":    "0",
+		"GAAL_HAS_ERRORS":     "0",
 	}
 	if plan == nil {
 		return env

--- a/internal/engine/hooks/env.go
+++ b/internal/engine/hooks/env.go
@@ -1,0 +1,91 @@
+package hooks
+
+import (
+	"strings"
+
+	"gaal/internal/engine/render"
+)
+
+// planEnv builds the map of GAAL_* variables describing what sync touched.
+// Variables are intentionally newline-separated lists so shells can iterate
+// them with `IFS=$'\n' for x in $GAAL_CHANGED_REPOS; do ...`. Pre-sync uses
+// "PLANNED" framing; post-sync replays the same plan because plan == reality
+// when the sync completed successfully, and re-collecting status here would
+// require I/O the caller has already done.
+//
+// An empty plan still sets each variable to the empty string so hooks can
+// detect "ran with no changes" by checking [[ -z "$GAAL_CHANGED_REPOS" ]].
+func planEnv(plan *render.PlanReport) map[string]string {
+	env := map[string]string{
+		"GAAL_CHANGED_REPOS":   "",
+		"GAAL_CHANGED_SKILLS":  "",
+		"GAAL_CHANGED_MCPS":    "",
+		"GAAL_PLANNED_REPOS":   "",
+		"GAAL_PLANNED_SKILLS":  "",
+		"GAAL_PLANNED_MCPS":    "",
+		"GAAL_HAS_CHANGES":     "0",
+		"GAAL_HAS_ERRORS":      "0",
+	}
+	if plan == nil {
+		return env
+	}
+	if plan.HasChanges {
+		env["GAAL_HAS_CHANGES"] = "1"
+	}
+	if plan.HasErrors {
+		env["GAAL_HAS_ERRORS"] = "1"
+	}
+
+	repos := changedRepos(plan)
+	skills := changedSkills(plan)
+	mcps := changedMCPs(plan)
+
+	joined := func(xs []string) string { return strings.Join(xs, "\n") }
+	env["GAAL_CHANGED_REPOS"] = joined(repos)
+	env["GAAL_CHANGED_SKILLS"] = joined(skills)
+	env["GAAL_CHANGED_MCPS"] = joined(mcps)
+	env["GAAL_PLANNED_REPOS"] = joined(repos)
+	env["GAAL_PLANNED_SKILLS"] = joined(skills)
+	env["GAAL_PLANNED_MCPS"] = joined(mcps)
+	return env
+}
+
+func changedRepos(p *render.PlanReport) []string {
+	out := make([]string, 0, len(p.Repositories))
+	for _, e := range p.Repositories {
+		if e.Action == render.PlanClone || e.Action == render.PlanUpdate {
+			out = append(out, e.Path)
+		}
+	}
+	return out
+}
+
+// changedSkills returns "agent:source" rows for every skill entry whose
+// planned action is not a no-op or error. This format is unambiguous in a
+// shell loop and stays stable across deduping in the plan layer.
+func changedSkills(p *render.PlanReport) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(p.Skills))
+	for _, e := range p.Skills {
+		if e.Action != render.PlanCreate && e.Action != render.PlanUpdate {
+			continue
+		}
+		key := e.Agent + ":" + e.Source
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	return out
+}
+
+func changedMCPs(p *render.PlanReport) []string {
+	out := make([]string, 0, len(p.MCPs))
+	for _, e := range p.MCPs {
+		if e.Action == render.PlanCreate || e.Action == render.PlanUpdate {
+			out = append(out, e.Name)
+		}
+	}
+	return out
+}

--- a/internal/engine/hooks/hooks.go
+++ b/internal/engine/hooks/hooks.go
@@ -1,0 +1,279 @@
+// Package hooks runs user-defined commands around the gaal sync pipeline.
+//
+// Hooks let users glue cross-machine workflows into a single config — for
+// example, "after every successful sync, run `git pull` in another working
+// copy." The shape of a hook is intentionally minimal and exec-form: command
+// plus args, no shell, so the same config works on Linux, macOS, and Windows.
+package hooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"gaal/internal/config"
+	"gaal/internal/engine/render"
+)
+
+// Manager owns the hooks declared in the merged Config and is responsible for
+// planning, filtering, and executing them at the right phase of sync.
+//
+// Concurrency model: hooks run sequentially in declared order. This is a
+// deliberate v1 choice — predictable output beats faster wall time, and many
+// post-sync hooks (e.g. `git pull` on a working copy) are not safe to
+// parallelise anyway.
+type Manager struct {
+	hooks    *config.ConfigHooks
+	workDir  string
+	home     string
+	goos     string
+	executor Executor
+}
+
+// Executor runs a hook subprocess. It is split out so tests can substitute a
+// fake that records invocations without touching the host filesystem.
+type Executor func(ctx context.Context, h ResolvedHook) error
+
+// ResolvedHook is a ConfigHook after path/env expansion and timeout parsing.
+// It is what an Executor actually runs.
+type ResolvedHook struct {
+	Phase   render.HookPhase
+	Name    string
+	Command string
+	Args    []string
+	Cwd     string
+	Env     []string // full environment, ready for exec.Cmd.Env
+	Timeout time.Duration
+}
+
+// Result describes the outcome of a single hook invocation.
+type Result struct {
+	Hook    ResolvedHook
+	Err     error
+	Skipped bool // true when the hook was filtered out (OS mismatch, etc.)
+}
+
+// NewManager builds a Manager. cfg may be nil, in which case all methods are
+// no-ops. workDir and home are used to resolve relative paths and ~ tokens;
+// goos is exposed for tests — production callers pass runtime.GOOS.
+func NewManager(cfg *config.ConfigHooks, workDir, home, goos string) *Manager {
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	return &Manager{
+		hooks:    cfg,
+		workDir:  workDir,
+		home:     home,
+		goos:     goos,
+		executor: defaultExecutor,
+	}
+}
+
+// SetExecutor replaces the executor used by RunPreSync/RunPostSync. Intended
+// for tests; production code never calls this.
+func (m *Manager) SetExecutor(e Executor) {
+	if e == nil {
+		m.executor = defaultExecutor
+		return
+	}
+	m.executor = e
+}
+
+// Plan returns the PlanHookEntry slice for every declared hook, marking each
+// with whether it will run or be skipped on the current OS. The result is
+// safe to embed in render.PlanReport without further filtering.
+func (m *Manager) Plan() []render.PlanHookEntry {
+	if m == nil || m.hooks == nil {
+		return nil
+	}
+	out := make([]render.PlanHookEntry, 0, len(m.hooks.PreSync)+len(m.hooks.PostSync))
+	out = append(out, m.planPhase(render.HookPreSync, m.hooks.PreSync)...)
+	out = append(out, m.planPhase(render.HookPostSync, m.hooks.PostSync)...)
+	return out
+}
+
+func (m *Manager) planPhase(phase render.HookPhase, hooks []config.ConfigHook) []render.PlanHookEntry {
+	out := make([]render.PlanHookEntry, 0, len(hooks))
+	for _, h := range hooks {
+		entry := render.PlanHookEntry{
+			Phase:   phase,
+			Name:    h.Name,
+			Command: h.Command,
+			Args:    append([]string(nil), h.Args...),
+			Action:  render.PlanRun,
+		}
+		if !osMatches(m.goos, h.OS) {
+			entry.Action = render.PlanSkip
+			entry.Reason = "os filter excludes " + m.goos
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// RunPreSync runs every pre-sync hook in order. A hook's non-zero exit
+// aborts the sync (returning a non-nil error) unless the hook is marked
+// continue_on_error. Hooks filtered out by their OS list are silently
+// skipped. Pre-sync hooks see GAAL_PLANNED_* env vars derived from plan.
+func (m *Manager) RunPreSync(ctx context.Context, plan *render.PlanReport) error {
+	if m == nil || m.hooks == nil || len(m.hooks.PreSync) == 0 {
+		return nil
+	}
+	env := planEnv(plan)
+	env["GAAL_HOOK_PHASE"] = string(render.HookPreSync)
+	return m.runPhase(ctx, render.HookPreSync, m.hooks.PreSync, env)
+}
+
+// RunPostSync runs every post-sync hook in order. Behaviour mirrors
+// RunPreSync but the env payload describes what *did* change rather than
+// what was planned. Callers must skip this call entirely when the sync
+// itself failed — that policy lives in the cmd layer so the meaning of
+// "successful sync" stays one decision in one place.
+func (m *Manager) RunPostSync(ctx context.Context, plan *render.PlanReport) error {
+	if m == nil || m.hooks == nil || len(m.hooks.PostSync) == 0 {
+		return nil
+	}
+	env := planEnv(plan)
+	env["GAAL_HOOK_PHASE"] = string(render.HookPostSync)
+	return m.runPhase(ctx, render.HookPostSync, m.hooks.PostSync, env)
+}
+
+func (m *Manager) runPhase(ctx context.Context, phase render.HookPhase, hooks []config.ConfigHook, extraEnv map[string]string) error {
+	var errs []error
+	for i, h := range hooks {
+		if !osMatches(m.goos, h.OS) {
+			slog.DebugContext(ctx, "hook skipped: os filter",
+				"phase", phase, "index", i, "name", h.Name, "goos", m.goos, "filter", h.OS)
+			continue
+		}
+
+		resolved, err := m.resolve(phase, h, extraEnv)
+		if err != nil {
+			err = fmt.Errorf("hooks.%s[%d] %s: resolve: %w", phase, i, hookLabel(h), err)
+			if h.ContinueOnError {
+				slog.WarnContext(ctx, "hook resolve failed; continuing", "err", err)
+				errs = append(errs, err)
+				continue
+			}
+			return err
+		}
+
+		slog.InfoContext(ctx, "running hook",
+			"phase", phase, "name", resolved.Name,
+			"command", resolved.Command, "args", resolved.Args)
+
+		runCtx, cancel := context.WithTimeout(ctx, resolved.Timeout)
+		runErr := m.executor(runCtx, resolved)
+		cancel()
+
+		if runErr == nil {
+			continue
+		}
+		hookErr := fmt.Errorf("hooks.%s[%d] %s: %w", phase, i, hookLabel(h), runErr)
+		if h.ContinueOnError {
+			slog.WarnContext(ctx, "hook failed; continue_on_error=true, continuing",
+				"phase", phase, "name", resolved.Name, "err", runErr)
+			errs = append(errs, hookErr)
+			continue
+		}
+		return hookErr
+	}
+	return errors.Join(errs...)
+}
+
+func hookLabel(h config.ConfigHook) string {
+	if h.Name != "" {
+		return strconv.Quote(h.Name)
+	}
+	return strconv.Quote(h.Command)
+}
+
+// resolve expands ~ and env tokens, builds the env slice, and parses the
+// timeout. Validation already ensured Timeout is well-formed.
+func (m *Manager) resolve(phase render.HookPhase, h config.ConfigHook, extraEnv map[string]string) (ResolvedHook, error) {
+	args := make([]string, len(h.Args))
+	for i, a := range h.Args {
+		args[i] = m.expand(a)
+	}
+	cwd := m.workDir
+	if h.Cwd != "" {
+		cwd = m.expand(h.Cwd)
+		if !filepath.IsAbs(cwd) {
+			cwd = filepath.Join(m.workDir, cwd)
+		}
+	}
+	cmd := h.Command
+	// Only expand path-like commands (~/bin/foo); a bare name like "git"
+	// must remain bare so exec.LookPath finds it on PATH.
+	if strings.HasPrefix(cmd, "~/") || strings.HasPrefix(cmd, `~\`) || strings.ContainsAny(cmd, "/\\") {
+		cmd = m.expand(cmd)
+	}
+
+	env := os.Environ()
+	for k, v := range extraEnv {
+		env = append(env, k+"="+v)
+	}
+	for k, v := range h.Env {
+		env = append(env, k+"="+m.expand(v))
+	}
+
+	return ResolvedHook{
+		Phase:   phase,
+		Name:    h.Name,
+		Command: cmd,
+		Args:    args,
+		Cwd:     cwd,
+		Env:     env,
+		Timeout: h.EffectiveTimeout(),
+	}, nil
+}
+
+// expand applies ~ and env expansion to s. Order matters: ~ first (so that
+// a literal ~ followed by $VAR keeps its home meaning), then os.ExpandEnv.
+func (m *Manager) expand(s string) string {
+	if strings.HasPrefix(s, "~/") || strings.HasPrefix(s, `~\`) {
+		s = filepath.Join(m.home, s[2:])
+	}
+	return os.ExpandEnv(s)
+}
+
+// osMatches reports whether the current GOOS satisfies a hook's optional
+// OS filter. An empty filter matches every platform.
+func osMatches(goos string, filter []string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	for _, f := range filter {
+		if strings.EqualFold(f, goos) {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultExecutor runs the hook with stdout and stderr wired straight to
+// gaal's own streams. The user wrote the command; the user gets to see what
+// it printed. Spinner-based capture (as in internal/runner) is the wrong
+// default here — hook output is rarely incidental.
+func defaultExecutor(ctx context.Context, h ResolvedHook) error {
+	cmd := exec.CommandContext(ctx, h.Command, h.Args...) //nolint:gosec // hook commands are user-authored by design
+	cmd.Dir = h.Cwd
+	cmd.Env = h.Env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("timeout after %s", h.Timeout)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/engine/hooks/hooks_test.go
+++ b/internal/engine/hooks/hooks_test.go
@@ -1,0 +1,278 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gaal/internal/config"
+	"gaal/internal/engine/render"
+)
+
+// recorder is a test executor that captures every hook invocation in order
+// and returns a configurable error.
+type recorder struct {
+	mu    sync.Mutex
+	calls []ResolvedHook
+	errs  map[string]error // keyed by hook.Name or hook.Command
+}
+
+func (r *recorder) exec(ctx context.Context, h ResolvedHook) error {
+	r.mu.Lock()
+	r.calls = append(r.calls, h)
+	r.mu.Unlock()
+	if r.errs == nil {
+		return nil
+	}
+	if err, ok := r.errs[h.Name]; ok {
+		return err
+	}
+	return r.errs[h.Command]
+}
+
+func (r *recorder) names() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.calls))
+	for _, c := range r.calls {
+		out = append(out, c.Name+"|"+c.Command)
+	}
+	return out
+}
+
+func newRec() *recorder { return &recorder{errs: map[string]error{}} }
+
+func TestManager_NilConfigIsNoOp(t *testing.T) {
+	m := NewManager(nil, ".", "/home", "linux")
+	rec := newRec()
+	m.SetExecutor(rec.exec)
+	if err := m.RunPreSync(context.Background(), nil); err != nil {
+		t.Fatalf("pre: %v", err)
+	}
+	if err := m.RunPostSync(context.Background(), nil); err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if got := len(rec.calls); got != 0 {
+		t.Fatalf("expected 0 executor calls, got %d", got)
+	}
+	if plan := m.Plan(); len(plan) != 0 {
+		t.Fatalf("expected empty plan, got %v", plan)
+	}
+}
+
+func TestPlan_OSFilterMarksSkip(t *testing.T) {
+	cfg := &config.ConfigHooks{
+		PreSync: []config.ConfigHook{
+			{Name: "linux-only", Command: "true", OS: []string{"linux"}},
+			{Name: "windows-only", Command: "true", OS: []string{"windows"}},
+		},
+		PostSync: []config.ConfigHook{
+			{Name: "universal", Command: "true"},
+		},
+	}
+	m := NewManager(cfg, ".", "/home", "linux")
+	got := m.Plan()
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries, got %d", len(got))
+	}
+	want := map[string]render.PlanAction{
+		"linux-only":   render.PlanRun,
+		"windows-only": render.PlanSkip,
+		"universal":    render.PlanRun,
+	}
+	for _, e := range got {
+		if want[e.Name] != e.Action {
+			t.Errorf("%s: want action %s, got %s (reason=%q)", e.Name, want[e.Name], e.Action, e.Reason)
+		}
+		if e.Action == render.PlanSkip && e.Reason == "" {
+			t.Errorf("%s: skipped entry has no reason", e.Name)
+		}
+	}
+}
+
+func TestRunPreSync_OSFilterSkipsExecutor(t *testing.T) {
+	cfg := &config.ConfigHooks{
+		PreSync: []config.ConfigHook{
+			{Name: "linux-only", Command: "true", OS: []string{"linux"}},
+			{Name: "windows-only", Command: "true", OS: []string{"windows"}},
+		},
+	}
+	m := NewManager(cfg, ".", "/home", "linux")
+	rec := newRec()
+	m.SetExecutor(rec.exec)
+
+	if err := m.RunPreSync(context.Background(), &render.PlanReport{}); err != nil {
+		t.Fatalf("RunPreSync: %v", err)
+	}
+	if got := len(rec.calls); got != 1 {
+		t.Fatalf("expected 1 call (windows-only filtered out), got %d", got)
+	}
+	if rec.calls[0].Name != "linux-only" {
+		t.Fatalf("ran the wrong hook: %s", rec.calls[0].Name)
+	}
+}
+
+func TestRunPreSync_FailureAborts(t *testing.T) {
+	cfg := &config.ConfigHooks{
+		PreSync: []config.ConfigHook{
+			{Name: "first", Command: "true"},
+			{Name: "boom", Command: "false"},
+			{Name: "never-runs", Command: "true"},
+		},
+	}
+	m := NewManager(cfg, ".", "/home", "linux")
+	rec := newRec()
+	rec.errs["boom"] = errors.New("exit 1")
+	m.SetExecutor(rec.exec)
+
+	err := m.RunPreSync(context.Background(), &render.PlanReport{})
+	if err == nil {
+		t.Fatal("expected error from failing hook")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error should reference hook name, got %v", err)
+	}
+	if got := len(rec.calls); got != 2 {
+		t.Fatalf("expected exec to stop after failing hook (2 calls), got %d", got)
+	}
+}
+
+func TestRunPreSync_ContinueOnErrorRunsRemaining(t *testing.T) {
+	cfg := &config.ConfigHooks{
+		PreSync: []config.ConfigHook{
+			{Name: "first", Command: "true"},
+			{Name: "soft-fail", Command: "false", ContinueOnError: true},
+			{Name: "after-soft-fail", Command: "true"},
+		},
+	}
+	m := NewManager(cfg, ".", "/home", "linux")
+	rec := newRec()
+	rec.errs["soft-fail"] = errors.New("exit 1")
+	m.SetExecutor(rec.exec)
+
+	err := m.RunPreSync(context.Background(), &render.PlanReport{})
+	if err == nil {
+		t.Fatal("expected joined error to be non-nil")
+	}
+	if got := len(rec.calls); got != 3 {
+		t.Fatalf("expected all 3 calls (continue_on_error=true), got %d", got)
+	}
+}
+
+func TestRunPostSync_PassesChangedEnv(t *testing.T) {
+	cfg := &config.ConfigHooks{
+		PostSync: []config.ConfigHook{
+			{Name: "inspect", Command: "true"},
+		},
+	}
+	m := NewManager(cfg, ".", "/home", "linux")
+	rec := newRec()
+	m.SetExecutor(rec.exec)
+
+	plan := &render.PlanReport{
+		Repositories: []render.PlanRepoEntry{
+			{Path: "src/a", Action: render.PlanUpdate},
+			{Path: "src/b", Action: render.PlanNoOp},
+		},
+		Skills: []render.PlanSkillEntry{
+			{Source: "owner/repo", Agent: "claude-code", Action: render.PlanCreate},
+		},
+		MCPs: []render.PlanMCPEntry{
+			{Name: "filesystem", Action: render.PlanUpdate},
+		},
+		HasChanges: true,
+	}
+	if err := m.RunPostSync(context.Background(), plan); err != nil {
+		t.Fatalf("RunPostSync: %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(rec.calls))
+	}
+	env := rec.calls[0].Env
+	mustContain := []string{
+		"GAAL_HOOK_PHASE=post-sync",
+		"GAAL_CHANGED_REPOS=src/a",
+		"GAAL_CHANGED_SKILLS=claude-code:owner/repo",
+		"GAAL_CHANGED_MCPS=filesystem",
+		"GAAL_HAS_CHANGES=1",
+	}
+	for _, want := range mustContain {
+		if !containsEnv(env, want) {
+			t.Errorf("env missing %q in %v", want, env)
+		}
+	}
+}
+
+func TestResolve_HomeAndEnvExpansion(t *testing.T) {
+	t.Setenv("FOO_VALUE", "bar")
+	cfg := &config.ConfigHooks{
+		PreSync: []config.ConfigHook{
+			{
+				Name:    "expand",
+				Command: "true",
+				Args:    []string{"~/x", "$FOO_VALUE", "${FOO_VALUE}-suffix"},
+				Cwd:     "~/work",
+				Env:     map[string]string{"OUT": "$FOO_VALUE"},
+			},
+		},
+	}
+	m := NewManager(cfg, "/wd", "/home/test", "linux")
+	rec := newRec()
+	m.SetExecutor(rec.exec)
+	if err := m.RunPreSync(context.Background(), &render.PlanReport{}); err != nil {
+		t.Fatalf("RunPreSync: %v", err)
+	}
+	got := rec.calls[0]
+	wantArgs := []string{"/home/test/x", "bar", "bar-suffix"}
+	if !equalStrings(got.Args, wantArgs) {
+		t.Errorf("args: want %v, got %v", wantArgs, got.Args)
+	}
+	if got.Cwd != "/home/test/work" {
+		t.Errorf("cwd: want /home/test/work, got %s", got.Cwd)
+	}
+	if !containsEnv(got.Env, "OUT=bar") {
+		t.Errorf("env missing OUT=bar: %v", got.Env)
+	}
+}
+
+func TestEffectiveTimeout(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"", config.DefaultHookTimeout},
+		{"30s", 30 * time.Second},
+		{"2m", 2 * time.Minute},
+		{"bogus", config.DefaultHookTimeout},
+	}
+	for _, tc := range cases {
+		got := config.ConfigHook{Timeout: tc.raw}.EffectiveTimeout()
+		if got != tc.want {
+			t.Errorf("Timeout=%q: want %s, got %s", tc.raw, tc.want, got)
+		}
+	}
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/engine/render/plan_table.go
+++ b/internal/engine/render/plan_table.go
@@ -15,6 +15,8 @@ var actionLabel = map[PlanAction]string{
 	PlanUpdate: "update",
 	PlanCreate: "create",
 	PlanError:  "error",
+	PlanRun:    "run",
+	PlanSkip:   "skip",
 }
 
 // actionCell renders a PlanAction as a coloured pterm string.
@@ -36,6 +38,10 @@ func actionCell(action PlanAction, errMsg string) string {
 			msg = errMsg
 		}
 		return pterm.FgRed.Sprint("! " + msg)
+	case PlanRun:
+		return pterm.FgCyan.Sprint("> " + label)
+	case PlanSkip:
+		return pterm.FgGray.Sprint("- " + label)
 	default:
 		return label
 	}
@@ -57,6 +63,9 @@ func (pr *planTableRenderer) Render(w io.Writer, r *PlanReport) error {
 		return err
 	}
 	if err := pr.mcpTable(w, tr, r.MCPs, termW); err != nil {
+		return err
+	}
+	if err := pr.hookTable(w, tr, r.Hooks, termW); err != nil {
 		return err
 	}
 
@@ -150,6 +159,39 @@ func (pr *planTableRenderer) mcpTable(w io.Writer, tr *tableRenderer, entries []
 			e.Name,
 			actionCell(e.Action, e.Error),
 			trunc(e.Target, vw),
+		})
+	}
+	return tr.ptermTable(w, data)
+}
+
+func (pr *planTableRenderer) hookTable(w io.Writer, tr *tableRenderer, entries []PlanHookEntry, termW int) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	tr.section(w, "Hooks", len(entries))
+	vw := varColWidth(termW, 4, 2, 22)
+	if vw < 12 {
+		vw = 12
+	}
+
+	data := pterm.TableData{{"PHASE", "NAME", "ACTION", "COMMAND"}}
+	for _, e := range entries {
+		name := e.Name
+		if name == "" {
+			name = "—"
+		}
+		command := e.Command
+		if len(e.Args) > 0 {
+			command = e.Command + " " + strings.Join(e.Args, " ")
+		}
+		if e.Action == PlanSkip && e.Reason != "" {
+			command = command + "  (" + e.Reason + ")"
+		}
+		data = append(data, []string{
+			string(e.Phase),
+			trunc(name, vw),
+			actionCell(e.Action, ""),
+			trunc(command, vw*2),
 		})
 	}
 	return tr.ptermTable(w, data)

--- a/internal/engine/render/plan_text.go
+++ b/internal/engine/render/plan_text.go
@@ -35,7 +35,7 @@ const planTargetSoftLimit = 60
 func (pr *planTextRenderer) Render(w io.Writer, r *PlanReport) error {
 	slog.Debug("rendering plan text output")
 
-	if len(r.Repositories) == 0 && len(r.Skills) == 0 && len(r.MCPs) == 0 {
+	if len(r.Repositories) == 0 && len(r.Skills) == 0 && len(r.MCPs) == 0 && len(r.Hooks) == 0 {
 		fmt.Fprintln(w, "nothing to do")
 		return nil
 	}
@@ -44,6 +44,7 @@ func (pr *planTextRenderer) Render(w io.Writer, r *PlanReport) error {
 	pr.writeRepos(w, r.Repositories)
 	pr.writeSkills(w, r.Skills)
 	pr.writeMCPs(w, r.MCPs)
+	pr.writeHooks(w, r.Hooks)
 
 	switch {
 	case r.HasErrors:
@@ -226,19 +227,80 @@ func (pr *planTextRenderer) writeMCPs(w io.Writer, entries []PlanMCPEntry) {
 	pr.writeSection(w, "mcps", rows)
 }
 
+func (pr *planTextRenderer) writeHooks(w io.Writer, entries []PlanHookEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	// Group by phase so the user sees "pre-sync" then "post-sync".
+	pre, post := splitHooksByPhase(entries)
+	if len(pre) > 0 {
+		pr.writeSection(w, "pre-sync hooks", hookRows(pre))
+	}
+	if len(post) > 0 {
+		pr.writeSection(w, "post-sync hooks", hookRows(post))
+	}
+}
+
+func splitHooksByPhase(entries []PlanHookEntry) (pre, post []PlanHookEntry) {
+	for _, e := range entries {
+		if e.Phase == HookPreSync {
+			pre = append(pre, e)
+		} else {
+			post = append(post, e)
+		}
+	}
+	return pre, post
+}
+
+func hookRows(entries []PlanHookEntry) []planRow {
+	rows := make([]planRow, 0, len(entries))
+	for _, e := range entries {
+		rows = append(rows, planRow{
+			marker: planMarker(e.Action),
+			verb:   planVerb(e.Action, "hook"),
+			name:   hookDisplayName(e),
+			detail: hookPlanDetail(e),
+			action: e.Action,
+		})
+	}
+	return rows
+}
+
+func hookDisplayName(e PlanHookEntry) string {
+	if e.Name != "" {
+		return e.Name
+	}
+	return e.Command
+}
+
+func hookPlanDetail(e PlanHookEntry) string {
+	if e.Action == PlanSkip {
+		if e.Reason != "" {
+			return "(" + e.Reason + ")"
+		}
+		return "(skipped)"
+	}
+	if len(e.Args) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(e.Args, " ") + "]"
+}
+
 // actionRank orders plan actions within a section: errors first (most
-// urgent), then creates/updates, then no-ops (passive / already done).
-// Stable sorts preserve input order within each rank.
+// urgent), then creates/updates/runs, then no-ops, then skips. Stable sorts
+// preserve input order within each rank — hooks keep declared order this way.
 func actionRank(a PlanAction) int {
 	switch a {
 	case PlanError:
 		return 0
-	case PlanClone, PlanCreate, PlanUpdate:
+	case PlanClone, PlanCreate, PlanUpdate, PlanRun:
 		return 1
 	case PlanNoOp:
 		return 2
-	default:
+	case PlanSkip:
 		return 3
+	default:
+		return 4
 	}
 }
 
@@ -253,6 +315,10 @@ func planMarker(a PlanAction) string {
 		return "~"
 	case PlanError:
 		return "✗"
+	case PlanRun:
+		return ">"
+	case PlanSkip:
+		return "-"
 	default:
 		return "·"
 	}
@@ -290,6 +356,15 @@ func planVerb(a PlanAction, kind string) string {
 			return "upsert"
 		case PlanUpdate:
 			return "update"
+		case PlanError:
+			return "error"
+		}
+	case "hook":
+		switch a {
+		case PlanRun:
+			return "run"
+		case PlanSkip:
+			return "skip"
 		case PlanError:
 			return "error"
 		}

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -97,7 +97,32 @@ const (
 	PlanUpdate PlanAction = "update"
 	PlanCreate PlanAction = "create"
 	PlanError  PlanAction = "error"
+	// PlanRun marks a hook whose command would be invoked.
+	PlanRun PlanAction = "run"
+	// PlanSkip marks a hook excluded from this run (e.g. by an OS filter).
+	PlanSkip PlanAction = "skip"
 )
+
+// HookPhase identifies when in the sync pipeline a hook fires.
+type HookPhase string
+
+const (
+	HookPreSync  HookPhase = "pre-sync"
+	HookPostSync HookPhase = "post-sync"
+)
+
+// PlanHookEntry describes a single hook that would run (or would be skipped)
+// during the current sync. Hooks live outside the StatusReport because they
+// have no on-disk state to query; they are computed straight from the loaded
+// config plus the current GOOS.
+type PlanHookEntry struct {
+	Phase   HookPhase  `json:"phase"`
+	Name    string     `json:"name,omitempty"`
+	Command string     `json:"command"`
+	Args    []string   `json:"args,omitempty"`
+	Action  PlanAction `json:"action"`
+	Reason  string     `json:"reason,omitempty"` // populated when Action == PlanSkip
+}
 
 // PlanRepoEntry describes the planned action for a single repository.
 type PlanRepoEntry struct {
@@ -137,6 +162,7 @@ type PlanReport struct {
 	Repositories []PlanRepoEntry  `json:"repositories"`
 	Skills       []PlanSkillEntry `json:"skills"`
 	MCPs         []PlanMCPEntry   `json:"mcps"`
+	Hooks        []PlanHookEntry  `json:"hooks,omitempty"`
 	HasChanges   bool             `json:"has_changes"`
 	HasErrors    bool             `json:"has_errors"`
 }

--- a/internal/engine/render/summary_plan.go
+++ b/internal/engine/render/summary_plan.go
@@ -34,12 +34,13 @@ type planSummaryRow struct {
 func (r *summaryPlanRenderer) Render(w io.Writer, report *PlanReport) error {
 	slog.Debug("rendering summary plan output")
 
-	if len(report.Repositories) == 0 && len(report.Skills) == 0 && len(report.MCPs) == 0 {
+	if len(report.Repositories) == 0 && len(report.Skills) == 0 && len(report.MCPs) == 0 && len(report.Hooks) == 0 {
 		fmt.Fprintln(w, "nothing to do")
 		return nil
 	}
 
 	rows, noopCount := buildSummaryPlanRows(report)
+	rows = append(rows, hookSummaryRows(report.Hooks)...)
 
 	fmt.Fprintln(w, "Plan:")
 
@@ -230,4 +231,41 @@ func pluralise(n int, one, many string) string {
 		return fmt.Sprintf("%d %s", n, one)
 	}
 	return fmt.Sprintf("%d %s", n, many)
+}
+
+// hookSummaryRows compresses planned hooks into one row per phase per action.
+// We don't expand every hook — for v1 the summary stays one line per "N
+// pre-sync hooks would run" so the rest of the plan output isn't drowned out
+// by long hook lists.
+func hookSummaryRows(entries []PlanHookEntry) []planSummaryRow {
+	var rows []planSummaryRow
+	var preRun, postRun, preSkip, postSkip int
+	for _, e := range entries {
+		switch {
+		case e.Phase == HookPreSync && e.Action == PlanRun:
+			preRun++
+		case e.Phase == HookPostSync && e.Action == PlanRun:
+			postRun++
+		case e.Phase == HookPreSync && e.Action == PlanSkip:
+			preSkip++
+		case e.Phase == HookPostSync && e.Action == PlanSkip:
+			postSkip++
+		}
+	}
+	add := func(verb string, n int, action PlanAction, label string) {
+		if n == 0 {
+			return
+		}
+		rows = append(rows, planSummaryRow{
+			marker: planMarker(action),
+			verb:   verb,
+			name:   pluralise(n, label, label+"s"),
+			action: action,
+		})
+	}
+	add("pre-sync", preRun, PlanRun, "hook")
+	add("post-sync", postRun, PlanRun, "hook")
+	add("pre-sync", preSkip, PlanSkip, "hook")
+	add("post-sync", postSkip, PlanSkip, "hook")
+	return rows
 }


### PR DESCRIPTION
Closes #219.

## Summary

- Adds a `hooks:` block to `gaal.yaml` with `pre-sync` and `post-sync` lists. Each hook is exec-form (`command` + `args[]`) so the same config works across Linux, macOS, and Windows — no shell is involved, tokens are passed verbatim, and `~/`, `\$VAR`, `\${VAR}` are expanded at run time.
- Pre-sync runs before any resource is touched. A non-zero exit aborts the sync (overridable per hook with `continue_on_error: true`).
- Post-sync runs only after a fully successful sync (`#219` requires "strictly post-success"). Skipped on any sync or prune error.
- Both phases receive `GAAL_HOOK_PHASE`, `GAAL_PLANNED_*`, `GAAL_CHANGED_*`, `GAAL_HAS_CHANGES`, `GAAL_HAS_ERRORS` so hooks can react to what actually changed.
- Service mode runs hooks each iteration but never exits the loop on hook failure — pre-sync failure skips that iteration's sync, post-sync failure is logged.
- Dry-run lists hooks (`> run` / `- skip`) in text, table, and JSON renderers without invoking them.
- Per-hook optional `os:` filter (`[linux, darwin, windows]`) skips a hook on platforms where it doesn't apply, so one config file can target multiple machines.
- Per-hook optional `timeout` (Go duration string; default 5m), `cwd`, `env`, and `name` (used for log/dry-run output).
- Multi-level merge: workspace-level hooks are appended after user/global, so workspace hooks fire last at each phase.

## What changed

- New `internal/engine/hooks` package: `Manager` with `Plan`, `RunPreSync`, `RunPostSync`; pluggable `Executor` for tests; `defaultExecutor` wires stdout/stderr straight to gaal so hook output is visible.
- `internal/config` gains `ConfigHooks` + `ConfigHook` with full validation (required command, OS enum, timeout-string parse).
- `internal/engine/render` gains `PlanHookEntry`, `PlanRun`, `PlanSkip` actions and rendering in the three plan renderers + the summary plan.
- `cmd/sync.go` runs pre-sync after the plan and post-sync after the summary; sync errors short-circuit post-sync.
- `internal/engine.RunService` calls hooks per iteration and never exits the loop on hook failure.
- Docs: `docs/commands/sync.md` gains a new "Hooks" section with flow diagram and env-var table; `docs/config.md` mentions the merge rule.
- `example.gaal.yaml` shows a fully commented `hooks:` block including the dotclaude `git -C ~/.claude pull` use case from #219.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes (no regressions)
- [x] `go test -race ./internal/engine/hooks/... ./internal/config/... ./internal/engine/...` passes
- [x] Manual smoke: pre + post hooks fire with `GAAL_*` env populated; OS filter silently skips
- [x] Manual smoke: failing pre-sync hook aborts sync with non-zero exit, post-sync does not run
- [x] Manual smoke: `gaal sync --dry-run -o table` and `-o json` list hooks correctly