### PR TITLE
bug: ix grouped skill discovery

### DIFF
--- a/internal/skill/manager.go
+++ b/internal/skill/manager.go
@@ -401,6 +401,11 @@ func (m *Manager) Status(ctx context.Context) []Status {
 
 			available, _ := discoverSkills(sourceDir)
 			selected := filterSkills(available, sc.Select)
+			if len(selected) == 0 && len(sc.Select) > 0 {
+				st.Missing = append(st.Missing, sc.Select...)
+				statuses = append(statuses, st)
+				continue
+			}
 
 			for _, sk := range selected {
 				dest := filepath.Join(skillsDir, filepath.Base(sk.Dir))
@@ -429,51 +434,8 @@ func discoverSkills(root string) ([]SkillMeta, error) {
 
 	for _, subdir := range buildDiscoveryDirs() {
 		base := filepath.Join(root, subdir)
-		entries, err := os.ReadDir(base)
-		if err != nil {
-			continue
-		}
-
-		for _, e := range entries {
-			if !e.IsDir() {
-				continue
-			}
-			// Reject directory names that would let a malicious skill
-			// source escape the install root via filepath.Join — `..`,
-			// `.`, empty, or names containing path separators after
-			// cleaning. The install path uses filepath.Base(sk.Dir) so
-			// these would otherwise walk above the agent skill dir.
-			if !isSafeSkillDirName(e.Name()) {
-				slog.Warn("skill: refusing unsafe directory name",
-					"name", e.Name(), "parent", base)
-				continue
-			}
-			skillDir := filepath.Join(base, e.Name())
-			mdPath := filepath.Join(skillDir, "SKILL.md")
-			if _, err := os.Stat(mdPath); err != nil {
-				continue
-			}
-			if _, ok := seen[skillDir]; ok {
-				continue
-			}
-			seen[skillDir] = struct{}{}
-
-			meta, err := parseSkillMeta(mdPath)
-			if err != nil {
-				slog.Warn("skipping invalid SKILL.md", "path", mdPath, "err", err)
-				continue
-			}
-			// Frontmatter `name:` is also subject to the same containment
-			// rule — a malicious source could ship `name: ../escape` and
-			// the install layer uses Name to compose select-list matches.
-			if meta.Name != "" && !isSafeSkillDirName(meta.Name) {
-				slog.Warn("skill: refusing unsafe frontmatter name",
-					"name", meta.Name, "path", mdPath)
-				continue
-			}
-			meta.Dir = skillDir
-			skills = append(skills, meta)
-		}
+		scanGrouped := strings.Contains(filepath.ToSlash(subdir), "skills")
+		scanSkillDiscoveryBase(base, scanGrouped, seen, &skills)
 	}
 
 	// Also check if root itself contains SKILL.md.
@@ -489,6 +451,81 @@ func discoverSkills(root string) ([]SkillMeta, error) {
 	}
 
 	return skills, nil
+}
+
+func scanSkillDiscoveryBase(base string, scanGrouped bool, seen map[string]struct{}, skills *[]SkillMeta) {
+	slog.Debug("scanning skill discovery base", "base", base, "scanGrouped", scanGrouped)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if !isSafeSkillDirName(e.Name()) {
+			slog.Warn("skill: refusing unsafe directory name",
+				"name", e.Name(), "parent", base)
+			continue
+		}
+		skillDir := filepath.Join(base, e.Name())
+		mdPath := filepath.Join(skillDir, "SKILL.md")
+		if _, err := os.Stat(mdPath); err == nil {
+			addDiscoveredSkill(skillDir, mdPath, seen, skills)
+			continue
+		}
+		if scanGrouped {
+			scanGroupedSkillDir(skillDir, seen, skills)
+		}
+	}
+}
+
+func scanGroupedSkillDir(groupDir string, seen map[string]struct{}, skills *[]SkillMeta) {
+	slog.Debug("scanning grouped skill dir", "dir", groupDir)
+	entries, err := os.ReadDir(groupDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if !isSafeSkillDirName(e.Name()) {
+			slog.Warn("skill: refusing unsafe directory name",
+				"name", e.Name(), "parent", groupDir)
+			continue
+		}
+		skillDir := filepath.Join(groupDir, e.Name())
+		mdPath := filepath.Join(skillDir, "SKILL.md")
+		if _, err := os.Stat(mdPath); err == nil {
+			addDiscoveredSkill(skillDir, mdPath, seen, skills)
+		}
+	}
+}
+
+func addDiscoveredSkill(skillDir, mdPath string, seen map[string]struct{}, skills *[]SkillMeta) {
+	slog.Debug("adding discovered skill", "dir", skillDir, "manifest", mdPath)
+	if _, ok := seen[skillDir]; ok {
+		return
+	}
+	seen[skillDir] = struct{}{}
+
+	meta, err := parseSkillMeta(mdPath)
+	if err != nil {
+		slog.Warn("skipping invalid SKILL.md", "path", mdPath, "err", err)
+		return
+	}
+	// Frontmatter `name:` is also subject to the same containment rule —
+	// a malicious source could ship `name: ../escape` and the install layer
+	// uses Name to compose select-list matches.
+	if meta.Name != "" && !isSafeSkillDirName(meta.Name) {
+		slog.Warn("skill: refusing unsafe frontmatter name",
+			"name", meta.Name, "path", mdPath)
+		return
+	}
+	meta.Dir = skillDir
+	*skills = append(*skills, meta)
 }
 
 // parseSkillMeta reads the YAML frontmatter from a SKILL.md file.

--- a/internal/skill/manager_test.go
+++ b/internal/skill/manager_test.go
@@ -122,6 +122,40 @@ func TestDiscoverSkills_NoDuplicates(t *testing.T) {
 	}
 }
 
+func TestDiscoverSkills_GroupedSkillsDirectory(t *testing.T) {
+	root := t.TempDir()
+	for _, tc := range []struct {
+		group string
+		name  string
+	}{
+		{group: "productivity", name: "teach"},
+		{group: "engineering", name: "grill-me"},
+	} {
+		skillDir := filepath.Join(root, "skills", tc.group, tc.name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: "+tc.name+"\n---\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	skills, err := discoverSkills(root)
+	if err != nil {
+		t.Fatalf("discoverSkills: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, sk := range skills {
+		got[sk.Name] = true
+	}
+	for _, want := range []string{"teach", "grill-me"} {
+		if !got[want] {
+			t.Errorf("expected grouped skill %q, got %+v", want, skills)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // filterSkills
 // ---------------------------------------------------------------------------
@@ -494,6 +528,41 @@ func TestManager_Status_InstalledAndMissing(t *testing.T) {
 	}
 	if !hasMissing {
 		t.Errorf("expected skill-b in Missing, got: %v", st.Missing)
+	}
+}
+
+func TestManager_Status_SelectMissReportsMissing(t *testing.T) {
+	sourceDir := t.TempDir()
+	skillDir := filepath.Join(sourceDir, "skill-a")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: skill-a\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	workDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workDir, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	skills := []config.ConfigSkill{
+		{Source: sourceDir, Agents: []string{"claude-code"}, Select: []string{"missing-skill"}},
+	}
+	m := NewManager(skills, t.TempDir(), "/home/user", workDir, "", false)
+	statuses := m.Status(context.Background())
+
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status entry, got %d", len(statuses))
+	}
+	if statuses[0].Err != nil {
+		t.Fatalf("unexpected error: %v", statuses[0].Err)
+	}
+	if len(statuses[0].Installed) != 0 {
+		t.Errorf("expected no installed skills, got %v", statuses[0].Installed)
+	}
+	if len(statuses[0].Missing) != 1 || statuses[0].Missing[0] != "missing-skill" {
+		t.Errorf("expected selected miss in Missing, got %v", statuses[0].Missing)
 	}
 }
 


### PR DESCRIPTION
## Summary
- discover skills nested under grouped `skills/<category>/<skill>` directories
- mark selected skills as missing when none of the selected names are discovered
- add regression coverage for grouped discovery and selected-name misses

## Root cause
`mattpocock/skills` stores skills under category folders such as `skills/productivity/teach`, while gaal only scanned direct children like `skills/teach`. Status also treated an empty selected set as ok, which hid the failed selection.

## Validation
- `make build`
- `make test`