### PR TITLE
fix(urlx): treat Windows drive-letter paths as local; skip 7 Windows-only test bugs (#231)

### DIFF
--- a/internal/engine/hooks/hooks_test.go
+++ b/internal/engine/hooks/hooks_test.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"errors"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -207,6 +208,9 @@ func TestRunPostSync_PassesChangedEnv(t *testing.T) {
 }
 
 func TestResolve_HomeAndEnvExpansion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("expectations hard-code POSIX absolute paths; needs filepath.Join/ToSlash port (tracked in #231)")
+	}
 	t.Setenv("FOO_VALUE", "bar")
 	cfg := &config.ConfigHooks{
 		PreSync: []config.ConfigHook{

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -705,6 +705,9 @@ func TestLoadServers_InvalidMCPServersType(t *testing.T) {
 }
 
 func TestLoadServers_ReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 does not block reads under Windows ACLs (tracked in #231)")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("root bypasses permissions — skipping")
 	}
@@ -737,6 +740,9 @@ func TestListServers_InvalidMCPServersType(t *testing.T) {
 }
 
 func TestListServers_ReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 does not block reads under Windows ACLs (tracked in #231)")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("root bypasses permissions — skipping")
 	}
@@ -757,6 +763,9 @@ func TestListServers_ReadError(t *testing.T) {
 }
 
 func TestManager_Status_ReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 does not block reads under Windows ACLs (tracked in #231)")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("root bypasses permissions — skipping")
 	}

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -326,6 +326,9 @@ func TestIsLocalPath(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestManager_SourcePaths_ExpandsHomeAndKeepsAbsolute(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("expectations hard-code POSIX absolute paths; needs filepath.Join/ToSlash port (tracked in #231)")
+	}
 	skills := []config.ConfigSkill{
 		{Source: "~/skills/personal"},
 		{Source: "/abs/skills"},
@@ -345,6 +348,9 @@ func TestManager_SourcePaths_ExpandsHomeAndKeepsAbsolute(t *testing.T) {
 }
 
 func TestManager_SourcePaths_RemoteResolvesToCachePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HasPrefix \"/cache\" assertion uses POSIX separators; needs filepath.ToSlash port (tracked in #231)")
+	}
 	skills := []config.ConfigSkill{
 		{Source: "owner/repo"},
 		{Source: "https://github.com/owner/repo2"},
@@ -1036,6 +1042,9 @@ func TestEmitConfigWarnings_FiresOncePerManager(t *testing.T) {
 // aggregated error must mention both source paths to prove the loop did not
 // bail after the first failure.
 func TestManager_Sync_AggregatesErrorsAcrossSources(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("t.TempDir() returns the long-form path but the mkdir error uses the 8.3 short name, so strings.Contains misses; needs EvalSymlinks or basename comparison (tracked in #231)")
+	}
 	tmp := t.TempDir()
 	workDirAsFile := filepath.Join(tmp, "not-a-dir")
 	if err := os.WriteFile(workDirAsFile, []byte("file"), 0o644); err != nil {

--- a/internal/urlx/scheme.go
+++ b/internal/urlx/scheme.go
@@ -68,6 +68,12 @@ func ValidateRepoURL(rawurl string) error {
 	if isSCPStyleGitURL(rawurl) {
 		return nil
 	}
+	// "C:\path" and "C:/path" are local Windows paths, not URLs — but net/url
+	// parses them with scheme="c" and would fall through to the rejection
+	// branch below. Treat them like any other local path (empty-scheme case).
+	if isWindowsDrivePath(rawurl) {
+		return nil
+	}
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		return fmt.Errorf("parsing url: %w", err)
@@ -104,6 +110,32 @@ func isLoopbackHost(hostport string) bool {
 		return ip.IsLoopback()
 	}
 	return false
+}
+
+// isWindowsDrivePath reports whether s starts with a Windows drive-letter
+// prefix (e.g. "C:\", "d:/", or bare "Z:"). Such strings are local
+// filesystem paths, but net/url parses the leading letter as a URL scheme
+// and the result drops into ValidateRepoURL's default-reject branch with a
+// misleading "scheme c is not allowed" error.
+//
+// Detection is host-OS-agnostic on purpose: a Windows path string is the
+// same shape whether the running process is on Windows or not, and gaal
+// configs are sometimes authored on one OS and consumed on another.
+func isWindowsDrivePath(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	c := s[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+		return false
+	}
+	if s[1] != ':' {
+		return false
+	}
+	if len(s) == 2 {
+		return true
+	}
+	return s[2] == '\\' || s[2] == '/'
 }
 
 // isSCPStyleGitURL detects the user@host:path syntax that git accepts in

--- a/internal/urlx/scheme_test.go
+++ b/internal/urlx/scheme_test.go
@@ -93,12 +93,12 @@ func TestIsWindowsDrivePath(t *testing.T) {
 		{"", false},
 		{"C", false},
 		{"C:", true},
-		{"CC:\\x", false},      // multi-char "scheme"
-		{":\\path", false},     // missing letter
-		{"1:\\path", false},    // digit, not a letter
-		{"https://x", false},   // real URL
-		{"/srv/repo", false},   // unix path
-		{"./repo", false},      // relative
+		{"CC:\\x", false},    // multi-char "scheme"
+		{":\\path", false},   // missing letter
+		{"1:\\path", false},  // digit, not a letter
+		{"https://x", false}, // real URL
+		{"/srv/repo", false}, // unix path
+		{"./repo", false},    // relative
 		{"git@host:repo", false},
 	}
 	for _, tt := range tests {

--- a/internal/urlx/scheme_test.go
+++ b/internal/urlx/scheme_test.go
@@ -58,6 +58,15 @@ func TestValidateRepoURL(t *testing.T) {
 		{"scp-style with user ok", "alice@host.example:foo/bar", false},
 		{"plain local path ok", "/srv/local/repo", false},
 		{"plain relative path ok", "./local/repo", false},
+		// Windows local paths: net/url parses "C:\..." as scheme="c". Without
+		// special handling, Windows tests and Windows users get a bogus
+		// "scheme c is not allowed" rejection. Both separators must work
+		// because Go's filepath returns native backslashes but users sometimes
+		// write forward slashes in config.
+		{"windows drive backslash ok", `C:\Users\me\repo`, false},
+		{"windows drive forward slash ok", "C:/Users/me/repo", false},
+		{"windows drive lowercase ok", `d:\src\repo`, false},
+		{"windows drive bare ok", `Z:\`, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,6 +76,35 @@ func TestValidateRepoURL(t *testing.T) {
 			}
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error for %q: %v", tt.in, err)
+			}
+		})
+	}
+}
+
+func TestIsWindowsDrivePath(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{`C:\Users\me`, true},
+		{"C:/Users/me", true},
+		{`d:\src`, true},
+		{"Z:", true},
+		{"", false},
+		{"C", false},
+		{"C:", true},
+		{"CC:\\x", false},      // multi-char "scheme"
+		{":\\path", false},     // missing letter
+		{"1:\\path", false},    // digit, not a letter
+		{"https://x", false},   // real URL
+		{"/srv/repo", false},   // unix path
+		{"./repo", false},      // relative
+		{"git@host:repo", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := isWindowsDrivePath(tt.in); got != tt.want {
+				t.Errorf("isWindowsDrivePath(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

The v0.3.0 release workflow failed on the `Test / windows` job ([run 26413771732](https://github.com/getgaal/gaal/actions/runs/26413771732)) with 20 test failures. CI's `test` matrix is linux+macOS only — Windows tests run *only* in the release workflow, so all 20 failures had been latent on `main` since v0.2.0.

This PR unblocks the v0.3.0 release. It is a prerequisite for re-tagging `v0.3.0`.

## What

**Real fix (13 of 20 failures)** — [`internal/urlx/scheme.go`](internal/urlx/scheme.go)
- `ValidateRepoURL` now recognises Windows drive-letter prefixes (`C:\…`, `c:/…`, bare `Z:`) as local paths instead of letting `net/url` parse them as a scheme called `"c"`. Detection is host-OS-agnostic (configs may be authored on one OS and consumed on another). New `TestIsWindowsDrivePath` plus four positive cases in `TestValidateRepoURL`.
- Unblocks 10 tests in `internal/core/vcs/git_test.go` (pre-existing pattern from before v0.2.0), 1 in `internal/repo/backends_test.go` from PR #220, and 2 from the PR #230 (#217 fix) — all using the same `srcDir := t.TempDir(); pass as URL` idiom.

**Triage (7 of 20 failures)** — `t.Skip` guarded by `runtime.GOOS == \"windows\"`, each citing #231:
- `engine/hooks.TestResolve_HomeAndEnvExpansion` — POSIX path expectations
- `mcp.Test{Load,List,Status}Servers_ReadError` ×3 — chmod 0o000 doesn't block reads under Windows ACLs (same pattern as 15+ existing skips)
- `skill.TestManager_SourcePaths_{ExpandsHomeAndKeepsAbsolute,RemoteResolvesToCachePath}` — POSIX path expectations
- `skill.TestManager_Sync_AggregatesErrorsAcrossSources` — long-form vs 8.3 short-name path mismatch in substring assertion

#231 documents each test's root cause and the suggested port. It also flags the meta-issue: Windows test coverage exists only in the release workflow today, so regressions surface a month late — adding Windows to the regular CI matrix is part of the follow-up.

## Test plan

- [x] `make build` clean
- [x] `make test` green on macOS (full suite, 0 failures)
- [x] New RED→GREEN cycle on `TestValidateRepoURL` (Windows drive-letter cases failed before the fix, pass after)
- [x] All 7 skips reference #231 in their skip messages so a future fix can grep them out

Targets `v0.3.0` milestone. Closes the release blocker described in #231.