### PR TITLE
fix: declare remote URL precedence and surface mismatch errors (#220)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -148,6 +148,32 @@ Intra-file duplicates (same `Source` or `Name` within a single file) are
 silently dropped, keeping the first occurrence. Cross-level deduplication
 follows the upsert rules above.
 
+### Repositories: remote URL precedence
+
+When `repositories.<path>` points at an existing git working copy, gaal
+**honors the working copy's existing `origin` URL** during `gaal sync`. The
+`url:` declared in `gaal.yaml` is used only on the initial clone; subsequent
+fetches go to whatever `origin` currently points at. gaal never rewrites
+`origin` — the working copy is yours.
+
+If the two URLs disagree — for example, `gaal.yaml` says
+`https://github.com/owner/repo.git` but `origin` is
+`git@github.com:owner/repo.git` — `gaal sync` returns a
+`RemoteURLMismatchError` instead of attempting the fetch. The error names
+both URLs and the working copy path, so users hit a clear precedence message
+instead of a leaked SSH-agent or HTTPS-auth error. URL comparison is
+normalised: scheme, credentials, trailing `.git`, and trailing slashes are
+ignored, so syntactic-only variants do not trigger the error.
+
+To resolve a real mismatch, pick one source of truth:
+
+- Change the remote to match `gaal.yaml`: `git remote set-url origin <gaal.yaml URL>`.
+- Or update `url:` in `gaal.yaml` to match the working copy's remote.
+
+This rule applies to the `git` backend only; archive (`tar` / `zip`) backends
+have no remote URL, and `hg` / `svn` / `bzr` checkouts are not currently
+inspected.
+
 ---
 
 ## Scope Restriction Policy

--- a/docs/packages/core-vcs.md
+++ b/docs/packages/core-vcs.md
@@ -11,11 +11,24 @@
 
 | Symbol | Description |
 |--------|-------------|
-| `VCS` | Interface: `Clone`, `Update`, `IsCloned`, `CurrentVersion`, `HasChanges` |
+| `VCS` | Interface: `Clone(ctx, url, path, version)`, `Update(ctx, url, path, version)`, `IsCloned`, `CurrentVersion`, `HasChanges` |
 | `New(vcsType string) (VCS, error)` | Factory by type string |
 | `NewShallow(vcsType string) (VCS, error)` | Same, but git is `depth=1` (used for skill caches) |
 | `DetectType(source string) string` | Auto-detect from URL or local path |
 | `VcsGit`, `VcsMercurial`, `VcsSVN`, `VcsBazaar`, `VcsArchive` | Backend types |
+| `RemoteURLMismatchError` | Typed error returned by `VcsGit.Update` when the working copy's `origin` URL disagrees with the configured URL (#220) |
+
+### URL parameter on `Update`
+
+`Update` accepts the configured URL alongside `path` and `version`. Today
+only `VcsGit` consumes it: when non-empty, the backend reads `origin`'s
+URL and returns a `*RemoteURLMismatchError` if it does not match. The
+comparison strips scheme, credentials, trailing `.git`, and trailing
+slashes; the host is lowercased while the path segment preserves case so
+case-sensitive forges are handled correctly. Pass `""` to skip the
+check — the skill manager does this for both local-path skills and
+gaal-owned cache clones, because it owns the remote in the cache case
+and cannot know the original URL in the local-path case.
 
 ## Backends
 
@@ -99,6 +112,7 @@ options.
 |----|-------|--------|
 | #117 | scheme allowlist | `ValidateRepoURL` enforces https/ssh/git + loopback-only http/svn/bzr |
 | #116 | argv injection | `--` separator + operand validation across all subprocess backends |
+| #220 | remote URL precedence | `VcsGit.Update` returns `*RemoteURLMismatchError` when the working copy's `origin` disagrees with the configured URL — `Update` signature gains a leading `url` parameter (other backends ignore it) |
 | (open) #207 | partial-clone recovery | `VcsGit.IsCloned` validates HEAD; `Clone` stages + atomically swaps |
 | (open) #206 | archive update | `VcsArchive.Update` re-fetches and atomically replaces; interface gains `url` parameter |
 

--- a/docs/packages/repo.md
+++ b/docs/packages/repo.md
@@ -65,6 +65,17 @@ completion; errors are collected via the buffered channel and joined
 via `errors.Join`. The caller (`engine.RunOnce`) surfaces the joined
 error to the user along with the partial-success summary.
 
+### `RemoteURLMismatchError` (git only)
+
+When `repositories.<path>` points at an existing git working copy whose
+`origin` URL disagrees with `url:` in `gaal.yaml`, `VcsGit.Update`
+returns a typed `*vcs.RemoteURLMismatchError` **before** any fetch — so
+the user gets a precedence message instead of a leaked SSH-agent or
+HTTPS-auth error. Manager wraps with
+`fmt.Errorf("repo %q: %w", path, err)`; `errors.As` still matches the
+typed error through the wrap. See
+[Repositories: remote URL precedence](../config.md#repositories-remote-url-precedence).
+
 ## Related
 
 - [`packages/core-vcs.md`](core-vcs.md) — backends.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -100,6 +100,8 @@ mcps:
           env: CF_ACCESS_CLIENT_SECRET
 ```
 
+> **Repositories — remote URL precedence.** For an existing git working copy, `url:` is used only on the initial clone — subsequent fetches go to the working copy's `origin`. If the two disagree, `gaal sync` stops with an explicit `RemoteURLMismatchError`. See [config.md — Repositories: remote URL precedence](config.md#repositories-remote-url-precedence).
+
 ### Configuration reference
 
 For the complete field reference, merge rules, scope restriction policy, and

--- a/internal/core/vcs/archive.go
+++ b/internal/core/vcs/archive.go
@@ -74,7 +74,7 @@ func (a *VcsArchive) Clone(ctx context.Context, url, path, version string) error
 }
 
 // Update re-downloads and extracts the archive (no incremental update possible).
-func (a *VcsArchive) Update(ctx context.Context, path, version string) error {
+func (a *VcsArchive) Update(_ context.Context, _, _, _ string) error {
 	// Archives have no "version" concept — just re-extract.
 	// We need the URL: it is not stored in the struct, so Update is a no-op
 	// for archives. The manager should call Clone instead.

--- a/internal/core/vcs/archive_test.go
+++ b/internal/core/vcs/archive_test.go
@@ -85,7 +85,7 @@ func TestVcsArchive_CurrentVersion(t *testing.T) {
 
 func TestVcsArchive_Update_NoOp(t *testing.T) {
 	a := &VcsArchive{Format: "tar"}
-	err := a.Update(context.Background(), t.TempDir(), "")
+	err := a.Update(context.Background(), "", t.TempDir(), "")
 	if err != nil {
 		t.Errorf("Update should be a no-op, got error: %v", err)
 	}

--- a/internal/core/vcs/bzr.go
+++ b/internal/core/vcs/bzr.go
@@ -43,7 +43,7 @@ func (b *VcsBazaar) Clone(ctx context.Context, url, path, version string) error 
 	return runner.Run(ctx, "branching "+shortPath(path), "", "bzr", args...)
 }
 
-func (b *VcsBazaar) Update(ctx context.Context, path, version string) error {
+func (b *VcsBazaar) Update(ctx context.Context, _, path, version string) error {
 	if err := requireBinary("bzr"); err != nil {
 		return err
 	}

--- a/internal/core/vcs/bzr_test.go
+++ b/internal/core/vcs/bzr_test.go
@@ -43,7 +43,7 @@ func TestVcsBazaar_Clone_NoBinary(t *testing.T) {
 func TestVcsBazaar_Update_NoBinary(t *testing.T) {
 	t.Setenv("PATH", "")
 	b := &VcsBazaar{}
-	err := b.Update(context.Background(), t.TempDir(), "")
+	err := b.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when bzr binary missing")
 	}
@@ -86,7 +86,7 @@ func TestVcsBazaar_Update_FakeBin(t *testing.T) {
 	binDir := makeFakeBin(t, "bzr", "exit 0")
 	t.Setenv("PATH", binDir)
 	b := &VcsBazaar{}
-	if err := b.Update(context.Background(), t.TempDir(), ""); err != nil {
+	if err := b.Update(context.Background(), "", t.TempDir(), ""); err != nil {
 		t.Fatalf("Update with fake bzr: %v", err)
 	}
 }
@@ -95,7 +95,7 @@ func TestVcsBazaar_Update_FakeBin_WithVersion(t *testing.T) {
 	binDir := makeFakeBin(t, "bzr", "exit 0")
 	t.Setenv("PATH", binDir)
 	b := &VcsBazaar{}
-	if err := b.Update(context.Background(), t.TempDir(), "2"); err != nil {
+	if err := b.Update(context.Background(), "", t.TempDir(), "2"); err != nil {
 		t.Fatalf("Update with fake bzr + version: %v", err)
 	}
 }
@@ -104,7 +104,7 @@ func TestVcsBazaar_Update_PullFails(t *testing.T) {
 	binDir := makeFakeBin(t, "bzr", "exit 1")
 	t.Setenv("PATH", binDir)
 	b := &VcsBazaar{}
-	err := b.Update(context.Background(), t.TempDir(), "")
+	err := b.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when bzr pull fails")
 	}

--- a/internal/core/vcs/git.go
+++ b/internal/core/vcs/git.go
@@ -65,6 +65,19 @@ func (g *VcsGit) Update(ctx context.Context, url, path, version string) error {
 		return fmt.Errorf("opening repository at %s: %w", shortPath(path), err)
 	}
 
+	if url != "" {
+		if remote, rerr := r.Remote("origin"); rerr == nil && len(remote.Config().URLs) > 0 {
+			actual := remote.Config().URLs[0]
+			if normalizeGitURL(actual) != normalizeGitURL(url) {
+				return &RemoteURLMismatchError{
+					Path:          path,
+					ConfiguredURL: url,
+					RemoteURL:     actual,
+				}
+			}
+		}
+	}
+
 	slog.DebugContext(ctx, "fetching", "path", shortPath(path))
 
 	fetchErr := r.FetchContext(ctx, &gogit.FetchOptions{

--- a/internal/core/vcs/git.go
+++ b/internal/core/vcs/git.go
@@ -59,7 +59,7 @@ func (g *VcsGit) Clone(ctx context.Context, url, path, version string) error {
 	return nil
 }
 
-func (g *VcsGit) Update(ctx context.Context, path, version string) error {
+func (g *VcsGit) Update(ctx context.Context, url, path, version string) error {
 	r, err := gogit.PlainOpen(path)
 	if err != nil {
 		return fmt.Errorf("opening repository at %s: %w", shortPath(path), err)

--- a/internal/core/vcs/git_mismatch.go
+++ b/internal/core/vcs/git_mismatch.go
@@ -1,0 +1,106 @@
+package vcs
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// RemoteURLMismatchError is returned by VcsGit.Update when the working copy's
+// origin URL does not match the URL declared in gaal.yaml. gaal honors the
+// existing remote (it never rewrites origin during sync); this error tells the
+// user up-front that the two disagree, instead of leaking the low-level fetch
+// failure that the protocol mismatch usually triggers (e.g. SSH agent missing
+// when gaal.yaml is HTTPS but origin is SSH).
+type RemoteURLMismatchError struct {
+	Path          string // working copy path
+	ConfiguredURL string // url: from gaal.yaml
+	RemoteURL     string // origin URL inside the working copy
+}
+
+func (e *RemoteURLMismatchError) Error() string {
+	return fmt.Sprintf(
+		"gaal.yaml URL is %s but the remote at %s is %s; "+
+			"either update the remote (`git remote set-url origin %s`) "+
+			"or change `url:` in gaal.yaml to match (current remote: %s)",
+		urlProtocolLabel(e.ConfiguredURL),
+		e.Path,
+		urlProtocolLabel(e.RemoteURL),
+		e.ConfiguredURL,
+		e.RemoteURL,
+	)
+}
+
+// urlProtocolLabel returns a human-readable protocol label for the URL forms
+// accepted under repositories.url. Used in the mismatch error message.
+func urlProtocolLabel(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	if isSCPStyleGitURL(s) {
+		return "SSH"
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Scheme == "" {
+		return "local path"
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+		return "HTTPS"
+	case "http":
+		return "HTTP"
+	case "ssh":
+		return "SSH"
+	case "git":
+		return "git://"
+	case "file":
+		return "file://"
+	default:
+		return u.Scheme + "://"
+	}
+}
+
+// isSCPStyleGitURL detects the user@host:path form that git accepts in
+// addition to URL forms. urlx has the same heuristic but keeping a local copy
+// avoids widening urlx's API surface for this single internal call site.
+func isSCPStyleGitURL(s string) bool {
+	at := strings.Index(s, "@")
+	if at <= 0 {
+		return false
+	}
+	rest := s[at+1:]
+	colon := strings.Index(rest, ":")
+	if colon <= 0 {
+		return false
+	}
+	if strings.Contains(rest[:colon], "/") {
+		return false
+	}
+	return true
+}
+
+// normalizeGitURL strips protocol, credentials, trailing ".git", and trailing
+// slashes so two URLs pointing at the same logical repo compare equal.
+//
+// Host is lowercased (DNS is case-insensitive); path case is preserved
+// (some forges treat owner/repo segments case-sensitively).
+func normalizeGitURL(s string) string {
+	if s == "" {
+		return ""
+	}
+	if isSCPStyleGitURL(s) {
+		at := strings.Index(s, "@")
+		rest := s[at+1:]
+		colon := strings.Index(rest, ":")
+		host := strings.ToLower(rest[:colon])
+		path := strings.TrimSuffix(strings.TrimSuffix(rest[colon+1:], "/"), ".git")
+		return host + "/" + path
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Host == "" {
+		return strings.TrimSuffix(strings.TrimSuffix(s, "/"), ".git")
+	}
+	path := strings.TrimPrefix(u.Path, "/")
+	path = strings.TrimSuffix(strings.TrimSuffix(path, "/"), ".git")
+	return strings.ToLower(u.Host) + "/" + path
+}

--- a/internal/core/vcs/git_mismatch_test.go
+++ b/internal/core/vcs/git_mismatch_test.go
@@ -1,0 +1,81 @@
+package vcs
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeGitURL(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"https with .git", "https://github.com/owner/repo.git", "github.com/owner/repo"},
+		{"https without .git", "https://github.com/owner/repo", "github.com/owner/repo"},
+		{"https trailing slash", "https://github.com/owner/repo/", "github.com/owner/repo"},
+		{"ssh url", "ssh://git@github.com/owner/repo.git", "github.com/owner/repo"},
+		{"scp-style", "git@github.com:owner/repo.git", "github.com/owner/repo"},
+		{"scp-style no .git", "git@github.com:owner/repo", "github.com/owner/repo"},
+		{"git protocol", "git://github.com/owner/repo.git", "github.com/owner/repo"},
+		{"case difference", "HTTPS://GITHUB.com/Owner/Repo.git", "github.com/Owner/Repo"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeGitURL(tc.in)
+			if got != tc.want {
+				t.Errorf("normalizeGitURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestURLProtocolLabel(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://github.com/o/r.git", "HTTPS"},
+		{"http://localhost/r", "HTTP"},
+		{"ssh://git@github.com/o/r", "SSH"},
+		{"git@github.com:o/r.git", "SSH"},
+		{"git://github.com/o/r", "git://"},
+		{"file:///tmp/r", "file://"},
+		{"/tmp/r", "local path"},
+		{"", "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := urlProtocolLabel(tc.in); got != tc.want {
+				t.Errorf("urlProtocolLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRemoteURLMismatchError_Message(t *testing.T) {
+	err := &RemoteURLMismatchError{
+		Path:          "/home/u/repo",
+		ConfiguredURL: "https://github.com/owner/repo.git",
+		RemoteURL:     "git@github.com:owner/repo.git",
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"gaal.yaml URL is HTTPS",
+		"remote at /home/u/repo is SSH",
+		"https://github.com/owner/repo.git",
+		"git@github.com:owner/repo.git",
+		"git remote set-url origin",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q\n  got: %s", want, msg)
+		}
+	}
+}
+
+func TestRemoteURLMismatchError_AsTarget(t *testing.T) {
+	err := &RemoteURLMismatchError{Path: "p", ConfiguredURL: "a", RemoteURL: "b"}
+	var target *RemoteURLMismatchError
+	if !errors.As(err, &target) {
+		t.Fatal("errors.As did not match RemoteURLMismatchError")
+	}
+}

--- a/internal/core/vcs/git_test.go
+++ b/internal/core/vcs/git_test.go
@@ -72,7 +72,7 @@ func TestVcsGit_Update_AfterClone(t *testing.T) {
 	if err := g.Clone(context.Background(), srcDir, destDir, ""); err != nil {
 		t.Fatalf("Clone: %v", err)
 	}
-	err := g.Update(context.Background(), destDir, "")
+	err := g.Update(context.Background(), "", destDir, "")
 	_ = err
 }
 
@@ -238,7 +238,7 @@ func TestVcsGit_Clone_BadURL(t *testing.T) {
 
 func TestVcsGit_Update_NotARepo(t *testing.T) {
 	g := &VcsGit{}
-	err := g.Update(context.Background(), t.TempDir(), "")
+	err := g.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when updating non-git directory")
 	}
@@ -260,7 +260,7 @@ func TestVcsGit_Update_InitedRepoNoRemote(t *testing.T) {
 	g := &VcsGit{}
 	// Update will fail because there is no remote configured; this covers
 	// the fetch error branch.
-	err := g.Update(context.Background(), dir, "")
+	err := g.Update(context.Background(), "", dir, "")
 	if err == nil {
 		t.Log("update succeeded unexpectedly on repo without remote")
 	}
@@ -363,7 +363,7 @@ func TestVcsGit_Update_Shallow_ResetsToOrigin(t *testing.T) {
 		t.Fatalf("Commit: %v", err)
 	}
 
-	if err := g.Update(context.Background(), destDir, ""); err != nil {
+	if err := g.Update(context.Background(), "", destDir, ""); err != nil {
 		t.Fatalf("shallow Update: %v", err)
 	}
 	// The new file should now exist in the destination.

--- a/internal/core/vcs/git_test.go
+++ b/internal/core/vcs/git_test.go
@@ -2,14 +2,33 @@ package vcs
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
+	gogitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
+
+// setOrigin replaces origin's URL on the repo at dir.
+func setOrigin(t *testing.T, dir, urlStr string) {
+	t.Helper()
+	r, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("PlainOpen: %v", err)
+	}
+	cfg, err := r.Config()
+	if err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+	cfg.Remotes["origin"] = &gogitconfig.RemoteConfig{Name: "origin", URLs: []string{urlStr}}
+	if err := r.SetConfig(cfg); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+}
 
 // makeLocalRepo initialises a git repo in dir, creates one file, and commits it.
 func makeLocalRepo(t *testing.T, dir string) *gogit.Repository {
@@ -369,5 +388,75 @@ func TestVcsGit_Update_Shallow_ResetsToOrigin(t *testing.T) {
 	// The new file should now exist in the destination.
 	if _, err := os.Stat(filepath.Join(destDir, "extra.txt")); err != nil {
 		t.Errorf("expected extra.txt after shallow update: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VcsGit - Update URL mismatch detection (#220)
+// ---------------------------------------------------------------------------
+
+func TestVcsGit_Update_URLMismatch_HTTPSvsSSH(t *testing.T) {
+	srcDir := t.TempDir()
+	makeLocalRepo(t, srcDir)
+	destDir := filepath.Join(t.TempDir(), "clone")
+	g := &VcsGit{}
+	if err := g.Clone(context.Background(), srcDir, destDir, ""); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	// Rewrite origin so it points at a different host (real mismatch).
+	setOrigin(t, destDir, "git@gitlab.example.com:owner/repo.git")
+
+	err := g.Update(context.Background(), "https://github.com/owner/repo.git", destDir, "")
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+	var mm *RemoteURLMismatchError
+	if !errors.As(err, &mm) {
+		t.Fatalf("expected *RemoteURLMismatchError, got %T: %v", err, err)
+	}
+	if mm.Path != destDir {
+		t.Errorf("Path = %q, want %q", mm.Path, destDir)
+	}
+	if mm.ConfiguredURL != "https://github.com/owner/repo.git" {
+		t.Errorf("ConfiguredURL = %q", mm.ConfiguredURL)
+	}
+	if mm.RemoteURL != "git@gitlab.example.com:owner/repo.git" {
+		t.Errorf("RemoteURL = %q", mm.RemoteURL)
+	}
+}
+
+func TestVcsGit_Update_URLMismatch_EmptyURLSkipsCheck(t *testing.T) {
+	srcDir := t.TempDir()
+	makeLocalRepo(t, srcDir)
+	destDir := filepath.Join(t.TempDir(), "clone")
+	g := &VcsGit{}
+	if err := g.Clone(context.Background(), srcDir, destDir, ""); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	// Origin pointing at something gaal would normally flag — but with an
+	// empty configured URL we must skip the check entirely (skill manager
+	// behaviour).
+	setOrigin(t, destDir, "https://elsewhere.invalid/x.git")
+	err := g.Update(context.Background(), "", destDir, "")
+	var mm *RemoteURLMismatchError
+	if errors.As(err, &mm) {
+		t.Fatalf("did not expect mismatch error with empty URL, got: %v", err)
+	}
+}
+
+func TestVcsGit_Update_URLMatch_NormalisedEquivalent(t *testing.T) {
+	srcDir := t.TempDir()
+	makeLocalRepo(t, srcDir)
+	destDir := filepath.Join(t.TempDir(), "clone")
+	g := &VcsGit{}
+	if err := g.Clone(context.Background(), srcDir, destDir, ""); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	// Configured URL adds a trailing slash; origin keeps the bare path. The
+	// normaliser must collapse these so no mismatch is raised.
+	err := g.Update(context.Background(), srcDir+"/", destDir, "")
+	var mm *RemoteURLMismatchError
+	if errors.As(err, &mm) {
+		t.Fatalf("unexpected mismatch for equivalent URLs: %v", err)
 	}
 }

--- a/internal/core/vcs/hg.go
+++ b/internal/core/vcs/hg.go
@@ -43,7 +43,7 @@ func (m *VcsMercurial) Clone(ctx context.Context, url, path, version string) err
 	return runner.Run(ctx, "cloning "+shortPath(path), "", "hg", args...)
 }
 
-func (m *VcsMercurial) Update(ctx context.Context, path, version string) error {
+func (m *VcsMercurial) Update(ctx context.Context, _, path, version string) error {
 	if err := requireBinary("hg"); err != nil {
 		return err
 	}

--- a/internal/core/vcs/hg_test.go
+++ b/internal/core/vcs/hg_test.go
@@ -43,7 +43,7 @@ func TestVcsMercurial_Clone_NoBinary(t *testing.T) {
 func TestVcsMercurial_Update_NoBinary(t *testing.T) {
 	t.Setenv("PATH", "")
 	m := &VcsMercurial{}
-	err := m.Update(context.Background(), t.TempDir(), "")
+	err := m.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when hg binary missing")
 	}
@@ -86,7 +86,7 @@ func TestVcsMercurial_Update_FakeBin(t *testing.T) {
 	binDir := makeFakeBin(t, "hg", "exit 0")
 	t.Setenv("PATH", binDir)
 	m := &VcsMercurial{}
-	if err := m.Update(context.Background(), t.TempDir(), ""); err != nil {
+	if err := m.Update(context.Background(), "", t.TempDir(), ""); err != nil {
 		t.Fatalf("Update with fake hg: %v", err)
 	}
 }
@@ -95,7 +95,7 @@ func TestVcsMercurial_Update_FakeBin_WithVersion(t *testing.T) {
 	binDir := makeFakeBin(t, "hg", "exit 0")
 	t.Setenv("PATH", binDir)
 	m := &VcsMercurial{}
-	if err := m.Update(context.Background(), t.TempDir(), "tip"); err != nil {
+	if err := m.Update(context.Background(), "", t.TempDir(), "tip"); err != nil {
 		t.Fatalf("Update with fake hg + version: %v", err)
 	}
 }
@@ -104,7 +104,7 @@ func TestVcsMercurial_Update_PullFails(t *testing.T) {
 	binDir := makeFakeBin(t, "hg", "exit 1")
 	t.Setenv("PATH", binDir)
 	m := &VcsMercurial{}
-	err := m.Update(context.Background(), t.TempDir(), "")
+	err := m.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when hg pull fails")
 	}

--- a/internal/core/vcs/svn.go
+++ b/internal/core/vcs/svn.go
@@ -43,7 +43,7 @@ func (s *VcsSVN) Clone(ctx context.Context, url, path, version string) error {
 	return runner.Run(ctx, "checkout "+shortPath(path), "", "svn", args...)
 }
 
-func (s *VcsSVN) Update(ctx context.Context, path, version string) error {
+func (s *VcsSVN) Update(ctx context.Context, _, path, version string) error {
 	if err := requireBinary("svn"); err != nil {
 		return err
 	}

--- a/internal/core/vcs/svn_test.go
+++ b/internal/core/vcs/svn_test.go
@@ -43,7 +43,7 @@ func TestVcsSVN_Clone_NoBinary(t *testing.T) {
 func TestVcsSVN_Update_NoBinary(t *testing.T) {
 	t.Setenv("PATH", "")
 	s := &VcsSVN{}
-	err := s.Update(context.Background(), t.TempDir(), "")
+	err := s.Update(context.Background(), "", t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error when svn binary missing")
 	}
@@ -86,7 +86,7 @@ func TestVcsSVN_Update_FakeBin(t *testing.T) {
 	binDir := makeFakeBin(t, "svn", "exit 0")
 	t.Setenv("PATH", binDir)
 	s := &VcsSVN{}
-	if err := s.Update(context.Background(), t.TempDir(), ""); err != nil {
+	if err := s.Update(context.Background(), "", t.TempDir(), ""); err != nil {
 		t.Fatalf("Update with fake svn: %v", err)
 	}
 }
@@ -95,7 +95,7 @@ func TestVcsSVN_Update_FakeBin_WithVersion(t *testing.T) {
 	binDir := makeFakeBin(t, "svn", "exit 0")
 	t.Setenv("PATH", binDir)
 	s := &VcsSVN{}
-	if err := s.Update(context.Background(), t.TempDir(), "42"); err != nil {
+	if err := s.Update(context.Background(), "", t.TempDir(), "42"); err != nil {
 		t.Fatalf("Update with fake svn + version: %v", err)
 	}
 }

--- a/internal/core/vcs/vcs.go
+++ b/internal/core/vcs/vcs.go
@@ -12,7 +12,13 @@ type VCS interface {
 	Clone(ctx context.Context, url, path, version string) error
 
 	// Update fetches and checks out version in an already-cloned repo at path.
-	Update(ctx context.Context, path, version string) error
+	// If version is empty the default branch is used.
+	//
+	// url is the URL declared in gaal.yaml. Backends that track a remote URL
+	// (currently only git) compare it against the working copy's existing
+	// remote and return a *RemoteURLMismatchError on disagreement. Pass "" to
+	// skip the check.
+	Update(ctx context.Context, url, path, version string) error
 
 	// IsCloned reports whether path contains a valid local working copy.
 	IsCloned(path string) bool

--- a/internal/repo/backends_test.go
+++ b/internal/repo/backends_test.go
@@ -2,9 +2,18 @@ package repo
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	gogitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"gaal/internal/config"
+	"gaal/internal/core/vcs"
 )
 
 // ---------------------------------------------------------------------------
@@ -108,5 +117,71 @@ func TestManager_Status_DirtyFalse_Archive(t *testing.T) {
 	}
 	if statuses[0].Dirty {
 		t.Error("expected Dirty=false for archive backend")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager.Sync - URL mismatch wraps *vcs.RemoteURLMismatchError (#220)
+// ---------------------------------------------------------------------------
+
+func TestManager_Sync_URLMismatchReturnsStructuredError(t *testing.T) {
+	srcDir := t.TempDir()
+	r, err := gogit.PlainInit(srcDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "f"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := w.Add("f"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := w.Commit("c", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@t", When: time.Now()},
+	}); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	destDir := filepath.Join(t.TempDir(), "wc")
+	gitBackend, err := vcs.New("git")
+	if err != nil {
+		t.Fatalf("vcs.New: %v", err)
+	}
+	if err := gitBackend.Clone(context.Background(), srcDir, destDir, ""); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	// Rewrite origin so it disagrees with what we'll declare in gaal.yaml.
+	rr, err := gogit.PlainOpen(destDir)
+	if err != nil {
+		t.Fatalf("PlainOpen: %v", err)
+	}
+	cfg, err := rr.Config()
+	if err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+	cfg.Remotes["origin"] = &gogitconfig.RemoteConfig{Name: "origin", URLs: []string{"git@gitlab.example.com:owner/repo.git"}}
+	if err := rr.SetConfig(cfg); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	repos := map[string]config.ConfigRepo{
+		destDir: {Type: "git", URL: "https://github.com/owner/repo.git"},
+	}
+	m := NewManager(repos, "")
+	err = m.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected Sync to return an error")
+	}
+	var mm *vcs.RemoteURLMismatchError
+	if !errors.As(err, &mm) {
+		t.Fatalf("expected wrapped *vcs.RemoteURLMismatchError, got %T: %v", err, err)
+	}
+	if mm.Path != destDir {
+		t.Errorf("Path = %q, want %q", mm.Path, destDir)
 	}
 }

--- a/internal/repo/manager.go
+++ b/internal/repo/manager.go
@@ -78,7 +78,7 @@ func (m *Manager) syncOne(ctx context.Context, path string, cfg config.ConfigRep
 	}
 
 	slog.Debug("updating repository", "path", path)
-	return backend.Update(ctx, path, cfg.Version)
+	return backend.Update(ctx, cfg.URL, path, cfg.Version)
 }
 
 // Status returns the current status of every repository.

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -250,7 +250,7 @@ func (m *Manager) resolveSource(ctx context.Context, source string) (string, err
 		backend, err := vcs.NewShallow(vcsType)
 		if err == nil && backend.IsCloned(expanded) {
 			slog.DebugContext(ctx, "updating local source", "path", expanded, "vcs", vcsType)
-			if err := backend.Update(ctx, expanded, ""); err != nil {
+			if err := backend.Update(ctx, "", expanded, ""); err != nil {
 				slog.Warn("could not update local source", "path", expanded, "err", err)
 			}
 		}
@@ -275,7 +275,7 @@ func (m *Manager) resolveSource(ctx context.Context, source string) (string, err
 		}
 	} else {
 		slog.Debug("updating skill source", "path", localPath)
-		if err := backend.Update(ctx, localPath, ""); err != nil {
+		if err := backend.Update(ctx, "", localPath, ""); err != nil {
 			slog.Warn("could not update skill source", "path", localPath, "err", err)
 		}
 	}


### PR DESCRIPTION
## Summary

- gaal honors the working copy's existing `origin` URL on `gaal sync` for repositories declared under `repositories:` — the `url:` declared in `gaal.yaml` is used only on the initial clone. This was the de-facto behaviour; the precedence rule is now documented in `config.md`, `packages/repo.md`, `packages/core-vcs.md`, and `quick_start.md`.
- When the configured `url:` disagrees with the working copy's `origin`, `VcsGit.Update` now returns a typed `*vcs.RemoteURLMismatchError` **before** any fetch — replacing the leaked SSH-agent / HTTPS-auth errors that previously looked like gaal bugs. Example message: ``gaal.yaml URL is HTTPS but the remote at /home/u/repo is SSH; either update the remote (`git remote set-url origin https://…`) or change `url:` in gaal.yaml to match (current remote: git@…)``.
- URL comparison is normalised: scheme, credentials, trailing `.git`, and trailing slashes are stripped; host is lowercased while path case is preserved.
- `VCS.Update` signature gains a leading `url string` parameter (mirrors `Clone`). Non-git backends ignore it. The skill manager passes `""` at both call sites — gaal owns the remote there and the mismatch check would be a false positive.

Closes #220.

## Test plan

- [x] `make test` — full suite passes
- [x] `make lint` — gofmt + go vet clean
- [x] Added unit tests for the normaliser, protocol label, error message, and `errors.As` matching
- [x] Added `TestVcsGit_Update_URLMismatch_HTTPSvsSSH` — detects mismatch and asserts typed error
- [x] Added `TestVcsGit_Update_URLMismatch_EmptyURLSkipsCheck` — empty URL bypasses the check (skill-manager path)
- [x] Added `TestVcsGit_Update_URLMatch_NormalisedEquivalent` — syntactic-only differences don't trip the check
- [x] Added `TestManager_Sync_URLMismatchReturnsStructuredError` — confirms `errors.As` matches through `repo.Manager`'s wrap

## Out of scope

The issue also mentions Windows SSH detection fragility (Pageant / Windows OpenSSH agent). The clearer error message partially addresses the pain point by directing users at the URL choice instead of the agent, but improving go-git's Windows SSH transport is a separate piece of work.