### PR TITLE
fix(repo): refuse to clone into a non-empty destination (#217)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -176,6 +176,26 @@ This rule applies to the `git` backend only; archive (`tar` / `zip`) backends
 have no remote URL, and `hg` / `svn` / `bzr` checkouts are not currently
 inspected.
 
+### Repositories: non-empty destination refusal
+
+When `repositories.<path>` resolves to a directory that already exists and
+contains any entries (tracked or untracked, hidden files included) but is not
+already a working copy, `gaal sync` refuses to clone and returns a
+`NonEmptyDestinationError` naming the destination and the entries it found.
+The pre-existing content is not touched.
+
+This protects the canonical "manage my agent config directory" use case
+(`repositories: { ~/.claude: ... }`) from a sync that would otherwise let
+`git clone` overwrite tracked files and expose untracked siblings to checkout
+reset — wiping live runtime state, per-machine secrets, and any auxiliary
+content the agent manages itself.
+
+To opt in to a clone, point the entry at an empty or non-existent path, or
+remove the existing content first. The check is uniform across backends
+(`git`, `hg`, `svn`, `bzr`, `tar`, `zip`): all clones go through the same
+refusal. Once the directory contains the backend's marker (`.git`, `.hg`,
+etc.), subsequent syncs take the `Update` path and are unaffected.
+
 ---
 
 ## Scope Restriction Policy

--- a/docs/packages/repo.md
+++ b/docs/packages/repo.md
@@ -76,6 +76,18 @@ HTTPS-auth error. Manager wraps with
 typed error through the wrap. See
 [Repositories: remote URL precedence](../config.md#repositories-remote-url-precedence).
 
+### `NonEmptyDestinationError` (all backends)
+
+Before delegating to any backend's `Clone`, `Manager.syncOne` calls
+`vcs.CheckEmptyDestination(path)`. If the destination directory already
+contains any entries (hidden files included), the manager returns a typed
+`*vcs.NonEmptyDestinationError` and skips the clone entirely. This is the
+mechanism behind the
+[non-empty destination refusal](../config.md#repositories-non-empty-destination-refusal)
+policy — it guarantees that no backend can wipe pre-existing untracked
+content on the initial `Clone` path. As with the URL-mismatch error, the
+manager wraps via `errors.Join`; `errors.As` still matches.
+
 ## Related
 
 - [`packages/core-vcs.md`](core-vcs.md) — backends.

--- a/internal/core/vcs/destination.go
+++ b/internal/core/vcs/destination.go
@@ -1,0 +1,77 @@
+package vcs
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// NonEmptyDestinationError is returned by CheckEmptyDestination when a clone
+// would write into a directory that already contains content. gaal refuses to
+// proceed in that case because go-git's PlainClone will silently overwrite
+// tracked files and leave untracked siblings exposed to checkout reset (see
+// issue #217: live runtime state under ~/.claude/ was being wiped on sync).
+type NonEmptyDestinationError struct {
+	Path    string   // destination path
+	Entries []string // names of entries found in the destination (may be truncated)
+}
+
+// maxListedEntries caps how many entry names the error message embeds, so a
+// destination with hundreds of files does not produce an unreadable blob.
+const maxListedEntries = 8
+
+func (e *NonEmptyDestinationError) Error() string {
+	names := e.Entries
+	suffix := ""
+	if len(names) > maxListedEntries {
+		extra := len(names) - maxListedEntries
+		names = names[:maxListedEntries]
+		suffix = fmt.Sprintf(" (and %d more)", extra)
+	}
+	return fmt.Sprintf(
+		"destination %s is not empty (contains: %s%s); "+
+			"gaal refuses to clone into a directory with existing content to avoid "+
+			"overwriting untracked files — move or delete the existing content, or "+
+			"point `repositories:` at a different path",
+		e.Path,
+		strings.Join(names, ", "),
+		suffix,
+	)
+}
+
+// CheckEmptyDestination returns a *NonEmptyDestinationError when path exists
+// and contains any entries (hidden files included). Returns nil when path
+// does not exist or exists and is empty. Returns a plain error when path
+// exists but is not a directory.
+//
+// Used by the repository Manager before delegating to a backend's Clone, so
+// that all VCS types share a single refusal policy.
+func CheckEmptyDestination(path string) error {
+	slog.Debug("checking destination is empty", "path", shortPath(path))
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspecting destination %s: %w", path, err)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("destination %s exists and is not a directory", path)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("reading destination %s: %w", path, err)
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return &NonEmptyDestinationError{Path: path, Entries: names}
+}

--- a/internal/core/vcs/destination_test.go
+++ b/internal/core/vcs/destination_test.go
@@ -1,0 +1,110 @@
+package vcs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckEmptyDestination_MissingPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+	if err := CheckEmptyDestination(dir); err != nil {
+		t.Fatalf("missing path should be allowed, got: %v", err)
+	}
+}
+
+func TestCheckEmptyDestination_EmptyDir(t *testing.T) {
+	if err := CheckEmptyDestination(t.TempDir()); err != nil {
+		t.Fatalf("empty directory should be allowed, got: %v", err)
+	}
+}
+
+func TestCheckEmptyDestination_NonEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "data.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	err := CheckEmptyDestination(dir)
+	if err == nil {
+		t.Fatal("expected error for non-empty directory")
+	}
+	var ne *NonEmptyDestinationError
+	if !errors.As(err, &ne) {
+		t.Fatalf("expected *NonEmptyDestinationError, got %T: %v", err, err)
+	}
+	if ne.Path != dir {
+		t.Errorf("Path = %q, want %q", ne.Path, dir)
+	}
+	found := false
+	for _, name := range ne.Entries {
+		if name == "data.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Entries to include %q, got %v", "data.txt", ne.Entries)
+	}
+}
+
+func TestCheckEmptyDestination_HiddenFileCounts(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	err := CheckEmptyDestination(dir)
+	var ne *NonEmptyDestinationError
+	if !errors.As(err, &ne) {
+		t.Fatalf("hidden file must count as non-empty, got %T: %v", err, err)
+	}
+}
+
+func TestCheckEmptyDestination_PathIsFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := CheckEmptyDestination(file); err == nil {
+		t.Fatal("expected error when destination is an existing file")
+	}
+}
+
+func TestNonEmptyDestinationError_Message(t *testing.T) {
+	err := &NonEmptyDestinationError{
+		Path:    "/home/u/.claude",
+		Entries: []string{"plans", ".credentials.json", "settings.json"},
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"/home/u/.claude",
+		"not empty",
+		"plans",
+		".credentials.json",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q\n  got: %s", want, msg)
+		}
+	}
+}
+
+func TestNonEmptyDestinationError_TruncatesEntries(t *testing.T) {
+	entries := make([]string, 0, 12)
+	for i := 0; i < 12; i++ {
+		entries = append(entries, "file")
+	}
+	err := &NonEmptyDestinationError{Path: "/x", Entries: entries}
+	msg := err.Error()
+	if !strings.Contains(msg, "more") {
+		t.Errorf("expected truncation hint in message, got: %s", msg)
+	}
+}
+
+func TestNonEmptyDestinationError_AsTarget(t *testing.T) {
+	err := &NonEmptyDestinationError{Path: "/x", Entries: []string{"a"}}
+	var target *NonEmptyDestinationError
+	if !errors.As(err, &target) {
+		t.Fatal("errors.As did not match NonEmptyDestinationError")
+	}
+}

--- a/internal/repo/backends_test.go
+++ b/internal/repo/backends_test.go
@@ -121,6 +121,107 @@ func TestManager_Status_DirtyFalse_Archive(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Manager.Sync - refuses to clone into a non-empty destination (#217)
+// ---------------------------------------------------------------------------
+
+// makeLocalGitSource initialises a tiny on-disk git repo with one commit, so
+// tests can exercise the git backend without network access. Mirrors the
+// helper in the vcs package's own tests.
+func makeLocalGitSource(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	r, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := w.Add("README.md"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := w.Commit("initial", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@t", When: time.Now()},
+	}); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return dir
+}
+
+func TestManager_Sync_RefusesNonEmptyCloneDestination(t *testing.T) {
+	src := makeLocalGitSource(t)
+
+	// Simulate the #217 scenario: a directory the user has been populating
+	// (live runtime state under ~/.claude/, secrets, etc.) into which a
+	// `repositories:` entry is now pointed for the first time.
+	dest := t.TempDir()
+	keepPath := filepath.Join(dest, ".credentials.json")
+	if err := os.WriteFile(keepPath, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	repos := map[string]config.ConfigRepo{
+		dest: {Type: "git", URL: src},
+	}
+	m := NewManager(repos, "")
+	err := m.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected Sync to refuse non-empty destination")
+	}
+	var ne *vcs.NonEmptyDestinationError
+	if !errors.As(err, &ne) {
+		t.Fatalf("expected wrapped *vcs.NonEmptyDestinationError, got %T: %v", err, err)
+	}
+	if ne.Path != dest {
+		t.Errorf("Path = %q, want %q", ne.Path, dest)
+	}
+	// Pre-existing content must survive unchanged.
+	got, readErr := os.ReadFile(keepPath)
+	if readErr != nil {
+		t.Fatalf("seed file was removed: %v", readErr)
+	}
+	if string(got) != "secret" {
+		t.Errorf("seed file modified: got %q, want %q", got, "secret")
+	}
+}
+
+func TestManager_Sync_AllowsEmptyCloneDestination(t *testing.T) {
+	src := makeLocalGitSource(t)
+	dest := t.TempDir() // exists, empty
+
+	repos := map[string]config.ConfigRepo{
+		dest: {Type: "git", URL: src},
+	}
+	m := NewManager(repos, "")
+	if err := m.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync into empty destination: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, ".git")); err != nil {
+		t.Errorf("expected .git in cloned destination: %v", err)
+	}
+}
+
+func TestManager_Sync_AllowsMissingCloneDestination(t *testing.T) {
+	src := makeLocalGitSource(t)
+	dest := filepath.Join(t.TempDir(), "child") // does not exist yet
+
+	repos := map[string]config.ConfigRepo{
+		dest: {Type: "git", URL: src},
+	}
+	m := NewManager(repos, "")
+	if err := m.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync into missing destination: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, ".git")); err != nil {
+		t.Errorf("expected .git in cloned destination: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Manager.Sync - URL mismatch wraps *vcs.RemoteURLMismatchError (#220)
 // ---------------------------------------------------------------------------
 

--- a/internal/repo/manager.go
+++ b/internal/repo/manager.go
@@ -73,6 +73,13 @@ func (m *Manager) syncOne(ctx context.Context, path string, cfg config.ConfigRep
 	}
 
 	if !backend.IsCloned(path) {
+		// Refuse to clone into a directory that already has content (#217).
+		// go-git's PlainClone would otherwise silently overwrite tracked files
+		// and expose untracked siblings to checkout reset, wiping live state
+		// the user did not intend to lose.
+		if err := vcs.CheckEmptyDestination(path); err != nil {
+			return err
+		}
 		slog.Debug("cloning repository", "path", path, "url", urlx.Redact(cfg.URL), "version", cfg.Version)
 		return backend.Clone(ctx, cfg.URL, path, cfg.Version)
 	}


### PR DESCRIPTION
## Summary

Closes #217 by adopting the "refuse to clone into a non-empty directory" path from the issue's suggested fix list.

- New `*vcs.NonEmptyDestinationError` + `vcs.CheckEmptyDestination(path)` helper in `internal/core/vcs/destination.go`. Mirrors the typed-error pattern from `RemoteURLMismatchError` (#220).
- `Manager.syncOne` calls the precheck before delegating to `backend.Clone`. The check is at the manager layer so the refusal policy applies uniformly to git, hg, svn, bzr, tar, and zip.
- Pre-existing content (including hidden files like `.credentials.json`) is left untouched.
- Once the directory contains the backend's marker (`.git`, `.hg`, …) the `Update` path takes over and is unaffected.
- Docs updated in `docs/config.md` and `docs/packages/repo.md` next to the existing URL-precedence sections.

## Test plan

- [x] `make build` clean
- [x] `make test` green (full suite)
- [x] New unit tests in `internal/core/vcs/destination_test.go` cover missing path, empty dir, non-empty dir (named entry), hidden file, path-is-a-file, message contents, message truncation, and `errors.As` matching.
- [x] New integration tests in `internal/repo/backends_test.go`:
  - `TestManager_Sync_RefusesNonEmptyCloneDestination` — seeds a sentinel file, expects refusal, and asserts the file survived unchanged (the #217 regression target).
  - `TestManager_Sync_AllowsEmptyCloneDestination` — empty dir still clones successfully.
  - `TestManager_Sync_AllowsMissingCloneDestination` — missing dir still clones successfully.
- [x] Tests use local on-disk git repos (no network), per `AGENTS.md`.