### PR TITLE
[codex] Fix SSH git sync on fresh machines

### DIFF
--- a/internal/core/vcs/git.go
+++ b/internal/core/vcs/git.go
@@ -10,6 +10,7 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 
 	"gaal/internal/urlx"
 )
@@ -18,7 +19,7 @@ import (
 // (pure Go — no git binary required).
 //
 // Authentication: HTTPS public repositories work without configuration.
-// Private repos (SSH or authenticated HTTPS) are not yet supported.
+// SSH repositories use the user's SSH agent and known_hosts files.
 type VcsGit struct {
 	// Shallow requests a depth-1 clone (suitable for skill caches that never
 	// need history). Update will hard-reset to origin/HEAD instead of pulling.
@@ -43,8 +44,14 @@ func (g *VcsGit) Clone(ctx context.Context, url, path, version string) error {
 	safeURL := urlx.Redact(url)
 	slog.DebugContext(ctx, "cloning", "url", safeURL, "path", shortPath(path), "version", version)
 
+	auth, err := sshAuthForURL(ctx, url)
+	if err != nil {
+		return err
+	}
+
 	r, err := gogit.PlainCloneContext(ctx, path, false, &gogit.CloneOptions{
 		URL:               url,
+		Auth:              auth,
 		RecurseSubmodules: gogit.DefaultSubmoduleRecursionDepth,
 		Tags:              gogit.AllTags,
 		Depth:             g.depth(),
@@ -80,8 +87,14 @@ func (g *VcsGit) Update(ctx context.Context, url, path, version string) error {
 
 	slog.DebugContext(ctx, "fetching", "path", shortPath(path))
 
+	auth, err := sshAuthForRemote(ctx, r, url)
+	if err != nil {
+		return err
+	}
+
 	fetchErr := r.FetchContext(ctx, &gogit.FetchOptions{
 		RemoteName: "origin",
+		Auth:       auth,
 		Tags:       gogit.AllTags,
 		Force:      true,
 		Prune:      true,
@@ -107,6 +120,7 @@ func (g *VcsGit) Update(ctx context.Context, url, path, version string) error {
 	}
 	if err = w.PullContext(ctx, &gogit.PullOptions{
 		RemoteName: "origin",
+		Auth:       auth,
 		Force:      true,
 	}); err != nil && !errors.Is(err, gogit.NoErrAlreadyUpToDate) {
 		return fmt.Errorf("pulling: %w", err)
@@ -141,6 +155,20 @@ func (g *VcsGit) resetToRemoteHEAD(ctx context.Context, r *gogit.Repository) err
 		Commit: hash,
 		Mode:   gogit.HardReset,
 	})
+}
+
+func sshAuthForRemote(ctx context.Context, r *gogit.Repository, configuredURL string) (transport.AuthMethod, error) {
+	slog.DebugContext(ctx, "preparing git auth for remote", "url", urlx.Redact(configuredURL))
+
+	if configuredURL != "" {
+		return sshAuthForURL(ctx, configuredURL)
+	}
+
+	remote, err := r.Remote("origin")
+	if err != nil || len(remote.Config().URLs) == 0 {
+		return nil, nil
+	}
+	return sshAuthForURL(ctx, remote.Config().URLs[0])
 }
 
 func (g *VcsGit) IsCloned(path string) bool {

--- a/internal/core/vcs/ssh_known_hosts.go
+++ b/internal/core/vcs/ssh_known_hosts.go
@@ -1,0 +1,276 @@
+package vcs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	gogitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	"gaal/internal/urlx"
+)
+
+const systemKnownHostsPath = "/etc/ssh/ssh_known_hosts"
+
+var newSSHAgentAuth = gogitssh.NewSSHAgentAuth
+
+var defaultSSHKeyNames = []string{
+	"id_ed25519",
+	"id_ecdsa",
+	"id_rsa",
+	"id_dsa",
+}
+
+type knownHostsConfig struct {
+	files     []string
+	writePath string
+}
+
+func sshAuthForURL(ctx context.Context, rawURL string) (transport.AuthMethod, error) {
+	slog.DebugContext(ctx, "preparing git auth for URL", "url", urlx.Redact(rawURL))
+
+	endpoint, err := transport.NewEndpoint(rawURL)
+	if err != nil || endpoint.Protocol != "ssh" {
+		return nil, nil
+	}
+
+	user := endpoint.User
+	if user == "" {
+		user = gogitssh.DefaultUsername
+	}
+
+	callback, err := acceptNewKnownHostsCallback(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	auth, err := sshPublicKeysAuth(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+	auth.HostKeyCallback = callback
+	return auth, nil
+}
+
+func sshPublicKeysAuth(ctx context.Context, user string) (*gogitssh.PublicKeysCallback, error) {
+	slog.DebugContext(ctx, "creating SSH public key auth", "user", user)
+
+	agentAuth, agentErr := newSSHAgentAuth(user)
+	keyPaths, err := defaultSSHPrivateKeyPaths()
+	if err != nil {
+		return nil, err
+	}
+	fileSigners, fileErr := loadSSHPrivateKeySigners(ctx, keyPaths)
+	if agentErr != nil && len(fileSigners) == 0 {
+		if fileErr != nil {
+			return nil, fmt.Errorf("creating SSH auth: agent unavailable (%v); loading SSH keys: %w", agentErr, fileErr)
+		}
+		return nil, fmt.Errorf("creating SSH auth: agent unavailable (%v) and no default SSH private keys found in ~/.ssh", agentErr)
+	}
+
+	return &gogitssh.PublicKeysCallback{
+		User: user,
+		Callback: func() ([]ssh.Signer, error) {
+			slog.Debug("loading SSH signers for authentication", "file_signers", len(fileSigners), "has_agent", agentAuth != nil)
+
+			signers := append([]ssh.Signer{}, fileSigners...)
+			if agentAuth != nil && agentAuth.Callback != nil {
+				agentSigners, err := agentAuth.Callback()
+				if err != nil && len(signers) == 0 {
+					return nil, fmt.Errorf("loading SSH agent signers: %w", err)
+				}
+				signers = append(signers, agentSigners...)
+			}
+			if len(signers) == 0 {
+				return nil, fmt.Errorf("no SSH identities available; add a key to ssh-agent or create a default key in ~/.ssh")
+			}
+			return signers, nil
+		},
+	}, nil
+}
+
+func defaultSSHPrivateKeyPaths() ([]string, error) {
+	slog.Debug("resolving default SSH private key paths")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving home directory: %w", err)
+	}
+	paths := make([]string, 0, len(defaultSSHKeyNames))
+	for _, name := range defaultSSHKeyNames {
+		paths = append(paths, filepath.Join(home, ".ssh", name))
+	}
+	return paths, nil
+}
+
+func loadSSHPrivateKeySigners(ctx context.Context, paths []string) ([]ssh.Signer, error) {
+	slog.DebugContext(ctx, "loading default SSH private keys", "count", len(paths))
+
+	var signers []ssh.Signer
+	var errs []error
+	for _, path := range paths {
+		signer, err := loadSSHPrivateKeySigner(path)
+		if err == nil {
+			signers = append(signers, signer)
+			continue
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			errs = append(errs, err)
+		}
+	}
+	return signers, errors.Join(errs...)
+}
+
+func loadSSHPrivateKeySigner(path string) (ssh.Signer, error) {
+	slog.Debug("loading SSH private key", "path", shortPath(path))
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	signer, err := ssh.ParsePrivateKey(data)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", shortPath(path), err)
+	}
+	return signer, nil
+}
+
+func acceptNewKnownHostsCallback(ctx context.Context) (ssh.HostKeyCallback, error) {
+	slog.DebugContext(ctx, "creating accept-new known_hosts callback")
+
+	cfg, err := prepareKnownHosts(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	callback, err := knownhosts.New(cfg.files...)
+	if err != nil {
+		return nil, fmt.Errorf("reading known_hosts: %w", err)
+	}
+
+	var mu sync.Mutex
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		slog.Debug("checking SSH host key", "host", hostname, "known_hosts", shortPath(cfg.writePath))
+
+		err := callback(hostname, remote, key)
+		if err == nil {
+			return nil
+		}
+
+		var keyErr *knownhosts.KeyError
+		if !errors.As(err, &keyErr) || len(keyErr.Want) > 0 {
+			return err
+		}
+
+		if err := appendKnownHost(cfg.writePath, hostname, key); err != nil {
+			return err
+		}
+		callback, err = knownhosts.New(cfg.files...)
+		if err != nil {
+			return fmt.Errorf("reloading known_hosts: %w", err)
+		}
+		slog.Debug("accepted new SSH host key", "host", hostname, "known_hosts", shortPath(cfg.writePath))
+		return nil
+	}, nil
+}
+
+func prepareKnownHosts(ctx context.Context) (knownHostsConfig, error) {
+	slog.DebugContext(ctx, "preparing known_hosts files")
+
+	candidates, writePath, err := knownHostsCandidates()
+	if err != nil {
+		return knownHostsConfig{}, err
+	}
+	if err := ensureKnownHostsFile(writePath); err != nil {
+		return knownHostsConfig{}, err
+	}
+
+	files := make([]string, 0, len(candidates))
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			files = append(files, path)
+		} else if !os.IsNotExist(err) {
+			return knownHostsConfig{}, fmt.Errorf("checking known_hosts %s: %w", shortPath(path), err)
+		}
+	}
+	if len(files) == 0 {
+		return knownHostsConfig{}, fmt.Errorf("no known_hosts files available")
+	}
+
+	return knownHostsConfig{files: files, writePath: writePath}, nil
+}
+
+func knownHostsCandidates() ([]string, string, error) {
+	slog.Debug("resolving known_hosts candidates")
+
+	if env := os.Getenv("SSH_KNOWN_HOSTS"); env != "" {
+		files := nonEmptyPathList(env)
+		if len(files) == 0 {
+			return nil, "", fmt.Errorf("SSH_KNOWN_HOSTS does not contain a usable path")
+		}
+		return files, files[0], nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	userKnownHosts := filepath.Join(home, ".ssh", "known_hosts")
+	return []string{userKnownHosts, systemKnownHostsPath}, userKnownHosts, nil
+}
+
+func nonEmptyPathList(value string) []string {
+	slog.Debug("splitting path list")
+
+	parts := filepath.SplitList(value)
+	files := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			files = append(files, part)
+		}
+	}
+	return files
+}
+
+func ensureKnownHostsFile(path string) error {
+	slog.Debug("ensuring known_hosts file exists", "path", shortPath(path))
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("creating known_hosts directory: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("creating known_hosts file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing known_hosts file: %w", err)
+	}
+	return nil
+}
+
+func appendKnownHost(path, hostname string, key ssh.PublicKey) error {
+	slog.Debug("appending SSH host key", "host", hostname, "known_hosts", shortPath(path))
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening known_hosts file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := fmt.Fprintln(f, knownhosts.Line([]string{hostname}, key)); err != nil {
+		return fmt.Errorf("writing known_hosts entry: %w", err)
+	}
+	return nil
+}

--- a/internal/core/vcs/ssh_known_hosts_test.go
+++ b/internal/core/vcs/ssh_known_hosts_test.go
@@ -1,0 +1,277 @@
+package vcs
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gogitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func testPublicKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatalf("NewSignerFromKey: %v", err)
+	}
+	if !publicKey.Equal(privateKey.Public()) {
+		t.Fatal("generated public key does not match private key")
+	}
+	return signer.PublicKey()
+}
+
+func testPrivateKeyPEM(t *testing.T) []byte {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	data, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: data})
+}
+
+func TestKnownHostsCandidates_DefaultUsesHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+
+	files, writePath, err := knownHostsCandidates()
+	if err != nil {
+		t.Fatalf("knownHostsCandidates: %v", err)
+	}
+
+	want := filepath.Join(home, ".ssh", "known_hosts")
+	if writePath != want {
+		t.Fatalf("writePath = %q, want %q", writePath, want)
+	}
+	if len(files) != 2 || files[0] != want || files[1] != systemKnownHostsPath {
+		t.Fatalf("files = %#v", files)
+	}
+}
+
+func TestKnownHostsCandidates_UsesSSHKnownHostsEnv(t *testing.T) {
+	first := filepath.Join(t.TempDir(), "known_hosts")
+	second := filepath.Join(t.TempDir(), "extra_known_hosts")
+	t.Setenv("SSH_KNOWN_HOSTS", first+string(os.PathListSeparator)+second)
+
+	files, writePath, err := knownHostsCandidates()
+	if err != nil {
+		t.Fatalf("knownHostsCandidates: %v", err)
+	}
+
+	if writePath != first {
+		t.Fatalf("writePath = %q, want %q", writePath, first)
+	}
+	if len(files) != 2 || files[0] != first || files[1] != second {
+		t.Fatalf("files = %#v", files)
+	}
+}
+
+func TestPrepareKnownHosts_CreatesUserFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+
+	cfg, err := prepareKnownHosts(context.Background())
+	if err != nil {
+		t.Fatalf("prepareKnownHosts: %v", err)
+	}
+
+	want := filepath.Join(home, ".ssh", "known_hosts")
+	if cfg.writePath != want {
+		t.Fatalf("writePath = %q, want %q", cfg.writePath, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("known_hosts was not created: %v", err)
+	}
+	if len(cfg.files) == 0 || cfg.files[0] != want {
+		t.Fatalf("files = %#v", cfg.files)
+	}
+}
+
+func TestAcceptNewKnownHostsCallback_AppendsUnknownHost(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	t.Setenv("SSH_KNOWN_HOSTS", path)
+
+	callback, err := acceptNewKnownHostsCallback(context.Background())
+	if err != nil {
+		t.Fatalf("acceptNewKnownHostsCallback: %v", err)
+	}
+
+	key := testPublicKey(t)
+	remote := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 22}
+	if err := callback("example.com:22", remote, key); err != nil {
+		t.Fatalf("callback unknown host: %v", err)
+	}
+	if err := callback("example.com:22", remote, key); err != nil {
+		t.Fatalf("callback appended host: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if got := strings.Count(string(data), "example.com "); got != 1 {
+		t.Fatalf("known_hosts entry count = %d, want 1\n%s", got, data)
+	}
+}
+
+func TestAcceptNewKnownHostsCallback_RejectsChangedHostKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	oldKey := testPublicKey(t)
+	if err := os.WriteFile(path, []byte(knownhosts.Line([]string{"example.com:22"}, oldKey)+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("SSH_KNOWN_HOSTS", path)
+
+	callback, err := acceptNewKnownHostsCallback(context.Background())
+	if err != nil {
+		t.Fatalf("acceptNewKnownHostsCallback: %v", err)
+	}
+
+	newKey := testPublicKey(t)
+	remote := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 22}
+	err = callback("example.com:22", remote, newKey)
+	var keyErr *knownhosts.KeyError
+	if !errors.As(err, &keyErr) || len(keyErr.Want) == 0 {
+		t.Fatalf("expected known_hosts key mismatch, got %T: %v", err, err)
+	}
+}
+
+func TestSSHAuthForURL_NonSSHReturnsNil(t *testing.T) {
+	auth, err := sshAuthForURL(context.Background(), "https://github.com/getgaal/gaal.git")
+	if err != nil {
+		t.Fatalf("sshAuthForURL: %v", err)
+	}
+	if auth != nil {
+		t.Fatalf("auth = %T, want nil", auth)
+	}
+}
+
+func TestSSHAuthForURL_SSHUsesGitUser(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	t.Setenv("SSH_KNOWN_HOSTS", path)
+
+	oldNewSSHAgentAuth := newSSHAgentAuth
+	t.Cleanup(func() { newSSHAgentAuth = oldNewSSHAgentAuth })
+	var gotUser string
+	newSSHAgentAuth = func(user string) (*gogitssh.PublicKeysCallback, error) {
+		gotUser = user
+		return &gogitssh.PublicKeysCallback{User: user}, nil
+	}
+
+	auth, err := sshAuthForURL(context.Background(), "git@github.com:owner/repo.git")
+	if err != nil {
+		t.Fatalf("sshAuthForURL: %v", err)
+	}
+	if gotUser != gogitssh.DefaultUsername {
+		t.Fatalf("newSSHAgentAuth user = %q, want %q", gotUser, gogitssh.DefaultUsername)
+	}
+	if got := auth.(*gogitssh.PublicKeysCallback).User; got != gogitssh.DefaultUsername {
+		t.Fatalf("User = %q, want %q", got, gogitssh.DefaultUsername)
+	}
+}
+
+func TestDefaultSSHPrivateKeyPaths_UsesHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := defaultSSHPrivateKeyPaths()
+	if err != nil {
+		t.Fatalf("defaultSSHPrivateKeyPaths: %v", err)
+	}
+	if len(paths) != len(defaultSSHKeyNames) {
+		t.Fatalf("len(paths) = %d, want %d", len(paths), len(defaultSSHKeyNames))
+	}
+	if paths[0] != filepath.Join(home, ".ssh", defaultSSHKeyNames[0]) {
+		t.Fatalf("first key path = %q", paths[0])
+	}
+}
+
+func TestLoadSSHPrivateKeySigners_LoadsDefaultKey(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	if err := os.WriteFile(keyPath, testPrivateKeyPEM(t), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	signers, err := loadSSHPrivateKeySigners(context.Background(), []string{
+		keyPath,
+		filepath.Join(dir, "missing"),
+	})
+	if err != nil {
+		t.Fatalf("loadSSHPrivateKeySigners: %v", err)
+	}
+	if len(signers) != 1 {
+		t.Fatalf("len(signers) = %d, want 1", len(signers))
+	}
+}
+
+func TestSSHPublicKeysAuth_UsesDefaultKeyWhenAgentUnavailable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "id_ed25519"), testPrivateKeyPEM(t), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	oldNewSSHAgentAuth := newSSHAgentAuth
+	t.Cleanup(func() { newSSHAgentAuth = oldNewSSHAgentAuth })
+	newSSHAgentAuth = func(user string) (*gogitssh.PublicKeysCallback, error) {
+		return nil, fmt.Errorf("agent unavailable for %s", user)
+	}
+
+	auth, err := sshPublicKeysAuth(context.Background(), gogitssh.DefaultUsername)
+	if err != nil {
+		t.Fatalf("sshPublicKeysAuth: %v", err)
+	}
+	signers, err := auth.Callback()
+	if err != nil {
+		t.Fatalf("Callback: %v", err)
+	}
+	if len(signers) != 1 {
+		t.Fatalf("len(signers) = %d, want 1", len(signers))
+	}
+}
+
+func TestSSHPublicKeysAuth_ErrorsWithoutAgentOrKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	oldNewSSHAgentAuth := newSSHAgentAuth
+	t.Cleanup(func() { newSSHAgentAuth = oldNewSSHAgentAuth })
+	newSSHAgentAuth = func(user string) (*gogitssh.PublicKeysCallback, error) {
+		return nil, fmt.Errorf("agent unavailable for %s", user)
+	}
+
+	_, err := sshPublicKeysAuth(context.Background(), gogitssh.DefaultUsername)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no default SSH private keys") {
+		t.Fatalf("error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes first-run SSH git sync failures for users who have not previously populated `known_hosts` or loaded keys into `ssh-agent`.

## Root cause

The go-git SSH transport was relying on its default known_hosts callback and SSH agent behavior. On a fresh machine this could fail before clone with:

```text
unable to find any valid known_hosts file
```

After creating known_hosts, it could still fail when a default private key existed on disk but was not loaded into `ssh-agent`.

## Changes

- Add explicit SSH auth setup for git clone, fetch, and pull.
- Create/use the normal `~/.ssh/known_hosts` path, while honoring `SSH_KNOWN_HOSTS`.
- Accept and persist unknown host keys on first contact, while still rejecting changed host keys.
- Load signers from both `ssh-agent` and default unencrypted private key files in `~/.ssh`.
- Add unit coverage for known_hosts creation, accept-new behavior, changed-key rejection, and default-key auth fallback.

Fixes #239.

## Validation

- `go test ./internal/core/vcs`
- `make build`
- `make test`