### PR TITLE
feat(skill): support target subdirectories

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -140,13 +140,13 @@ Per-field merge rules:
 | `schema` | Source wins if non-nil; otherwise destination is preserved |
 | `telemetry` | Source wins if non-nil **and** `scope ≤ maxscope=user` (workspace is silently ignored — see below) |
 | `repositories` | Map merge — source entry wins on key conflict |
-| `skills` | Upsert by `Source` — source entry replaces the existing entry with the same `Source` |
+| `skills` | Upsert by `Source` + `target_subdir` — source entry replaces the existing entry with the same install identity |
 | `mcps` | Upsert by `Name` — source entry replaces the existing entry with the same `Name` |
 | `hooks` | Append — higher-priority hooks run *after* lower-priority ones at the same phase, so workspace-level hooks fire last |
 
-Intra-file duplicates (same `Source` or `Name` within a single file) are
-silently dropped, keeping the first occurrence. Cross-level deduplication
-follows the upsert rules above.
+Intra-file duplicates (same skill install identity, MCP `Name`, or tool
+`Name` within a single file) are silently dropped, keeping the first
+occurrence. Cross-level deduplication follows the upsert rules above.
 
 ### Repositories: remote URL precedence
 

--- a/docs/packages/skill.md
+++ b/docs/packages/skill.md
@@ -107,6 +107,22 @@ Sandbox-aware: in `--sandbox <dir>` mode, the entire cache lives under
 | `<workDir>/<agent.ProjectSkillsDir>/` | `<home>/<agent.GlobalSkillsDir>/` |
 | Versionable alongside the project | Shared across all projects |
 
+When a skill entry sets `target_subdir`, gaal installs beneath that
+subdirectory instead:
+
+```yaml
+skills:
+  - source: ~/personal-skills
+    agents: ["aya"]
+    global: true
+    target_subdir: personal-writing
+    select: [linkedin-writer, blog-writer]
+```
+
+The selected skills land in
+`<agent skills dir>/personal-writing/<skill-name>/`. `target_subdir`
+must be a relative path without `..` segments.
+
 The agent path is resolved via `agent.SkillDir(name, global, home)` —
 see [`packages/core-agent.md`](core-agent.md). Some agents share a
 `generic` skills tree (`.agents/skills`) — the redirect happens

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -116,6 +116,7 @@ Quick reference:
 | `skills` | `source` | GitHub shorthand, full URL, SSH URL, or local path |
 | `skills` | `agents` | Agent names or `["*"]` to auto-detect |
 | `skills` | `global` | `true` = user-wide, `false` = project-local (default) |
+| `skills` | `target_subdir` | Optional subdirectory under the resolved agent skills dir |
 | `skills` | `select` | Specific skill names to install (empty = all) |
 | `mcps` | `agents` | Agent names or `["*"]` to target all agents with a non-empty MCP config |
 | `mcps` | `global` | `true` = user-wide agent config, `false` = project-scoped (default) |

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/invopop/jsonschema"
@@ -91,11 +92,12 @@ type ConfigRepo struct {
 
 // ConfigSkill defines a skill source to install.
 type ConfigSkill struct {
-	Source string       `yaml:"source"           json:"source"           jsonschema:"description=Skill source: GitHub shorthand (owner/repo), HTTPS URL, or local path" validate:"required"`
-	Agents []string     `yaml:"agents,omitempty" json:"agents,omitempty" jsonschema:"description=Target agent identifiers; use [\"*\"] to target all detected agents"`
-	Global bool         `yaml:"global,omitempty" json:"global,omitempty" jsonschema:"description=When true the skill is installed globally under ~/.<agent>/skills/ instead of the project directory"`
-	Select []string     `yaml:"select,omitempty" json:"select,omitempty" jsonschema:"description=Specific skill names to include; empty list installs all skills from the source"`
-	Tools  []ConfigTool `yaml:"tools,omitempty"  json:"tools,omitempty"  jsonschema:"description=CLI tools required by this skill; gaal doctor reports any missing ones"                             validate:"dive"`
+	Source       string       `yaml:"source"                 json:"source"                 jsonschema:"description=Skill source: GitHub shorthand (owner/repo), HTTPS URL, or local path" validate:"required"`
+	Agents       []string     `yaml:"agents,omitempty"       json:"agents,omitempty"       jsonschema:"description=Target agent identifiers; use [\"*\"] to target all detected agents"`
+	Global       bool         `yaml:"global,omitempty"       json:"global,omitempty"       jsonschema:"description=When true the skill is installed globally under ~/.<agent>/skills/ instead of the project directory"`
+	TargetSubdir string       `yaml:"target_subdir,omitempty" json:"target_subdir,omitempty" jsonschema:"description=Optional subdirectory under the resolved agent skills directory where selected skills are installed"`
+	Select       []string     `yaml:"select,omitempty"       json:"select,omitempty"       jsonschema:"description=Specific skill names to include; empty list installs all skills from the source"`
+	Tools        []ConfigTool `yaml:"tools,omitempty"        json:"tools,omitempty"        jsonschema:"description=CLI tools required by this skill; gaal doctor reports any missing ones"                             validate:"dive"`
 }
 
 // ConfigTool declares a CLI executable that is expected to be present on PATH.
@@ -374,8 +376,8 @@ func (Config) JSONSchemaExtend(s *jsonschema.Schema) {
 //   - telemetry: src wins when explicitly set (non-nil) and scope ≤ maxscope
 //     declared on the field (currently ScopeUser — workspace cannot override).
 //   - repositories: map merge — src wins on key conflict.
-//   - skills: upsert by Source — src entry replaces any existing entry with
-//     the same Source.
+//   - skills: upsert by Source + TargetSubdir — src entry replaces any
+//     existing entry with the same install identity.
 //   - mcps: upsert by Name — src entry replaces any existing entry with the
 //     same Name.
 func (c *Config) mergeFrom(src *Config, scope ConfigScope) {
@@ -399,7 +401,7 @@ func (c *Config) mergeFrom(src *Config, scope ConfigScope) {
 	}
 
 	for _, sk := range src.Skills {
-		if i := indexOf(c.Skills, func(s ConfigSkill) bool { return s.Source == sk.Source }); i >= 0 {
+		if i := indexOf(c.Skills, func(s ConfigSkill) bool { return skillIdentity(s) == skillIdentity(sk) }); i >= 0 {
 			c.Skills[i] = sk // higher-priority src wins
 		} else {
 			c.Skills = append(c.Skills, sk)
@@ -436,12 +438,17 @@ func (c *Config) mergeFrom(src *Config, scope ConfigScope) {
 }
 
 // deduplicate removes duplicate entries within this Config, keeping the first
-// occurrence. Skills are keyed by Source; MCPs are keyed by Name; Tools are
-// keyed by Name.
+// occurrence. Skills are keyed by Source + TargetSubdir; MCPs are keyed by
+// Name; Tools are keyed by Name.
 func (c *Config) deduplicate() {
-	c.Skills = deduplicate(c.Skills, func(s ConfigSkill) string { return s.Source })
+	c.Skills = deduplicate(c.Skills, skillIdentity)
 	c.MCPs = deduplicate(c.MCPs, func(m ConfigMcp) string { return m.Name })
 	c.Tools = deduplicate(c.Tools, func(t ConfigTool) string { return t.Name })
+}
+
+func skillIdentity(s ConfigSkill) string {
+	slog.Debug("building skill identity", "source", s.Source, "targetSubdir", s.TargetSubdir)
+	return s.Source + "\x00" + filepath.ToSlash(filepath.Clean(s.TargetSubdir))
 }
 
 func (c *Config) validate() error {
@@ -449,10 +456,44 @@ func (c *Config) validate() error {
 	if err := schema.Validate(c); err != nil {
 		return err
 	}
+	if err := c.validateSkillTargetSubdirs(); err != nil {
+		return err
+	}
 	if err := c.validateMCPItems(); err != nil {
 		return err
 	}
 	return c.validateHooks()
+}
+
+func (c *Config) validateSkillTargetSubdirs() error {
+	slog.Debug("validating skill target subdirectories", "skills", len(c.Skills))
+	for _, sk := range c.Skills {
+		if sk.TargetSubdir == "" {
+			continue
+		}
+		if !safeRelativeSubdir(sk.TargetSubdir) {
+			return fmt.Errorf("skill %q: target_subdir must be a relative subdirectory without '..', got %q", sk.Source, sk.TargetSubdir)
+		}
+	}
+	return nil
+}
+
+func safeRelativeSubdir(path string) bool {
+	slog.Debug("checking relative subdirectory", "path", path)
+	slashed := strings.ReplaceAll(path, `\`, "/")
+	if path == "" || filepath.IsAbs(path) || strings.HasPrefix(slashed, "/") || strings.Contains(slashed, ":") {
+		return false
+	}
+	for _, seg := range strings.Split(slashed, "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			return false
+		}
+	}
+	clean := filepath.Clean(path)
+	if clean == "." || strings.HasPrefix(filepath.ToSlash(clean), "../") || clean == ".." {
+		return false
+	}
+	return true
 }
 
 // validHookOS enumerates the GOOS values gaal will match against runtime.GOOS
@@ -551,15 +592,16 @@ func (c *Config) validateMCPItems() error {
 // []string so downstream code does not need to care.
 func (s *ConfigSkill) UnmarshalYAML(node *yaml.Node) error {
 	slog.Debug("decoding config skill", "line", node.Line, "kind", node.Kind)
-	if err := ioyaml.ValidateMappingKeys(node, "source", "agents", "global", "select", "tools"); err != nil {
+	if err := ioyaml.ValidateMappingKeys(node, "source", "agents", "global", "target_subdir", "select", "tools"); err != nil {
 		return err
 	}
 	type rawSkill struct {
-		Source string       `yaml:"source"`
-		Agents yaml.Node    `yaml:"agents,omitempty"`
-		Global bool         `yaml:"global,omitempty"`
-		Select []string     `yaml:"select,omitempty"`
-		Tools  []ConfigTool `yaml:"tools,omitempty"`
+		Source       string       `yaml:"source"`
+		Agents       yaml.Node    `yaml:"agents,omitempty"`
+		Global       bool         `yaml:"global,omitempty"`
+		TargetSubdir string       `yaml:"target_subdir,omitempty"`
+		Select       []string     `yaml:"select,omitempty"`
+		Tools        []ConfigTool `yaml:"tools,omitempty"`
 	}
 	var raw rawSkill
 	if err := node.Decode(&raw); err != nil {
@@ -568,6 +610,7 @@ func (s *ConfigSkill) UnmarshalYAML(node *yaml.Node) error {
 
 	s.Source = raw.Source
 	s.Global = raw.Global
+	s.TargetSubdir = raw.TargetSubdir
 	s.Select = raw.Select
 	s.Tools = raw.Tools
 

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -129,6 +129,47 @@ skills:
 	}
 }
 
+func TestLoad_SkillTargetSubdir(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    target_subdir: personal-writing
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Skills[0].TargetSubdir; got != "personal-writing" {
+		t.Errorf("TargetSubdir = %q, want personal-writing", got)
+	}
+}
+
+func TestLoad_SkillTargetSubdirRejectsUnsafePaths(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"absolute", "/tmp/skills"},
+		{"parent", "../skills"},
+		{"nested parent", "personal/../skills"},
+		{"windows parent", `personal\..\skills`},
+		{"windows absolute", `C:\Users\me\skills`},
+		{"dot", "."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := writeYAML(t, fmt.Sprintf(`
+skills:
+  - source: owner/repo
+    target_subdir: %q
+`, tc.path))
+			if _, err := Load(p); err == nil {
+				t.Fatal("expected unsafe target_subdir to be rejected")
+			}
+		})
+	}
+}
+
 func TestLoad_SkillAgents_NestedListIsFlattened(t *testing.T) {
 	// Regression for https://github.com/getgaal/gaal/issues/13
 	// A list-of-lists is a common hand-written mistake (mentally copying the
@@ -918,6 +959,28 @@ skills:
 	// First occurrence must be kept.
 	if len(cfg.Skills[0].Agents) == 0 || cfg.Skills[0].Agents[0] != "*" {
 		t.Errorf("expected first occurrence (agents=[*]) to be kept, got %v", cfg.Skills[0].Agents)
+	}
+}
+
+func TestLoad_SkillsWithDifferentTargetSubdirsAreDistinct(t *testing.T) {
+	p := writeYAML(t, `
+skills:
+  - source: owner/repo
+    target_subdir: personal-writing
+    select: [linkedin-writer]
+  - source: owner/repo
+    target_subdir: personal-workflow
+    select: [crm-update]
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Skills) != 2 {
+		t.Fatalf("expected 2 skill entries, got %d", len(cfg.Skills))
+	}
+	if cfg.Skills[0].TargetSubdir == cfg.Skills[1].TargetSubdir {
+		t.Errorf("expected distinct target subdirectories, got %+v", cfg.Skills)
 	}
 }
 

--- a/internal/engine/ops/plan.go
+++ b/internal/engine/ops/plan.go
@@ -114,8 +114,9 @@ func planSkills(entries []render.SkillEntry) []render.PlanSkillEntry {
 			continue
 		}
 		p := render.PlanSkillEntry{
-			Source: e.Source,
-			Agent:  e.Agent,
+			Source:       e.Source,
+			Agent:        e.Agent,
+			TargetSubdir: e.TargetSubdir,
 		}
 		switch e.Status {
 		case render.StatusError:

--- a/internal/engine/ops/status.go
+++ b/internal/engine/ops/status.go
@@ -115,6 +115,9 @@ func reconcileSkills(config []render.SkillEntry, resources []discover.Resource, 
 		if !e.Global && !filepath.IsAbs(dir) {
 			dir = filepath.Join(workDir, dir)
 		}
+		if e.TargetSubdir != "" {
+			dir = filepath.Join(dir, e.TargetSubdir)
+		}
 		managedDirs[filepath.Clean(dir)] = struct{}{}
 	}
 	slog.Debug("reconcileSkills managed dirs", "count", len(managedDirs))
@@ -251,12 +254,13 @@ func collectSkills(stats []skill.Status) []render.SkillEntry {
 	entries := make([]render.SkillEntry, 0, len(stats))
 	for _, st := range stats {
 		e := render.SkillEntry{
-			Source:    st.Source,
-			Agent:     st.AgentName,
-			Global:    st.Global,
-			Installed: nonNil(st.Installed),
-			Missing:   nonNil(st.Missing),
-			Modified:  nonNil(st.Modified),
+			Source:       st.Source,
+			Agent:        st.AgentName,
+			Global:       st.Global,
+			TargetSubdir: st.TargetSubdir,
+			Installed:    nonNil(st.Installed),
+			Missing:      nonNil(st.Missing),
+			Modified:     nonNil(st.Modified),
 		}
 		switch {
 		case st.Err != nil:

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -28,14 +28,15 @@ type RepoEntry struct {
 
 // SkillEntry holds the status of a single skill configuration.
 type SkillEntry struct {
-	Source    string     `json:"source"`
-	Agent     string     `json:"agent"`
-	Global    bool       `json:"global"`
-	Status    StatusCode `json:"status"`
-	Installed []string   `json:"installed"`
-	Missing   []string   `json:"missing"`
-	Modified  []string   `json:"modified,omitempty"`
-	Error     string     `json:"error,omitempty"`
+	Source       string     `json:"source"`
+	Agent        string     `json:"agent"`
+	Global       bool       `json:"global"`
+	TargetSubdir string     `json:"target_subdir,omitempty"`
+	Status       StatusCode `json:"status"`
+	Installed    []string   `json:"installed"`
+	Missing      []string   `json:"missing"`
+	Modified     []string   `json:"modified,omitempty"`
+	Error        string     `json:"error,omitempty"`
 }
 
 // AgentEntry holds the registry information for a supported agent.
@@ -140,13 +141,14 @@ type PlanRepoEntry struct {
 // covers — they are disjoint lists that let the plan renderer aggregate
 // rows by skill name across (source, agent) pairs.
 type PlanSkillEntry struct {
-	Source  string     `json:"source"`
-	Agent   string     `json:"agent"`
-	Action  PlanAction `json:"action"`
-	Install []string   `json:"install,omitempty"`
-	Update  []string   `json:"update,omitempty"`
-	NoOp    []string   `json:"no_op,omitempty"`
-	Error   string     `json:"error,omitempty"`
+	Source       string     `json:"source"`
+	Agent        string     `json:"agent"`
+	TargetSubdir string     `json:"target_subdir,omitempty"`
+	Action       PlanAction `json:"action"`
+	Install      []string   `json:"install,omitempty"`
+	Update       []string   `json:"update,omitempty"`
+	NoOp         []string   `json:"no_op,omitempty"`
+	Error        string     `json:"error,omitempty"`
 }
 
 // PlanMCPEntry describes the planned action for a single MCP entry.

--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -71,13 +71,14 @@ type SkillMeta struct {
 
 // Status describes the installation state of a skill configuration entry.
 type Status struct {
-	Source    string
-	AgentName string
-	Global    bool
-	Installed []string // names of installed skills
-	Missing   []string // names of skills not yet installed
-	Modified  []string // names of installed skills whose local files differ from source
-	Err       error
+	Source       string
+	AgentName    string
+	Global       bool
+	TargetSubdir string
+	Installed    []string // names of installed skills
+	Missing      []string // names of skills not yet installed
+	Modified     []string // names of installed skills whose local files differ from source
+	Err          error
 }
 
 // Manager handles skill installation and updates.
@@ -206,15 +207,14 @@ func (m *Manager) syncOne(ctx context.Context, sc config.ConfigSkill) error {
 	//    does not skip every later install.
 	var errs []error
 	for _, agent := range agents {
-		skillsDir, ok := SkillDir(agent, sc.Global, m.home)
+		skillsDir, ok, err := m.targetSkillsDir(agent, sc)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("resolving skills dir for agent %q: %w", agent, err))
+			continue
+		}
 		if !ok {
 			slog.Warn("unknown agent, skipping", "agent", agent)
 			continue
-		}
-
-		// Project-relative path needs workDir prefix.
-		if !sc.Global && !filepath.IsAbs(skillsDir) {
-			skillsDir = filepath.Join(m.workDir, skillsDir)
 		}
 
 		// Create the skills directory if it does not exist yet.
@@ -235,6 +235,34 @@ func (m *Manager) syncOne(ctx context.Context, sc config.ConfigSkill) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+func (m *Manager) targetSkillsDir(agentName string, sc config.ConfigSkill) (string, bool, error) {
+	slog.Debug("resolving target skills dir", "agent", agentName, "global", sc.Global, "targetSubdir", sc.TargetSubdir)
+	skillsDir, ok := SkillDir(agentName, sc.Global, m.home)
+	if !ok {
+		return "", false, nil
+	}
+	if !sc.Global && !filepath.IsAbs(skillsDir) {
+		skillsDir = filepath.Join(m.workDir, skillsDir)
+	}
+	if sc.TargetSubdir != "" {
+		slashed := strings.ReplaceAll(sc.TargetSubdir, `\`, "/")
+		if strings.HasPrefix(slashed, "/") || strings.Contains(slashed, ":") {
+			return "", true, fmt.Errorf("unsafe target_subdir %q", sc.TargetSubdir)
+		}
+		for _, seg := range strings.Split(slashed, "/") {
+			if seg == "" || seg == "." || seg == ".." {
+				return "", true, fmt.Errorf("unsafe target_subdir %q", sc.TargetSubdir)
+			}
+		}
+		clean := filepath.Clean(sc.TargetSubdir)
+		if filepath.IsAbs(sc.TargetSubdir) || clean == "." || clean == ".." || strings.HasPrefix(filepath.ToSlash(clean), "../") {
+			return "", true, fmt.Errorf("unsafe target_subdir %q", sc.TargetSubdir)
+		}
+		skillsDir = filepath.Join(skillsDir, sc.TargetSubdir)
+	}
+	return skillsDir, true, nil
 }
 
 // resolveSource ensures the source is available locally and returns its path.
@@ -345,16 +373,18 @@ func (m *Manager) Status(ctx context.Context) []Status {
 	for _, sc := range m.skills {
 		agents := m.resolveAgents(sc)
 		for _, agent := range agents {
-			st := Status{Source: sc.Source, AgentName: agent, Global: sc.Global}
+			st := Status{Source: sc.Source, AgentName: agent, Global: sc.Global, TargetSubdir: sc.TargetSubdir}
 
-			skillsDir, ok := SkillDir(agent, sc.Global, m.home)
+			skillsDir, ok, err := m.targetSkillsDir(agent, sc)
+			if err != nil {
+				st.Err = err
+				statuses = append(statuses, st)
+				continue
+			}
 			if !ok {
 				st.Err = fmt.Errorf("unknown agent %q", agent)
 				statuses = append(statuses, st)
 				continue
-			}
-			if !sc.Global && !filepath.IsAbs(skillsDir) {
-				skillsDir = filepath.Join(m.workDir, skillsDir)
 			}
 
 			// Resolve local source (may not be downloaded yet).
@@ -745,12 +775,9 @@ func (m *Manager) Prune(ctx context.Context) error {
 		selected := filterSkills(available, sc.Select)
 
 		for _, agent := range m.syncAgents(sc) {
-			skillsDir, ok := SkillDir(agent, sc.Global, m.home)
-			if !ok {
+			skillsDir, ok, err := m.targetSkillsDir(agent, sc)
+			if err != nil || !ok {
 				continue
-			}
-			if !sc.Global && !filepath.IsAbs(skillsDir) {
-				skillsDir = filepath.Join(m.workDir, skillsDir)
 			}
 			if expected[skillsDir] == nil {
 				expected[skillsDir] = make(map[string]struct{})

--- a/internal/skill/manager_helpers_test.go
+++ b/internal/skill/manager_helpers_test.go
@@ -106,6 +106,88 @@ func TestManager_Sync_LocalSource_WithSkills(t *testing.T) {
 	}
 }
 
+func TestManager_Sync_LocalSource_WithTargetSubdir(t *testing.T) {
+	sourceDir := t.TempDir()
+	skillDir := filepath.Join(sourceDir, "linkedin-writer")
+	os.MkdirAll(skillDir, 0o755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: linkedin-writer\n---\n"), 0o644)
+
+	home := t.TempDir()
+	os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
+	skills := []config.ConfigSkill{
+		{Source: sourceDir, Agents: []string{"claude-code"}, Global: true, TargetSubdir: "personal-writing"},
+	}
+	m := NewManager(skills, t.TempDir(), home, t.TempDir(), "", false)
+	if err := m.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	destDir := filepath.Join(home, ".claude", "skills", "personal-writing", "linkedin-writer")
+	if _, err := os.Stat(destDir); err != nil {
+		t.Errorf("expected skill installed at %q: %v", destDir, err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills", "linkedin-writer")); !os.IsNotExist(err) {
+		t.Errorf("expected root skills dir not to receive skill, got err=%v", err)
+	}
+}
+
+func TestManager_Status_TargetSubdir(t *testing.T) {
+	sourceDir := t.TempDir()
+	skillDir := filepath.Join(sourceDir, "crm-update")
+	os.MkdirAll(skillDir, 0o755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: crm-update\n---\n"), 0o644)
+
+	home := t.TempDir()
+	installed := filepath.Join(home, ".claude", "skills", "personal-workflow", "crm-update")
+	if err := installSkill(skillDir, installed); err != nil {
+		t.Fatalf("installSkill: %v", err)
+	}
+	skills := []config.ConfigSkill{
+		{Source: sourceDir, Agents: []string{"claude-code"}, Global: true, TargetSubdir: "personal-workflow"},
+	}
+	m := NewManager(skills, t.TempDir(), home, t.TempDir(), "", false)
+	statuses := m.Status(context.Background())
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	if statuses[0].TargetSubdir != "personal-workflow" {
+		t.Errorf("TargetSubdir = %q, want personal-workflow", statuses[0].TargetSubdir)
+	}
+	if len(statuses[0].Installed) != 1 || statuses[0].Installed[0] != "crm-update" {
+		t.Errorf("Installed = %v, want [crm-update]", statuses[0].Installed)
+	}
+}
+
+func TestManager_Prune_TargetSubdir(t *testing.T) {
+	sourceDir := t.TempDir()
+	skillDir := filepath.Join(sourceDir, "kept")
+	os.MkdirAll(skillDir, 0o755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: kept\n---\n"), 0o644)
+
+	home := t.TempDir()
+	targetRoot := filepath.Join(home, ".claude", "skills", "personal-workflow")
+	if err := installSkill(skillDir, filepath.Join(targetRoot, "kept")); err != nil {
+		t.Fatalf("install kept: %v", err)
+	}
+	stale := filepath.Join(targetRoot, "stale")
+	os.MkdirAll(stale, 0o755)
+	os.WriteFile(filepath.Join(stale, "SKILL.md"), []byte("---\nname: stale\n---\n"), 0o644)
+
+	skills := []config.ConfigSkill{
+		{Source: sourceDir, Agents: []string{"claude-code"}, Global: true, TargetSubdir: "personal-workflow"},
+	}
+	m := NewManager(skills, t.TempDir(), home, t.TempDir(), "", false)
+	if err := m.Prune(context.Background()); err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetRoot, "kept")); err != nil {
+		t.Errorf("expected kept skill to remain: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("expected stale skill to be pruned, got err=%v", err)
+	}
+}
+
 func TestManager_Sync_NoSkillsFound(t *testing.T) {
 	sourceDir := t.TempDir()
 	skills := []config.ConfigSkill{


### PR DESCRIPTION
Closes #221.

## Summary

- Add optional `target_subdir` to `skills:` entries.
- Install selected skills under `<resolved agent skills dir>/<target_subdir>/<skill-name>` when set.
- Keep same-source/no-subdir dedupe behavior, but allow the same source to appear multiple times when `target_subdir` differs.
- Carry target subdir through status/plan JSON and pruning logic so managed subfolders are handled correctly.
- Document the Hermes-style split-folder use case.

## Test Plan

- [x] `go test ./internal/config ./internal/skill ./internal/engine/ops ./internal/engine/render -count=1`
- [x] `make build`
- [x] `make test`
- [x] `make lint`
