### PR TITLE
feat(content): add generic content sync

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-`gaal` is a Go (1.26) CLI tool that manages three types of local resources from a single YAML configuration file:
+`gaal` is a Go (1.26) CLI tool that manages four types of local resources from a single YAML configuration file:
 
 | Resource | Description |
 |----------|-------------|
 | **Repositories** | Multi-protocol repositories (git, hg, svn, bzr, tar, zip) |
 | **Skills** | `SKILL.md` file collections installed into AI agent directories |
+| **Content** | Generic file/directory mappings for agent instructions, commands, rules, and settings |
 | **MCPs** | MCP (*Model Context Protocol*) server configuration entries injected into JSON files |
 
 ---

--- a/docs/config.md
+++ b/docs/config.md
@@ -109,6 +109,7 @@ Config
 ├── Schema        *int
 ├── Repositories  map[string]ConfigRepo
 ├── Skills        []ConfigSkill
+├── Content       []ConfigContent
 ├── MCPs          []ConfigMcp
 │                   └── Inline  *ConfigMcpItem
 ├── Hooks         *ConfigHooks
@@ -141,6 +142,7 @@ Per-field merge rules:
 | `telemetry` | Source wins if non-nil **and** `scope ≤ maxscope=user` (workspace is silently ignored — see below) |
 | `repositories` | Map merge — source entry wins on key conflict |
 | `skills` | Upsert by `Source` + `target_subdir` — source entry replaces the existing entry with the same install identity |
+| `content` | Append, then deduplicate exact duplicate entries — repeated sources may intentionally target different agents or paths |
 | `mcps` | Upsert by `Name` — source entry replaces the existing entry with the same `Name` |
 | `hooks` | Append — higher-priority hooks run *after* lower-priority ones at the same phase, so workspace-level hooks fire last |
 

--- a/docs/packages/README.md
+++ b/docs/packages/README.md
@@ -40,6 +40,7 @@ Per-package detail below; per-command flows in
 
 | Package | Page | Role |
 |---------|------|------|
+| `internal/content` | [content.md](content.md) | Generic file/directory content sync into agent or workspace roots |
 | `internal/httpx` | [httpx.md](httpx.md) | Hardened outbound HTTP client (TLS min, redirect SSRF, body cap, UA) |
 | `internal/installscript` | [installscript.md](installscript.md) | `curl \| sh` installer payload generation |
 | `internal/logger` | [logger.md](logger.md) | Console + JSON file slog handlers |

--- a/docs/packages/content.md
+++ b/docs/packages/content.md
@@ -1,0 +1,55 @@
+# `internal/content`
+
+> Generic file and directory sync for agent-owned content that is not a
+> native `SKILL.md` package: instruction files, commands, hooks, rules, and
+> settings.
+
+## Configuration Shape
+
+```yaml
+content:
+  - source: my-org/agent-guidance
+    targets:
+      - agents: ["claude-code"]
+        scope: project
+        root: workspace
+        paths:
+          AGENTS.md: CLAUDE.md
+
+      - agents: ["codex"]
+        scope: project
+        root: workspace
+        paths:
+          AGENTS.md: AGENTS.md
+```
+
+`root: workspace` resolves destinations relative to the current project
+directory. `root: agent` resolves destinations relative to the agent config
+root inferred from the registry's skills directory, e.g. `~/.claude` from
+`~/.claude/skills`.
+
+The shorter form is useful when one target is enough:
+
+```yaml
+content:
+  - source: gregqualls/dotclaude
+    agents: ["claude-code"]
+    global: true
+    paths:
+      commands/: commands/
+      rules/: rules/
+      settings.json: settings.json
+```
+
+## Safety
+
+- Source and destination paths must be relative and cannot contain `..`.
+- Symlinks and non-regular files are skipped.
+- VCS metadata directories (`.git`, `.hg`, `.svn`, `.bzr`) are skipped.
+- Directory copies stage into a sibling temporary directory and then replace
+  the destination.
+
+## Relationship To Skills
+
+`skills:` remains the semantic `SKILL.md` resource. Use `content:` for files
+and directories that agents consume directly but that are not native skills.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -118,6 +118,10 @@ Quick reference:
 | `skills` | `global` | `true` = user-wide, `false` = project-local (default) |
 | `skills` | `target_subdir` | Optional subdirectory under the resolved agent skills dir |
 | `skills` | `select` | Specific skill names to install (empty = all) |
+| `content` | `source` | GitHub shorthand, full URL, SSH URL, or local path |
+| `content` | `targets` | Per-agent destination mappings for arbitrary files/directories |
+| `content.targets` | `root` | `workspace` for project root, `agent` for agent config root |
+| `content.targets` | `paths` | Source-relative to destination-relative mappings |
 | `mcps` | `agents` | Agent names or `["*"]` to target all agents with a non-empty MCP config |
 | `mcps` | `global` | `true` = user-wide agent config, `false` = project-scoped (default) |
 | `mcps` | `target` | _(deprecated)_ Explicit path to the agent JSON config file; prefer `agents` + `global` |
@@ -142,7 +146,8 @@ This single command:
 
 1. **Clones or updates** every repository listed under `repositories`.
 2. **Downloads and installs** every skill collection into the correct agent directories.
-3. **Upserts** every MCP server entry into the target JSON config files.
+3. **Copies** generic content mappings such as `AGENTS.md` → `CLAUDE.md`.
+4. **Upserts** every MCP server entry into the target JSON config files.
 
 That's it — your repos, skills, and MCP servers are now configured and centralised.
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -31,6 +31,7 @@ type Config struct {
 	Schema       *int                  `yaml:"schema,omitempty" json:"schema,omitempty" jsonschema:"description=gaal config schema version. Currently must be 1."`
 	Repositories map[string]ConfigRepo `yaml:"repositories" json:"repositories,omitempty" jsonschema:"description=Map of workspace-relative paths to repository entries" validate:"dive"`
 	Skills       []ConfigSkill         `yaml:"skills"       json:"skills,omitempty"       jsonschema:"description=Skill sources to install into agent skill directories"   validate:"dive"`
+	Content      []ConfigContent       `yaml:"content,omitempty" json:"content,omitempty" jsonschema:"description=Generic source path to destination path content sync entries" validate:"dive"`
 	MCPs         []ConfigMcp           `yaml:"mcps"         json:"mcps,omitempty"         jsonschema:"description=MCP server configuration entries to merge"             validate:"dive"`
 	Tools        []ConfigTool          `yaml:"tools,omitempty" json:"tools,omitempty"    jsonschema:"description=CLI tools expected to be on PATH; gaal doctor/sync report any missing ones" validate:"dive"`
 	Hooks        *ConfigHooks          `yaml:"hooks,omitempty" json:"hooks,omitempty" jsonschema:"description=User-defined commands to run before and after sync"`
@@ -106,6 +107,25 @@ type ConfigSkill struct {
 type ConfigTool struct {
 	Name string `yaml:"name"           json:"name"           jsonschema:"description=Executable name to look up on PATH (e.g. gh, fnm, rtk)" validate:"required"`
 	Hint string `yaml:"hint,omitempty" json:"hint,omitempty" jsonschema:"description=Free-form install hint shown when the tool is missing"`
+}
+
+// ConfigContent maps arbitrary files or directories from a source repository
+// into one or more agent/workspace destinations.
+type ConfigContent struct {
+	Source  string                `yaml:"source" json:"source" jsonschema:"description=Content source: GitHub shorthand (owner/repo), HTTPS URL, SSH URL, or local path" validate:"required"`
+	Agents  []string              `yaml:"agents,omitempty" json:"agents,omitempty" jsonschema:"description=Shorthand target agents used when targets is omitted"`
+	Global  bool                  `yaml:"global,omitempty" json:"global,omitempty" jsonschema:"description=Shorthand target scope used when targets is omitted"`
+	Root    string                `yaml:"root,omitempty" json:"root,omitempty" jsonschema:"description=Shorthand destination root used when targets is omitted,enum=agent,enum=workspace"`
+	Paths   map[string]string     `yaml:"paths,omitempty" json:"paths,omitempty" jsonschema:"description=Shorthand source-relative to destination-relative path mappings"`
+	Targets []ConfigContentTarget `yaml:"targets,omitempty" json:"targets,omitempty" jsonschema:"description=Concrete content deployment targets" validate:"dive"`
+}
+
+// ConfigContentTarget is one concrete destination fan-out for a content entry.
+type ConfigContentTarget struct {
+	Agents []string          `yaml:"agents,omitempty" json:"agents,omitempty" jsonschema:"description=Agent identifiers that receive this content"`
+	Scope  string            `yaml:"scope,omitempty" json:"scope,omitempty" jsonschema:"description=Destination scope,enum=project,enum=global"`
+	Root   string            `yaml:"root,omitempty" json:"root,omitempty" jsonschema:"description=Destination root,enum=agent,enum=workspace"`
+	Paths  map[string]string `yaml:"paths" json:"paths" jsonschema:"description=Source-relative to destination-relative path mappings" validate:"required"`
 }
 
 // ConfigMcp defines an MCP server configuration entry.
@@ -378,10 +398,12 @@ func (Config) JSONSchemaExtend(s *jsonschema.Schema) {
 //   - repositories: map merge — src wins on key conflict.
 //   - skills: upsert by Source + TargetSubdir — src entry replaces any
 //     existing entry with the same install identity.
+//   - content: append entries; path mappings are identity-bearing enough that
+//     users may intentionally repeat sources for different targets.
 //   - mcps: upsert by Name — src entry replaces any existing entry with the
 //     same Name.
 func (c *Config) mergeFrom(src *Config, scope ConfigScope) {
-	slog.Debug("merging config", "scope", scope, "repos", len(src.Repositories), "skills", len(src.Skills), "mcps", len(src.MCPs))
+	slog.Debug("merging config", "scope", scope, "repos", len(src.Repositories), "skills", len(src.Skills), "content", len(src.Content), "mcps", len(src.MCPs))
 
 	if src.Schema != nil {
 		c.Schema = src.Schema
@@ -407,6 +429,8 @@ func (c *Config) mergeFrom(src *Config, scope ConfigScope) {
 			c.Skills = append(c.Skills, sk)
 		}
 	}
+
+	c.Content = append(c.Content, src.Content...)
 
 	for _, mc := range src.MCPs {
 		if i := indexOf(c.MCPs, func(m ConfigMcp) bool { return m.Name == mc.Name }); i >= 0 {
@@ -438,10 +462,11 @@ func (c *Config) mergeFrom(src *Config, scope ConfigScope) {
 }
 
 // deduplicate removes duplicate entries within this Config, keeping the first
-// occurrence. Skills are keyed by Source + TargetSubdir; MCPs are keyed by
-// Name; Tools are keyed by Name.
+// occurrence. Skills are keyed by Source + TargetSubdir; content entries are
+// keyed by their full mapping identity; MCPs and Tools are keyed by Name.
 func (c *Config) deduplicate() {
 	c.Skills = deduplicate(c.Skills, skillIdentity)
+	c.Content = deduplicate(c.Content, contentIdentity)
 	c.MCPs = deduplicate(c.MCPs, func(m ConfigMcp) string { return m.Name })
 	c.Tools = deduplicate(c.Tools, func(t ConfigTool) string { return t.Name })
 }
@@ -451,12 +476,20 @@ func skillIdentity(s ConfigSkill) string {
 	return s.Source + "\x00" + filepath.ToSlash(filepath.Clean(s.TargetSubdir))
 }
 
+func contentIdentity(c ConfigContent) string {
+	slog.Debug("building content identity", "source", c.Source, "targets", len(c.Targets), "paths", len(c.Paths))
+	return c.Source + "\x00" + fmt.Sprint(c.Agents) + "\x00" + c.Root + "\x00" + fmt.Sprint(c.Global) + "\x00" + fmt.Sprint(c.Paths) + "\x00" + fmt.Sprint(c.Targets)
+}
+
 func (c *Config) validate() error {
-	slog.Debug("validating config", "repos", len(c.Repositories), "skills", len(c.Skills), "mcps", len(c.MCPs))
+	slog.Debug("validating config", "repos", len(c.Repositories), "skills", len(c.Skills), "content", len(c.Content), "mcps", len(c.MCPs))
 	if err := schema.Validate(c); err != nil {
 		return err
 	}
 	if err := c.validateSkillTargetSubdirs(); err != nil {
+		return err
+	}
+	if err := c.validateContent(); err != nil {
 		return err
 	}
 	if err := c.validateMCPItems(); err != nil {
@@ -478,6 +511,45 @@ func (c *Config) validateSkillTargetSubdirs() error {
 	return nil
 }
 
+func (c *Config) validateContent() error {
+	slog.Debug("validating content config", "entries", len(c.Content))
+	for _, entry := range c.Content {
+		if len(entry.Targets) == 0 {
+			if len(entry.Paths) == 0 {
+				return fmt.Errorf("content %q: paths must be set when targets is omitted", entry.Source)
+			}
+			if len(entry.Agents) == 0 {
+				return fmt.Errorf("content %q: agents must be set when targets is omitted", entry.Source)
+			}
+			if err := validateContentRoot(entry.Root); err != nil {
+				return fmt.Errorf("content %q: %w", entry.Source, err)
+			}
+			if err := validateContentPaths(entry.Paths); err != nil {
+				return fmt.Errorf("content %q: %w", entry.Source, err)
+			}
+			continue
+		}
+		for i, target := range entry.Targets {
+			if len(target.Agents) == 0 {
+				return fmt.Errorf("content %q target %d: agents must be set", entry.Source, i)
+			}
+			if len(target.Paths) == 0 {
+				return fmt.Errorf("content %q target %d: paths must be set", entry.Source, i)
+			}
+			if err := validateContentScope(target.Scope); err != nil {
+				return fmt.Errorf("content %q target %d: %w", entry.Source, i, err)
+			}
+			if err := validateContentRoot(target.Root); err != nil {
+				return fmt.Errorf("content %q target %d: %w", entry.Source, i, err)
+			}
+			if err := validateContentPaths(target.Paths); err != nil {
+				return fmt.Errorf("content %q target %d: %w", entry.Source, i, err)
+			}
+		}
+	}
+	return nil
+}
+
 func safeRelativeSubdir(path string) bool {
 	slog.Debug("checking relative subdirectory", "path", path)
 	slashed := strings.ReplaceAll(path, `\`, "/")
@@ -494,6 +566,58 @@ func safeRelativeSubdir(path string) bool {
 		return false
 	}
 	return true
+}
+
+func validateContentScope(scope string) error {
+	slog.Debug("validating content scope", "scope", scope)
+	switch scope {
+	case "", "project", "global":
+		return nil
+	default:
+		return fmt.Errorf("scope must be project or global, got %q", scope)
+	}
+}
+
+func validateContentRoot(root string) error {
+	slog.Debug("validating content root", "root", root)
+	switch root {
+	case "", "agent", "workspace":
+		return nil
+	default:
+		return fmt.Errorf("root must be agent or workspace, got %q", root)
+	}
+}
+
+func validateContentPaths(paths map[string]string) error {
+	slog.Debug("validating content paths", "count", len(paths))
+	for src, dst := range paths {
+		if !safeRelativeContentPath(src) {
+			return fmt.Errorf("source path must be relative and must not contain '..', got %q", src)
+		}
+		if !safeRelativeContentPath(dst) {
+			return fmt.Errorf("destination path must be relative and must not contain '..', got %q", dst)
+		}
+	}
+	return nil
+}
+
+func safeRelativeContentPath(path string) bool {
+	slog.Debug("checking relative content path", "path", path)
+	slashed := strings.ReplaceAll(path, `\`, "/")
+	if path == "" || filepath.IsAbs(path) || strings.HasPrefix(slashed, "/") || strings.Contains(slashed, ":") {
+		return false
+	}
+	trimmed := strings.TrimSuffix(slashed, "/")
+	if trimmed == "" {
+		return false
+	}
+	for _, seg := range strings.Split(trimmed, "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			return false
+		}
+	}
+	clean := filepath.Clean(path)
+	return clean != "." && clean != ".." && !strings.HasPrefix(filepath.ToSlash(clean), "../")
 }
 
 // validHookOS enumerates the GOOS values gaal will match against runtime.GOOS

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -1396,6 +1396,72 @@ tools:
 	}
 }
 
+func TestLoad_ContentTargets(t *testing.T) {
+	p := writeYAML(t, `
+content:
+  - source: ./agent-guidance
+    targets:
+      - agents: ["claude-code"]
+        scope: project
+        root: workspace
+        paths:
+          AGENTS.md: CLAUDE.md
+      - agents: ["codex"]
+        scope: project
+        root: workspace
+        paths:
+          AGENTS.md: AGENTS.md
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Content) != 1 || len(cfg.Content[0].Targets) != 2 {
+		t.Fatalf("unexpected content config: %+v", cfg.Content)
+	}
+	if cfg.Content[0].Targets[0].Paths["AGENTS.md"] != "CLAUDE.md" {
+		t.Errorf("unexpected first path mapping: %+v", cfg.Content[0].Targets[0].Paths)
+	}
+}
+
+func TestLoad_ContentShorthand(t *testing.T) {
+	p := writeYAML(t, `
+content:
+  - source: owner/dotclaude
+    agents: ["claude-code"]
+    global: true
+    paths:
+      commands/: commands/
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Content) != 1 || !cfg.Content[0].Global {
+		t.Fatalf("unexpected content config: %+v", cfg.Content)
+	}
+}
+
+func TestLoad_ContentRejectsUnsafePaths(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{"source parent", "content:\n  - source: owner/repo\n    agents: [codex]\n    paths:\n      ../AGENTS.md: AGENTS.md\n"},
+		{"dest parent", "content:\n  - source: owner/repo\n    agents: [codex]\n    paths:\n      AGENTS.md: ../AGENTS.md\n"},
+		{"bad root", "content:\n  - source: owner/repo\n    agents: [codex]\n    root: nowhere\n    paths:\n      AGENTS.md: AGENTS.md\n"},
+		{"missing agents", "content:\n  - source: owner/repo\n    paths:\n      AGENTS.md: AGENTS.md\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := writeYAML(t, tc.yaml)
+			if _, err := Load(p); err == nil {
+				t.Fatal("expected content config to be rejected")
+			}
+		})
+	}
+}
+
 func TestLoad_RejectsUnknownKeysInCustomYAMLTypes(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -172,6 +172,13 @@ func (c *Config) expandPaths(baseDir string) {
 		}
 	}
 
+	for i := range c.Content {
+		src := c.Content[i].Source
+		if !isRemoteURL(src) && !isGitHubShorthand(src) {
+			c.Content[i].Source = expandPath(src)
+		}
+	}
+
 	for i := range c.MCPs {
 		if c.MCPs[i].Target == "" {
 			continue

--- a/internal/content/manager.go
+++ b/internal/content/manager.go
@@ -1,0 +1,533 @@
+package content
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gaal/internal/config"
+	"gaal/internal/core/agent"
+	"gaal/internal/core/vcs"
+	"gaal/internal/discover"
+	"gaal/internal/urlx"
+)
+
+type PathStatus struct {
+	Source  string
+	Target  string
+	Present bool
+	Dirty   bool
+	Error   string
+}
+
+type Status struct {
+	Source string
+	Agent  string
+	Scope  string
+	Root   string
+	Paths  []PathStatus
+	Err    error
+}
+
+type Manager struct {
+	entries  []config.ConfigContent
+	cacheDir string
+	home     string
+	workDir  string
+	stateDir string
+	force    bool
+}
+
+func NewManager(entries []config.ConfigContent, cacheDir, home, workDir, stateDir string, force bool) *Manager {
+	slog.Debug("creating content manager", "entries", len(entries), "cacheDir", cacheDir)
+	return &Manager{entries: entries, cacheDir: cacheDir, home: home, workDir: workDir, stateDir: stateDir, force: force}
+}
+
+func (m *Manager) Sync(ctx context.Context) error {
+	slog.DebugContext(ctx, "syncing content entries", "count", len(m.entries))
+	var errs []error
+	for _, entry := range m.entries {
+		if err := m.syncOne(ctx, entry); err != nil {
+			errs = append(errs, fmt.Errorf("content %q: %w", entry.Source, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Manager) Status(ctx context.Context) []Status {
+	slog.DebugContext(ctx, "collecting content status", "count", len(m.entries))
+	var statuses []Status
+	for _, entry := range m.entries {
+		statuses = append(statuses, m.statusOne(ctx, entry)...)
+	}
+	return statuses
+}
+
+func (m *Manager) syncOne(ctx context.Context, entry config.ConfigContent) error {
+	slog.DebugContext(ctx, "syncing content source", "source", entry.Source)
+	sourceRoot, err := m.resolveSource(ctx, entry.Source)
+	if err != nil {
+		return fmt.Errorf("resolving source: %w", err)
+	}
+
+	var errs []error
+	for _, target := range expandTargets(entry) {
+		for _, agentName := range m.resolveAgents(target) {
+			root, err := m.targetRoot(agentName, target)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			for _, mapping := range sortedMappings(target.Paths) {
+				src := filepath.Join(sourceRoot, filepath.FromSlash(strings.TrimSuffix(mapping.Source, "/")))
+				dst := filepath.Join(root, filepath.FromSlash(strings.TrimSuffix(mapping.Dest, "/")))
+				if err := copyPath(src, dst); err != nil {
+					errs = append(errs, fmt.Errorf("%s -> %s: %w", mapping.Source, dst, err))
+					continue
+				}
+				m.writeContentSnapshot(dst)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Manager) statusOne(ctx context.Context, entry config.ConfigContent) []Status {
+	slog.DebugContext(ctx, "collecting content source status", "source", entry.Source)
+	sourceRoot, err := cachedSourcePath(m.cacheDir, entry.Source)
+	var out []Status
+	for _, target := range expandTargets(entry) {
+		for _, agentName := range m.resolveAgents(target) {
+			st := Status{Source: entry.Source, Agent: agentName, Scope: targetScope(target), Root: targetRootKind(target)}
+			root, rootErr := m.targetRoot(agentName, target)
+			if err != nil || sourceRoot == "" {
+				st.Err = fmt.Errorf("source not cached yet")
+				out = append(out, st)
+				continue
+			}
+			if rootErr != nil {
+				st.Err = rootErr
+				out = append(out, st)
+				continue
+			}
+			for _, mapping := range sortedMappings(target.Paths) {
+				src := filepath.Join(sourceRoot, filepath.FromSlash(strings.TrimSuffix(mapping.Source, "/")))
+				dst := filepath.Join(root, filepath.FromSlash(strings.TrimSuffix(mapping.Dest, "/")))
+				ps := PathStatus{Source: mapping.Source, Target: dst}
+				if _, statErr := os.Stat(dst); statErr != nil {
+					if os.IsNotExist(statErr) {
+						st.Paths = append(st.Paths, ps)
+						continue
+					}
+					ps.Error = statErr.Error()
+					st.Paths = append(st.Paths, ps)
+					continue
+				}
+				ps.Present = true
+				ps.Dirty = pathModified(src, dst)
+				st.Paths = append(st.Paths, ps)
+			}
+			out = append(out, st)
+		}
+	}
+	return out
+}
+
+func expandTargets(entry config.ConfigContent) []config.ConfigContentTarget {
+	slog.Debug("expanding content targets", "source", entry.Source, "targets", len(entry.Targets))
+	if len(entry.Targets) > 0 {
+		return entry.Targets
+	}
+	scope := "project"
+	if entry.Global {
+		scope = "global"
+	}
+	return []config.ConfigContentTarget{{
+		Agents: entry.Agents,
+		Scope:  scope,
+		Root:   entry.Root,
+		Paths:  entry.Paths,
+	}}
+}
+
+func targetScope(target config.ConfigContentTarget) string {
+	slog.Debug("resolving content target scope", "scope", target.Scope)
+	if target.Scope == "" {
+		return "project"
+	}
+	return target.Scope
+}
+
+func targetRootKind(target config.ConfigContentTarget) string {
+	slog.Debug("resolving content target root kind", "root", target.Root)
+	if target.Root == "" {
+		return "agent"
+	}
+	return target.Root
+}
+
+func (m *Manager) resolveAgents(target config.ConfigContentTarget) []string {
+	slog.Debug("resolving content target agents", "agents", target.Agents, "force", m.force)
+	if len(target.Agents) == 1 && target.Agents[0] == "*" {
+		if m.force {
+			return agent.Names()
+		}
+		var found []string
+		for _, name := range agent.Names() {
+			if _, err := m.targetRoot(name, target); err == nil {
+				found = append(found, name)
+			}
+		}
+		return found
+	}
+	return target.Agents
+}
+
+func (m *Manager) targetRoot(agentName string, target config.ConfigContentTarget) (string, error) {
+	slog.Debug("resolving content target root", "agent", agentName, "scope", target.Scope, "root", target.Root)
+	if targetRootKind(target) == "workspace" {
+		return m.workDir, nil
+	}
+	global := targetScope(target) == "global"
+	dir, ok := agent.SkillDir(agentName, global, m.home)
+	if !ok {
+		return "", fmt.Errorf("unknown agent %q", agentName)
+	}
+	if !global && !filepath.IsAbs(dir) {
+		dir = filepath.Join(m.workDir, dir)
+	}
+	return filepath.Dir(dir), nil
+}
+
+type pathMapping struct {
+	Source string
+	Dest   string
+}
+
+func sortedMappings(paths map[string]string) []pathMapping {
+	slog.Debug("sorting content path mappings", "count", len(paths))
+	out := make([]pathMapping, 0, len(paths))
+	for src, dst := range paths {
+		out = append(out, pathMapping{Source: src, Dest: dst})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Source == out[j].Source {
+			return out[i].Dest < out[j].Dest
+		}
+		return out[i].Source < out[j].Source
+	})
+	return out
+}
+
+func (m *Manager) resolveSource(ctx context.Context, source string) (string, error) {
+	slog.DebugContext(ctx, "resolving content source", "source", source)
+	if isLocalPath(source) {
+		return expandHome(source, m.home), nil
+	}
+
+	cloneURL := toCloneURL(source)
+	vcsType := vcs.DetectType(cloneURL)
+	localPath := filepath.Join(m.cacheDir, urlToCacheKey(cloneURL))
+	backend, err := vcs.NewShallow(vcsType)
+	if err != nil {
+		return "", err
+	}
+	if !backend.IsCloned(localPath) {
+		if err := backend.Clone(ctx, cloneURL, localPath, ""); err != nil {
+			return "", fmt.Errorf("cloning %s: %w", urlx.Redact(cloneURL), err)
+		}
+	} else if err := backend.Update(ctx, "", localPath, ""); err != nil {
+		slog.Warn("could not update content source", "path", localPath, "err", err)
+	}
+	return localPath, nil
+}
+
+func cachedSourcePath(cacheDir, source string) (string, error) {
+	slog.Debug("resolving cached content source path", "source", source)
+	if isLocalPath(source) {
+		return source, nil
+	}
+	path := filepath.Join(cacheDir, urlToCacheKey(toCloneURL(source)))
+	if _, err := os.Stat(path); err != nil {
+		return "", nil
+	}
+	return path, nil
+}
+
+func isLocalPath(source string) bool {
+	slog.Debug("checking content source locality", "source", source)
+	return filepath.IsAbs(source) ||
+		strings.HasPrefix(source, ".") ||
+		strings.HasPrefix(source, "~/") ||
+		strings.HasPrefix(source, `~\`) ||
+		strings.Contains(source, string(os.PathSeparator))
+}
+
+func expandHome(path, home string) string {
+	slog.Debug("expanding content source home", "path", path)
+	if strings.HasPrefix(path, "~/") || strings.HasPrefix(path, `~\`) {
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+func toCloneURL(source string) string {
+	slog.Debug("resolving content clone url", "source", source)
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "git@") || strings.Contains(source, "://") {
+		return source
+	}
+	return "https://github.com/" + source
+}
+
+func urlToCacheKey(rawURL string) string {
+	slog.Debug("building content cache key", "url", urlx.Redact(rawURL))
+	sum := sha1.Sum([]byte(rawURL))
+	return hex.EncodeToString(sum[:])
+}
+
+func copyPath(src, dst string) error {
+	slog.Debug("copying content path", "src", src, "dst", dst)
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("symlink sources are not supported")
+	}
+	if info.IsDir() {
+		return copyDirReplace(src, dst)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("source is not a regular file or directory")
+	}
+	return copyFileAtomic(src, dst, info.Mode().Perm())
+}
+
+func copyDirReplace(src, dst string) error {
+	slog.Debug("copying content directory", "src", src, "dst", dst)
+	parent := filepath.Dir(dst)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	staging, err := os.MkdirTemp(parent, ".gaal-content-tmp-*")
+	if err != nil {
+		return err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.RemoveAll(staging)
+		}
+	}()
+	if err := copyDirContents(src, staging); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+	if err := os.Rename(staging, dst); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func copyDirContents(src, dst string) error {
+	slog.Debug("copying content directory contents", "src", src, "dst", dst)
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && path != src {
+			if _, skip := vcsMetaDirs[d.Name()]; skip {
+				return filepath.SkipDir
+			}
+		}
+		rel, _ := filepath.Rel(src, path)
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			slog.Warn("content: skipping non-regular source entry", "path", path)
+			return nil
+		}
+		return copyFileAtomic(path, target, info.Mode().Perm())
+	})
+}
+
+var vcsMetaDirs = map[string]struct{}{
+	".git": {},
+	".hg":  {},
+	".svn": {},
+	".bzr": {},
+}
+
+func copyFileAtomic(src, dst string, mode os.FileMode) error {
+	slog.Debug("copying content file", "src", src, "dst", dst)
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".gaal-content-file-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(sanitizedMode(mode)); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func sanitizedMode(mode os.FileMode) os.FileMode {
+	slog.Debug("sanitizing content file mode", "mode", mode)
+	if mode&0o111 != 0 {
+		return 0o755
+	}
+	return 0o644
+}
+
+func pathModified(src, dst string) bool {
+	slog.Debug("checking content path drift", "src", src, "dst", dst)
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return true
+	}
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		return true
+	}
+	if srcInfo.IsDir() != dstInfo.IsDir() {
+		return true
+	}
+	if srcInfo.IsDir() {
+		return dirModified(src, dst)
+	}
+	return fileModified(src, dst)
+}
+
+func dirModified(src, dst string) bool {
+	slog.Debug("checking content directory drift", "src", src, "dst", dst)
+	modified := false
+	seen := map[string]struct{}{}
+	_ = filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || modified {
+			return err
+		}
+		if d.IsDir() && path != src {
+			if _, skip := vcsMetaDirs[d.Name()]; skip {
+				return filepath.SkipDir
+			}
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil || info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, _ := filepath.Rel(src, path)
+		seen[rel] = struct{}{}
+		if fileModified(path, filepath.Join(dst, rel)) {
+			modified = true
+		}
+		return nil
+	})
+	if modified {
+		return true
+	}
+	_ = filepath.WalkDir(dst, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || modified || d.IsDir() {
+			return err
+		}
+		rel, _ := filepath.Rel(dst, path)
+		if _, ok := seen[rel]; !ok {
+			modified = true
+		}
+		return nil
+	})
+	return modified
+}
+
+func fileModified(src, dst string) bool {
+	slog.Debug("checking content file drift", "src", src, "dst", dst)
+	a, err := os.ReadFile(src)
+	if err != nil {
+		return true
+	}
+	b, err := os.ReadFile(dst)
+	if err != nil {
+		return true
+	}
+	return !bytes.Equal(a, b)
+}
+
+func (m *Manager) writeContentSnapshot(dest string) {
+	slog.Debug("writing content snapshot", "dest", dest)
+	if m.stateDir == "" {
+		return
+	}
+	snap, err := snapshotPath(dest)
+	if err != nil {
+		slog.Warn("content snapshot failed", "dest", dest, "err", err)
+		return
+	}
+	key := "content-" + discover.WorkdirKey(dest)
+	if err := discover.Save(discover.SnapshotPath(m.stateDir, key), snap); err != nil {
+		slog.Warn("content snapshot save failed", "dest", dest, "err", err)
+	}
+}
+
+func snapshotPath(path string) (discover.Snapshot, error) {
+	slog.Debug("snapshotting content path", "path", path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return discover.SnapshotDir(path)
+	}
+	rec, err := discover.Record(path)
+	if err != nil {
+		return nil, err
+	}
+	return discover.Snapshot{filepath.Base(path): rec}, nil
+}

--- a/internal/content/manager_test.go
+++ b/internal/content/manager_test.go
@@ -1,0 +1,113 @@
+package content
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gaal/internal/config"
+)
+
+func TestManagerSync_ProjectWorkspaceInstructionFiles(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "AGENTS.md"), []byte("shared guidance"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	workDir := t.TempDir()
+	entries := []config.ConfigContent{{
+		Source: source,
+		Targets: []config.ConfigContentTarget{
+			{
+				Agents: []string{"claude-code"},
+				Scope:  "project",
+				Root:   "workspace",
+				Paths:  map[string]string{"AGENTS.md": "CLAUDE.md"},
+			},
+			{
+				Agents: []string{"codex"},
+				Scope:  "project",
+				Root:   "workspace",
+				Paths:  map[string]string{"AGENTS.md": "AGENTS.md"},
+			},
+		},
+	}}
+
+	m := NewManager(entries, t.TempDir(), t.TempDir(), workDir, "", false)
+	if err := m.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	for _, name := range []string{"CLAUDE.md", "AGENTS.md"} {
+		got, err := os.ReadFile(filepath.Join(workDir, name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		if string(got) != "shared guidance" {
+			t.Errorf("%s = %q", name, got)
+		}
+	}
+}
+
+func TestManagerStatusReportsMissingAndDirtyContent(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "AGENTS.md"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []config.ConfigContent{{
+		Source: source,
+		Targets: []config.ConfigContentTarget{{
+			Agents: []string{"claude-code"},
+			Scope:  "project",
+			Root:   "workspace",
+			Paths: map[string]string{
+				"AGENTS.md": "CLAUDE.md",
+				"README.md": "README.md",
+			},
+		}},
+	}}
+
+	m := NewManager(entries, t.TempDir(), t.TempDir(), workDir, "", false)
+	statuses := m.Status(context.Background())
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	byTarget := map[string]PathStatus{}
+	for _, p := range statuses[0].Paths {
+		byTarget[filepath.Base(p.Target)] = p
+	}
+	if !byTarget["CLAUDE.md"].Dirty {
+		t.Errorf("expected CLAUDE.md to be dirty, got %+v", byTarget["CLAUDE.md"])
+	}
+	if byTarget["README.md"].Present {
+		t.Errorf("expected README.md to be absent, got %+v", byTarget["README.md"])
+	}
+}
+
+func TestCopyPathDirectorySkipsVCSMetadata(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "file.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitDir := filepath.Join(source, ".git", "objects")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "pack"), []byte("skip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "commands")
+	if err := copyPath(source, dst); err != nil {
+		t.Fatalf("copyPath: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "file.txt")); err != nil {
+		t.Errorf("expected copied file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, ".git")); !os.IsNotExist(err) {
+		t.Errorf("expected .git to be skipped, got err=%v", err)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"gaal/internal/config"
+	"gaal/internal/content"
 	"gaal/internal/engine/hooks"
 	"gaal/internal/engine/ops"
 	"gaal/internal/engine/render"
@@ -75,6 +76,7 @@ type Engine struct {
 	cfg       *config.Config
 	repos     *repo.Manager
 	skills    *skill.Manager
+	content   *content.Manager
 	mcps      *mcp.Manager
 	hooks     *hooks.Manager
 	home      string
@@ -105,6 +107,7 @@ func NewWithOptions(cfg *config.Config, opts Options) *Engine {
 		cacheRoot = filepath.Join(home, ".cache")
 	}
 	cacheDir := filepath.Join(cacheRoot, "gaal", "skills")
+	contentCacheDir := filepath.Join(cacheRoot, "gaal", "content")
 
 	stateDir := filepath.Join(cacheRoot, "gaal", "state")
 	if opts.StateDir != "" {
@@ -117,6 +120,7 @@ func NewWithOptions(cfg *config.Config, opts Options) *Engine {
 		cfg:       cfg,
 		repos:     repo.NewManager(cfg.Repositories, stateDir),
 		skills:    skill.NewManager(cfg.Skills, cacheDir, home, workDir, stateDir, opts.Force),
+		content:   content.NewManager(cfg.Content, contentCacheDir, home, workDir, stateDir, opts.Force),
 		mcps:      mcp.NewManager(cfg.MCPs, home, stateDir),
 		hooks:     hooks.NewManager(cfg.Hooks, workDir, home, ""),
 		home:      home,
@@ -148,6 +152,13 @@ func (e *Engine) RunOnce(ctx context.Context) error {
 		slog.Debug("syncing skills", "count", len(e.cfg.Skills))
 		if err := e.skills.Sync(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("skills: %w", err))
+		}
+	}
+
+	if len(e.cfg.Content) > 0 {
+		slog.Debug("syncing content", "count", len(e.cfg.Content))
+		if err := e.content.Sync(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("content: %w", err))
 		}
 	}
 
@@ -228,7 +239,7 @@ func (e *Engine) Prune(ctx context.Context) error {
 
 // Collect gathers the current status of all resources without side effects.
 func (e *Engine) Collect(ctx context.Context) (*render.StatusReport, error) {
-	return ops.Collect(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir)
+	return ops.Collect(ctx, e.repos, e.skills, e.content, e.mcps, e.home, e.workDir, e.stateDir)
 }
 
 // DryRun computes what sync would do and renders the plan to os.Stdout.
@@ -254,7 +265,7 @@ func (e *Engine) DryRun(ctx context.Context, format OutputFormat) (*render.PlanR
 // summary can report past-tense verbs ("cloned", "installed", "upserted")
 // for each managed resource.
 func (e *Engine) Plan(ctx context.Context) (*render.PlanReport, error) {
-	plan, err := ops.SyncPlan(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir)
+	plan, err := ops.SyncPlan(ctx, e.repos, e.skills, e.content, e.mcps, e.home, e.workDir, e.stateDir)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +275,7 @@ func (e *Engine) Plan(ctx context.Context) (*render.PlanReport, error) {
 
 // Status collects the current resource state and renders it to os.Stdout.
 func (e *Engine) Status(ctx context.Context, format OutputFormat) error {
-	return ops.Status(ctx, e.repos, e.skills, e.mcps, e.home, e.workDir, e.stateDir, format)
+	return ops.Status(ctx, e.repos, e.skills, e.content, e.mcps, e.home, e.workDir, e.stateDir, format)
 }
 
 // Audit discovers all skills and MCP servers installed on the machine and
@@ -275,7 +286,7 @@ func (e *Engine) Audit(ctx context.Context, format OutputFormat) error {
 
 // Info renders a detailed view for the given package type to stdout.
 func (e *Engine) Info(ctx context.Context, pkg, filter string, format OutputFormat) error {
-	return ops.Info(ctx, e.repos, e.skills, e.mcps, e.cfg, e.home, e.workDir, e.stateDir, pkg, filter, format)
+	return ops.Info(ctx, e.repos, e.skills, e.content, e.mcps, e.cfg, e.home, e.workDir, e.stateDir, pkg, filter, format)
 }
 
 // ListAgents returns all registered agents with installed-detection.

--- a/internal/engine/ops/info.go
+++ b/internal/engine/ops/info.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pterm/pterm"
 
 	"gaal/internal/config"
+	"gaal/internal/content"
 	"gaal/internal/core/agent"
 	"gaal/internal/engine/render"
 	"gaal/internal/mcp"
@@ -25,10 +26,10 @@ import (
 // filter is an optional name/source substring; if non-empty only matching
 // entries are shown. Matching is case-insensitive.
 // format controls the output: FormatTable (pterm) or FormatJSON.
-func Info(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, cfg *config.Config, home, workDir, stateDir, pkg, filter string, format render.OutputFormat) error {
+func Info(ctx context.Context, repos *repo.Manager, skills *skill.Manager, contentMgr *content.Manager, mcps *mcp.Manager, cfg *config.Config, home, workDir, stateDir, pkg, filter string, format render.OutputFormat) error {
 	slog.DebugContext(ctx, "info requested", "package", pkg, "filter", filter, "format", format)
 
-	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir)
+	report, err := Collect(ctx, repos, skills, contentMgr, mcps, home, workDir, stateDir)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/ops/plan.go
+++ b/internal/engine/ops/plan.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 
+	"gaal/internal/content"
 	"gaal/internal/engine/render"
 	"gaal/internal/mcp"
 	"gaal/internal/repo"
@@ -15,10 +16,10 @@ import (
 // The returned PlanReport describes every action that RunOnce would take.
 // This is the shared planner used by both `sync --dry-run` and the future
 // `diff` command.
-func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string) (*render.PlanReport, error) {
+func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, contentMgr *content.Manager, mcps *mcp.Manager, home, workDir, stateDir string) (*render.PlanReport, error) {
 	slog.DebugContext(ctx, "computing sync plan")
 
-	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir)
+	report, err := Collect(ctx, repos, skills, contentMgr, mcps, home, workDir, stateDir)
 	if err != nil {
 		return nil, err
 	}
@@ -27,6 +28,7 @@ func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, m
 
 	plan.Repositories = planRepos(report.Repositories)
 	plan.Skills = planSkills(report.Skills)
+	plan.Content = planContent(report.Content)
 	plan.MCPs = planMCPs(report.MCPs)
 
 	for _, r := range plan.Repositories {
@@ -45,6 +47,14 @@ func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, m
 			plan.HasChanges = true
 		}
 	}
+	for _, c := range plan.Content {
+		if c.Action == render.PlanError {
+			plan.HasErrors = true
+		}
+		if c.Action != render.PlanNoOp && c.Action != render.PlanError {
+			plan.HasChanges = true
+		}
+	}
 	for _, m := range plan.MCPs {
 		if m.Action == render.PlanError {
 			plan.HasErrors = true
@@ -58,8 +68,8 @@ func SyncPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, m
 }
 
 // RenderPlan computes and renders the sync plan to stdout.
-func RenderPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string, format render.OutputFormat) (*render.PlanReport, error) {
-	plan, err := SyncPlan(ctx, repos, skills, mcps, home, workDir, stateDir)
+func RenderPlan(ctx context.Context, repos *repo.Manager, skills *skill.Manager, contentMgr *content.Manager, mcps *mcp.Manager, home, workDir, stateDir string, format render.OutputFormat) (*render.PlanReport, error) {
+	plan, err := SyncPlan(ctx, repos, skills, contentMgr, mcps, home, workDir, stateDir)
 	if err != nil {
 		return nil, err
 	}
@@ -134,6 +144,31 @@ func planSkills(entries []render.SkillEntry) []render.PlanSkillEntry {
 		default:
 			p.Action = render.PlanNoOp
 			p.NoOp = append([]string(nil), e.Installed...)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func planContent(entries []render.ContentEntry) []render.PlanContentEntry {
+	out := make([]render.PlanContentEntry, 0, len(entries))
+	for _, e := range entries {
+		p := render.PlanContentEntry{
+			Source: e.Source,
+			Agent:  e.Agent,
+			Path:   e.Path,
+			Target: e.Target,
+		}
+		switch e.Status {
+		case render.StatusError:
+			p.Action = render.PlanError
+			p.Error = e.Error
+		case render.StatusAbsent:
+			p.Action = render.PlanCreate
+		case render.StatusDirty:
+			p.Action = render.PlanUpdate
+		default:
+			p.Action = render.PlanNoOp
 		}
 		out = append(out, p)
 	}

--- a/internal/engine/ops/status.go
+++ b/internal/engine/ops/status.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gaal/internal/content"
 	"gaal/internal/discover"
 	"gaal/internal/engine/render"
 	"gaal/internal/mcp"
@@ -18,7 +19,7 @@ import (
 // Collect gathers the current status of all resources without side effects.
 // It performs a FS-first scan via discover.Scan and then reconciles with any
 // config-declared resources from the managers, marking them as managed.
-func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string) (*render.StatusReport, error) {
+func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, contentMgr *content.Manager, mcps *mcp.Manager, home, workDir, stateDir string) (*render.StatusReport, error) {
 	slog.DebugContext(ctx, "collecting status", "home", home, "workDir", workDir)
 
 	// FS-first: discover what is actually installed.
@@ -38,6 +39,7 @@ func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mc
 	// Config-driven status (may add managed resources absent from FS scan).
 	configRepos := collectRepos(repos.Status(ctx))
 	configSkills := collectSkills(skills.Status(ctx))
+	configContent := collectContent(contentMgr.Status(ctx))
 	configMCPs := collectMCPs(mcps.Status(ctx))
 
 	// Reconcile: mark config-declared resources as managed and merge
@@ -49,16 +51,17 @@ func Collect(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mc
 	return &render.StatusReport{
 		Repositories: repoEntries,
 		Skills:       skillEntries,
+		Content:      configContent,
 		MCPs:         mcpEntries,
 		Agents:       agents,
 	}, nil
 }
 
 // Status collects the current resource state and renders it to os.Stdout.
-func Status(ctx context.Context, repos *repo.Manager, skills *skill.Manager, mcps *mcp.Manager, home, workDir, stateDir string, format render.OutputFormat) error {
+func Status(ctx context.Context, repos *repo.Manager, skills *skill.Manager, contentMgr *content.Manager, mcps *mcp.Manager, home, workDir, stateDir string, format render.OutputFormat) error {
 	slog.DebugContext(ctx, "status requested", "format", format)
 
-	report, err := Collect(ctx, repos, skills, mcps, home, workDir, stateDir)
+	report, err := Collect(ctx, repos, skills, contentMgr, mcps, home, workDir, stateDir)
 	if err != nil {
 		return err
 	}
@@ -274,6 +277,47 @@ func collectSkills(stats []skill.Status) []render.SkillEntry {
 			e.Status = render.StatusOK
 		}
 		entries = append(entries, e)
+	}
+	return entries
+}
+
+func collectContent(stats []content.Status) []render.ContentEntry {
+	slog.Debug("collecting content status entries", "count", len(stats))
+	var entries []render.ContentEntry
+	for _, st := range stats {
+		if st.Err != nil {
+			entries = append(entries, render.ContentEntry{
+				Source: st.Source,
+				Agent:  st.Agent,
+				Scope:  st.Scope,
+				Root:   st.Root,
+				Status: render.StatusError,
+				Error:  st.Err.Error(),
+			})
+			continue
+		}
+		for _, p := range st.Paths {
+			e := render.ContentEntry{
+				Source: st.Source,
+				Agent:  st.Agent,
+				Scope:  st.Scope,
+				Root:   st.Root,
+				Path:   p.Source,
+				Target: p.Target,
+			}
+			switch {
+			case p.Error != "":
+				e.Status = render.StatusError
+				e.Error = p.Error
+			case !p.Present:
+				e.Status = render.StatusAbsent
+			case p.Dirty:
+				e.Status = render.StatusDirty
+			default:
+				e.Status = render.StatusPresent
+			}
+			entries = append(entries, e)
+		}
 	}
 	return entries
 }

--- a/internal/engine/render/plan_table.go
+++ b/internal/engine/render/plan_table.go
@@ -62,6 +62,9 @@ func (pr *planTableRenderer) Render(w io.Writer, r *PlanReport) error {
 	if err := pr.skillTable(w, tr, r.Skills, termW); err != nil {
 		return err
 	}
+	if err := pr.contentTable(w, tr, r.Content, termW); err != nil {
+		return err
+	}
 	if err := pr.mcpTable(w, tr, r.MCPs, termW); err != nil {
 		return err
 	}
@@ -159,6 +162,24 @@ func (pr *planTableRenderer) mcpTable(w io.Writer, tr *tableRenderer, entries []
 			e.Name,
 			actionCell(e.Action, e.Error),
 			trunc(e.Target, vw),
+		})
+	}
+	return tr.ptermTable(w, data)
+}
+
+func (pr *planTableRenderer) contentTable(w io.Writer, tr *tableRenderer, entries []PlanContentEntry, termW int) error {
+	tr.section(w, "Content", len(entries))
+	vw := varColWidth(termW, 5, 3, 24)
+	if vw < 14 {
+		vw = 14
+	}
+	data := pterm.TableData{{"PATH", "AGENT", "ACTION", "TARGET"}}
+	for _, e := range entries {
+		data = append(data, []string{
+			trunc(e.Path, vw),
+			trunc(e.Agent, vw),
+			actionCell(e.Action, e.Error),
+			trunc(e.Target, vw*2),
 		})
 	}
 	return tr.ptermTable(w, data)

--- a/internal/engine/render/plan_text.go
+++ b/internal/engine/render/plan_text.go
@@ -35,7 +35,7 @@ const planTargetSoftLimit = 60
 func (pr *planTextRenderer) Render(w io.Writer, r *PlanReport) error {
 	slog.Debug("rendering plan text output")
 
-	if len(r.Repositories) == 0 && len(r.Skills) == 0 && len(r.MCPs) == 0 && len(r.Hooks) == 0 {
+	if len(r.Repositories) == 0 && len(r.Skills) == 0 && len(r.Content) == 0 && len(r.MCPs) == 0 && len(r.Hooks) == 0 {
 		fmt.Fprintln(w, "nothing to do")
 		return nil
 	}
@@ -43,6 +43,7 @@ func (pr *planTextRenderer) Render(w io.Writer, r *PlanReport) error {
 	fmt.Fprintln(w, "plan:")
 	pr.writeRepos(w, r.Repositories)
 	pr.writeSkills(w, r.Skills)
+	pr.writeContent(w, r.Content)
 	pr.writeMCPs(w, r.MCPs)
 	pr.writeHooks(w, r.Hooks)
 
@@ -227,6 +228,23 @@ func (pr *planTextRenderer) writeMCPs(w io.Writer, entries []PlanMCPEntry) {
 	pr.writeSection(w, "mcps", rows)
 }
 
+func (pr *planTextRenderer) writeContent(w io.Writer, entries []PlanContentEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	rows := make([]planRow, 0, len(entries))
+	for _, e := range entries {
+		rows = append(rows, planRow{
+			marker: planMarker(e.Action),
+			verb:   planVerb(e.Action, "content"),
+			name:   e.Path,
+			detail: contentPlanDetail(e),
+			action: e.Action,
+		})
+	}
+	pr.writeSection(w, "content", rows)
+}
+
 func (pr *planTextRenderer) writeHooks(w io.Writer, entries []PlanHookEntry) {
 	if len(entries) == 0 {
 		return
@@ -359,6 +377,15 @@ func planVerb(a PlanAction, kind string) string {
 		case PlanError:
 			return "error"
 		}
+	case "content":
+		switch a {
+		case PlanCreate:
+			return "copy"
+		case PlanUpdate:
+			return "update"
+		case PlanError:
+			return "error"
+		}
 	case "hook":
 		switch a {
 		case PlanRun:
@@ -405,6 +432,23 @@ func repoPlanDetail(e PlanRepoEntry) string {
 	default:
 		return ""
 	}
+}
+
+func contentPlanDetail(e PlanContentEntry) string {
+	if e.Action == PlanError {
+		return "(" + e.Error + ")"
+	}
+	parts := []string{}
+	if e.Agent != "" {
+		parts = append(parts, e.Agent)
+	}
+	if e.Target != "" {
+		parts = append(parts, displayTarget(e.Target, planTargetSoftLimit))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "→ " + strings.Join(parts, " · ")
 }
 
 func mcpPlanDetail(e PlanMCPEntry) string {

--- a/internal/engine/render/report.go
+++ b/internal/engine/render/report.go
@@ -39,6 +39,18 @@ type SkillEntry struct {
 	Error        string     `json:"error,omitempty"`
 }
 
+// ContentEntry holds the status of one generic content path mapping.
+type ContentEntry struct {
+	Source string     `json:"source"`
+	Agent  string     `json:"agent"`
+	Scope  string     `json:"scope"`
+	Root   string     `json:"root"`
+	Path   string     `json:"path"`
+	Target string     `json:"target"`
+	Status StatusCode `json:"status"`
+	Error  string     `json:"error,omitempty"`
+}
+
 // AgentEntry holds the registry information for a supported agent.
 type AgentEntry struct {
 	Name                    string `json:"name"`
@@ -83,10 +95,11 @@ type MCPEntry struct {
 
 // StatusReport aggregates the status of all managed resources.
 type StatusReport struct {
-	Repositories []RepoEntry  `json:"repositories"`
-	Skills       []SkillEntry `json:"skills"`
-	MCPs         []MCPEntry   `json:"mcps"`
-	Agents       []AgentEntry `json:"agents"`
+	Repositories []RepoEntry    `json:"repositories"`
+	Skills       []SkillEntry   `json:"skills"`
+	Content      []ContentEntry `json:"content,omitempty"`
+	MCPs         []MCPEntry     `json:"mcps"`
+	Agents       []AgentEntry   `json:"agents"`
 }
 
 // PlanAction describes what sync would do for a given resource.
@@ -151,6 +164,16 @@ type PlanSkillEntry struct {
 	Error        string     `json:"error,omitempty"`
 }
 
+// PlanContentEntry describes the planned action for a generic content path.
+type PlanContentEntry struct {
+	Source string     `json:"source"`
+	Agent  string     `json:"agent"`
+	Path   string     `json:"path"`
+	Target string     `json:"target"`
+	Action PlanAction `json:"action"`
+	Error  string     `json:"error,omitempty"`
+}
+
 // PlanMCPEntry describes the planned action for a single MCP entry.
 type PlanMCPEntry struct {
 	Name   string     `json:"name"`
@@ -161,12 +184,13 @@ type PlanMCPEntry struct {
 
 // PlanReport aggregates the planned actions for all managed resources.
 type PlanReport struct {
-	Repositories []PlanRepoEntry  `json:"repositories"`
-	Skills       []PlanSkillEntry `json:"skills"`
-	MCPs         []PlanMCPEntry   `json:"mcps"`
-	Hooks        []PlanHookEntry  `json:"hooks,omitempty"`
-	HasChanges   bool             `json:"has_changes"`
-	HasErrors    bool             `json:"has_errors"`
+	Repositories []PlanRepoEntry    `json:"repositories"`
+	Skills       []PlanSkillEntry   `json:"skills"`
+	Content      []PlanContentEntry `json:"content,omitempty"`
+	MCPs         []PlanMCPEntry     `json:"mcps"`
+	Hooks        []PlanHookEntry    `json:"hooks,omitempty"`
+	HasChanges   bool               `json:"has_changes"`
+	HasErrors    bool               `json:"has_errors"`
 }
 
 // AuditSkillEntry holds the metadata of a single skill discovered during audit.

--- a/internal/engine/render/table.go
+++ b/internal/engine/render/table.go
@@ -97,6 +97,9 @@ func (tr *tableRenderer) Render(w io.Writer, r *StatusReport) error {
 	if err := tr.skillTable(w, r.Skills, termW); err != nil {
 		return err
 	}
+	if err := tr.contentTable(w, r.Content, termW); err != nil {
+		return err
+	}
 	if err := tr.mcpTable(w, r.MCPs, termW); err != nil {
 		return err
 	}
@@ -447,6 +450,25 @@ func (tr *tableRenderer) mcpTable(w io.Writer, entries []MCPEntry, termW int) er
 			e.Name,
 			statusCell(e.Status, e.Error),
 			target,
+		})
+	}
+	return tr.ptermTable(w, data)
+}
+
+func (tr *tableRenderer) contentTable(w io.Writer, entries []ContentEntry, termW int) error {
+	tr.section(w, "Content", len(entries))
+	vw := varColWidth(termW, 5, 3, 28)
+	if vw < 16 {
+		vw = 16
+	}
+	data := pterm.TableData{{"PATH", "AGENT", "SCOPE", "STATUS", "TARGET"}}
+	for _, e := range entries {
+		data = append(data, []string{
+			trunc(e.Path, vw),
+			e.Agent,
+			e.Scope,
+			statusCell(e.Status, e.Error),
+			trunc(e.Target, vw),
 		})
 	}
 	return tr.ptermTable(w, data)

--- a/internal/engine/render/text.go
+++ b/internal/engine/render/text.go
@@ -30,6 +30,7 @@ func (tr *textRenderer) Render(w io.Writer, r *StatusReport) error {
 
 	write(func() bool { return tr.repoSection(w, r.Repositories) })
 	write(func() bool { return tr.skillSection(w, r.Skills) })
+	write(func() bool { return tr.contentSection(w, r.Content) })
 	write(func() bool { return tr.mcpSection(w, r.MCPs) })
 	write(func() bool { return tr.agentSection(w, r.Agents) })
 
@@ -128,6 +129,32 @@ func displayName(s string) string {
 		return "—"
 	}
 	return s
+}
+
+func (tr *textRenderer) contentSection(w io.Writer, entries []ContentEntry) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	fmt.Fprintln(w, "content")
+	nameWidth := maxWidth(entries, func(i int) string { return entries[i].Path })
+	for _, e := range entries {
+		suffix := ""
+		switch e.Status {
+		case StatusDirty:
+			suffix = " (dirty)"
+		case StatusAbsent:
+			suffix = " (absent)"
+		case StatusError:
+			if e.Error != "" {
+				suffix = " (error: " + e.Error + ")"
+			} else {
+				suffix = " (error)"
+			}
+		}
+		fmt.Fprintf(w, "  %s  %s → %s%s\n", padText(e.Path, nameWidth), e.Agent, e.Target, suffix)
+	}
+	fmt.Fprintln(w)
+	return true
 }
 
 func (tr *textRenderer) mcpSection(w io.Writer, entries []MCPEntry) bool {


### PR DESCRIPTION
Closes #218.

## Summary

- Add top-level `content:` config for generic file/directory mappings.
- Add `internal/content` manager with local/Git source resolution, safe file/dir copy, VCS metadata skipping, and status reporting.
- Support per-target fan-out so one tracked source file can deploy differently by agent, e.g. `AGENTS.md` -> `CLAUDE.md` for Claude Code and `AGENTS.md` for Codex.
- Wire content into engine sync, status, dry-run planning, JSON/text/table renderers, and docs.
- Keep `skills:` first-class; content is for arbitrary agent-consumed files/directories that are not native `SKILL.md` packages.

## Example

```yaml
content:
  - source: my-org/agent-guidance
    targets:
      - agents: ["claude-code"]
        scope: project
        root: workspace
        paths:
          AGENTS.md: CLAUDE.md

      - agents: ["codex"]
        scope: project
        root: workspace
        paths:
          AGENTS.md: AGENTS.md
```

## Test Plan

- [x] `go test ./internal/config ./internal/content ./internal/engine ./internal/engine/ops ./internal/engine/render -count=1`
- [x] `make build`
- [x] `make test`
- [x] `make lint`
