### PR TITLE
fix: match selected skills by directory name

### DIFF
--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -191,8 +191,12 @@ func (m *Manager) syncOne(ctx context.Context, sc config.ConfigSkill) error {
 
 	// 3. Filter by the "select" list.
 	selected := filterSkills(available, sc.Select)
-	if len(selected) == 0 {
+	if len(available) == 0 {
 		slog.Warn("no skills found in source", "source", sc.Source)
+		return nil
+	}
+	if len(selected) == 0 {
+		slog.Warn("no selected skills found in source", "source", sc.Source, "select", sc.Select)
 		return nil
 	}
 
@@ -497,9 +501,10 @@ func parseSkillMeta(path string) (SkillMeta, error) {
 	return SkillMeta{Name: name, Description: desc}, nil
 }
 
-// filterSkills returns the skills whose names match the select list.
-// An empty select list means "all".
+// filterSkills returns the skills whose names or directory names match the
+// select list. An empty select list means "all".
 func filterSkills(all []SkillMeta, selectNames []string) []SkillMeta {
+	slog.Debug("filtering skills", "available", len(all), "select", selectNames)
 	if len(selectNames) == 0 {
 		return all
 	}
@@ -510,6 +515,10 @@ func filterSkills(all []SkillMeta, selectNames []string) []SkillMeta {
 	var out []SkillMeta
 	for _, sk := range all {
 		if _, ok := set[sk.Name]; ok {
+			out = append(out, sk)
+			continue
+		}
+		if _, ok := set[filepath.Base(sk.Dir)]; ok {
 			out = append(out, sk)
 		}
 	}

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -1,6 +1,7 @@
 package skill
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"os"
@@ -141,11 +142,51 @@ func TestFilterSkills_Select_Subset(t *testing.T) {
 	}
 }
 
+func TestFilterSkills_Select_DirectoryName(t *testing.T) {
+	all := []SkillMeta{{Name: "firecrawl", Dir: filepath.Join(t.TempDir(), "firecrawl-cli")}}
+	got := filterSkills(all, []string{"firecrawl-cli"})
+	if len(got) != 1 {
+		t.Fatalf("expected 1, got %d", len(got))
+	}
+	if got[0].Name != "firecrawl" {
+		t.Errorf("expected selected skill name firecrawl, got %q", got[0].Name)
+	}
+}
+
 func TestFilterSkills_Select_NoMatch(t *testing.T) {
 	all := []SkillMeta{{Name: "a"}, {Name: "b"}}
 	got := filterSkills(all, []string{"z"})
 	if len(got) != 0 {
 		t.Errorf("expected 0, got %d", len(got))
+	}
+}
+
+func TestSyncOne_WarnsWhenSelectMatchesNoSkill(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "firecrawl-cli")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: firecrawl\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(oldLogger) })
+
+	m := NewManager(nil, t.TempDir(), t.TempDir(), t.TempDir(), t.TempDir(), false)
+	if err := m.syncOne(context.Background(), config.ConfigSkill{Source: root, Select: []string{"missing"}}); err != nil {
+		t.Fatalf("syncOne: %v", err)
+	}
+
+	log := buf.String()
+	if !strings.Contains(log, "no selected skills found in source") {
+		t.Fatalf("expected no-selected warning, got %q", log)
+	}
+	if strings.Contains(log, "msg=\"no skills found in source\"") {
+		t.Fatalf("expected no generic no-skills warning, got %q", log)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Match skill select entries against both SKILL.md frontmatter names and skill directory basenames.
- Keep the existing no-skills warning only for sources with zero discovered skills.
- Add a clearer warning when skills are discovered but the select list matches none.

Fixes #235

## Tests
- rtk go test ./internal/skill
- rtk make build
- rtk make test
- sandbox sync with the issue #235 config