### PR TITLE
feat(agents): add antigravity CLI (agy), retire deprecated gemini-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ gaal auto-detects 17 coding agents. Use `agents: ["*"]` and a skill or MCP lands
 |---|---|---|
 | Claude Code | Cursor | Codex |
 | GitHub Copilot | Amp | Cline |
-| Roo | Continue | Gemini CLI |
+| Roo | Continue | Antigravity CLI |
 | Goose | Kilo | Kiro CLI |
 | OpenCode | OpenHands | Trae |
 | Warp | Windsurf | |

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -129,12 +129,25 @@ skills are dashboard-published.
   in-app MCP Store / extension store.
 
 ### MCP config
-- Single global file shared with Gemini CLI / Code Companion. Reported path:
-  `~/.gemini/settings/mcp_config.json` (Linux/macOS); under `%USERPROFILE%`
-  on Windows. Earlier docs cited `~/.gemini/antigravity/mcp_config.json`.
+- Dedicated global file: `~/.gemini/config/mcp_config.json` (Linux/macOS),
+  shared across the Antigravity IDE/CLI (2.0+). Created on demand — absent
+  until the first server is added. On Windows assume the analogous
+  `%USERPROFILE%\.gemini\config\mcp_config.json` (unverified).
+  - This is **not** `~/.gemini/settings.json` — that file is Gemini-CLI's
+    (which stores MCP servers inline under `mcpServers`). Antigravity moved
+    MCP to its own file; do not write servers into `settings.json`.
+  - Superseded legacy paths still seen in older guides:
+    `~/.gemini/antigravity/mcp_config.json` (early IDE) and
+    `~/.gemini/antigravity-cli/mcp_config.json` (pre-migration CLI).
 - JSON. Top-level key: `mcpServers`.
-- stdio: `command`, `args`, `env`. HTTP: `url`, `headers`.
-- Env interpolation: undocumented.
+- stdio: `command`, `args`, `env`. HTTP/remote: the URL field is **`serverUrl`**
+  (NOT `url`/`httpUrl`); a wrong field name fails silently at tool-call time.
+  Plus `headers`. Server-level `timeout` is not supported; JSON comments are
+  not supported.
+- **Env interpolation: `${VAR}`/`$VAR` are NOT expanded** (reported day-one
+  bug). Values in `env`/`headers` must be inlined literally; `${workspaceFolder}`
+  is also unsupported (use absolute paths). Contrast Gemini CLI, which *does*
+  expand `${VAR}` in its own `settings.json`.
 
 ### Behavioural quirks
 - Preview product; tied to personal Gmail accounts. Chrome required for the
@@ -145,9 +158,13 @@ skills are dashboard-published.
 
 ### Sources
 - https://antigravity.google/docs/skills
-- https://antigravity.google/docs/mcp
+- https://antigravity.google/docs/mcp (JS-rendered SPA; not machine-readable)
 - https://codelabs.developers.google.com/getting-started-google-antigravity
 - https://codelabs.developers.google.com/getting-started-with-antigravity-skills
+- MCP path/shape (config/mcp_config.json, serverUrl, no ${VAR}), 2026-06:
+  https://medium.com/google-cloud/configuring-mcp-servers-and-skills-for-antigravity-cli-and-ide-a938c7eebb78
+- https://codelabs.developers.google.com/google-workspace-mcp-antigravity
+- Project-local MCP ignored by CLI: https://github.com/google-antigravity/antigravity-cli/issues/60
 
 ---
 

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -11,7 +11,7 @@
 > This file is the *narrative* counterpart: what each agent actually supports,
 > in what format, with what gotchas, and where the canonical vendor docs live.
 >
-> Last reviewed: 2026-05-15.
+> Last reviewed: 2026-06-23.
 
 ## Reading this document
 
@@ -40,6 +40,7 @@ encode. `n/a` means the agent has no MCP feature at all.
 
 | Agent | Native skills | Project MCP | MCP format | Supported OS |
 |-------|--------------|-------------|------------|--------------|
+| agy | yes (SKILL.md) | **no** (global-only) | JSON, key `mcpServers` | darwin / linux / windows |
 | amp | yes (SKILL.md) | yes (`.amp/settings.json`) | JSONC, key `amp.mcpServers` | darwin / linux / windows |
 | antigravity | yes (SKILL.md) | **no** (global-only) | JSON, key `mcpServers` | darwin / linux¹ / windows |
 | augment | yes (in plugin) | yes (`.mcp.json`) | JSON, key `mcpServers` | darwin / linux / windows |
@@ -49,7 +50,6 @@ encode. `n/a` means the agent has no MCP feature at all.
 | codex | yes (SKILL.md) | yes (trusted-only) | TOML, key `[mcp_servers.*]` | darwin / linux / windows |
 | continue | no (rules instead) | yes (`.continue/`) | YAML, key `mcpServers` | darwin / linux / windows |
 | cursor | no (rules instead) | yes (`.cursor/mcp.json`) | JSON, key `mcpServers` | darwin / linux / windows |
-| gemini-cli | yes (via extension) | yes (`.gemini/settings.json`) | JSON, key `mcpServers` | darwin / linux / windows |
 | generic | yes (convention only) | n/a | n/a | darwin / linux / windows |
 | github-copilot | no (custom agents) | yes (`.vscode/mcp.json`) | JSON, key **`servers`** | darwin / linux / windows |
 | goose | yes (SKILL.md) | no (global only) | YAML, key `extensions` | darwin / linux / windows |
@@ -66,6 +66,63 @@ encode. `n/a` means the agent has no MCP feature at all.
 ¹ Antigravity Linux support is limited to "select distros" in preview.
 ² Windsurf has a Skills feature but no documented `SKILL.md` disk format —
 skills are dashboard-published.
+
+---
+
+## agy
+
+> Antigravity CLI. The Go binary `agy` that replaced the deprecated Gemini
+> CLI for consumer tiers on 2026-06-18 (paid Gemini Enterprise / Cloud API
+> keys are unaffected). It is the CLI surface of the Antigravity family — see
+> [antigravity](#antigravity) for the IDE.
+> **The official `antigravity.google` docs are JS-rendered SPAs that can't be
+> machine-read; the on-disk paths below are corroborated across migration
+> guides, not verified against primary docs.**
+
+### Skills
+- Native `SKILL.md`; the agent semantic-matches the prompt against `description`.
+- agy itself reads global skills from `~/.gemini/antigravity-cli/skills/`
+  (CLI-only) and the shared `~/.gemini/skills/`; project skills from
+  `<workspace>/.agents/skills/`.
+- **gaal targets the vendor-neutral `.agents/skills` / `~/.agents/skills`
+  convention** (the `generic` agent) for both scopes rather than the
+  `~/.gemini/` paths.
+- Global rules/context: `~/.gemini/GEMINI.md` (AGENTS.md also read).
+
+### Plugins / extensions
+- Gemini "extensions" are now Antigravity "plugins". `agy plugin import gemini`
+  imports the legacy `~/.gemini/extensions/` and stages plugin bundles under
+  `~/.gemini/antigravity-cli/plugins/` (and the shared `~/.gemini/config/plugins/`).
+- A bundle may carry `plugin.json` plus optional `mcp_config.json`,
+  `hooks.json`, `skills/`, `agents/`, `rules/`.
+
+### MCP config
+- Global (shared with the Antigravity IDE): `~/.gemini/config/mcp_config.json`.
+  Per-tool dirs (`~/.gemini/antigravity-cli/mcp/`) are generated from it. This
+  is the single path gaal writes — no vendor-neutral global MCP standard exists.
+- **No per-workspace MCP** — project-local MCP is ignored by the CLI
+  (antigravity-cli issue #60).
+- JSON. Top-level key: `mcpServers`.
+- stdio: `command`, `args`, `env`. HTTP/remote: the URL field is **`serverUrl`**
+  (NOT `url`/`httpUrl`); a wrong name fails silently at tool-call time.
+- **Env interpolation: `${VAR}`/`$VAR` are NOT expanded** — inline values
+  literally; `${workspaceFolder}` is unsupported too.
+
+### Behavioural quirks
+- macOS, Linux, Windows. (One guide reports Windows is WSL2-only; others say
+  native PowerShell/CMD — unresolved.) Binary installs to `~/.local/bin/agy`.
+- Closed-source, unlike the Apache-2.0 Gemini CLI it replaced.
+- General CLI settings live in `~/.gemini/antigravity-cli/settings.json`
+  (separate from MCP config).
+
+### Sources
+- Deprecation/transition (official):
+  https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/
+- https://github.com/google-gemini/gemini-cli/discussions/27274
+- https://antigravity.google/docs/gcli-migration (JS-rendered SPA; not machine-readable)
+- Paths (skills/MCP/plugins under ~/.gemini), 2026-06:
+  https://medium.com/google-cloud/configuring-mcp-servers-and-skills-for-antigravity-cli-and-ide-a938c7eebb78
+- Project-local MCP ignored by CLI: https://github.com/google-antigravity/antigravity-cli/issues/60
 
 ---
 
@@ -533,57 +590,6 @@ skills are dashboard-published.
 ### Sources
 - https://cursor.com/docs/cli/mcp
 - https://cursor.com/help/customization/extensions
-
----
-
-## gemini-cli
-
-### Skills
-- Native — **only as part of an installed extension**. Skills placed at
-  `<extension>/skills/<name>/SKILL.md`. There is no documented standalone
-  `~/.gemini/skills/`; skills ride along with extensions.
-- Extensions (and their skills) live under `~/.gemini/extensions/<name>/`.
-- Anthropic-style `SKILL.md` frontmatter (`name`, `description`).
-
-### Plugins / extensions
-- First-class **Gemini CLI Extensions**.
-- On disk: `~/.gemini/extensions/<extension>/` (a copy is made at install;
-  `gemini extensions update` pulls source changes). Project-level
-  extensions directory: undocumented.
-- Manifest: `gemini-extension.json` at the extension root. Properties:
-  `name` (lowercase), `version`, `description`, `mcpServers`,
-  `contextFileName` (defaults to `GEMINI.md`), `excludeTools`, `plan`.
-  Extensions can also include `commands/*.toml`, themes, hooks, sub-agents
-  and `skills/`.
-- Install:
-  `gemini extensions install <github-url-or-local-path>` (optional `--ref`,
-  `--auto-update`). Enable/disable per-workspace or globally via
-  `gemini extensions enable|disable <name>`.
-
-### MCP config
-- User: `~/.gemini/settings.json`. Project: `<workspace>/.gemini/settings.json`.
-- JSON. Top-level key: `mcpServers`. Sibling `mcp` object holds global
-  allow/exclude lists (`mcp.allowed`, `mcp.excluded`, `mcp.serverCommand`).
-- stdio: `command`, `args`, `env`, `cwd`, `timeout`, `trust`. HTTP:
-  `httpUrl`, `headers`, `timeout`. SSE: `url`, `headers`, `timeout`.
-- Env interpolation: `$VAR` / `${VAR}` on all platforms; `%VAR%` on Windows.
-
-### Behavioural quirks
-- Platforms: macOS, Linux, Windows.
-- Tool-name normalisation replaces non-`[A-Za-z0-9_.\-:]` characters with
-  underscores → silent name collisions possible.
-- Underscores in server names discouraged (policy engine misinterprets);
-  use hyphens.
-- MCP connection failures only show a small hint at startup — silent
-  failure mode without explicit diagnostic commands.
-- `settings.json` edits need a restart to take effect.
-
-### Sources
-- https://geminicli.com/docs/tools/mcp-server/
-- https://geminicli.com/docs/extensions/
-- https://geminicli.com/docs/extensions/reference/
-- https://geminicli.com/docs/extensions/writing-extensions/
-- https://geminicli.com/docs/cli/tutorials/mcp-setup/
 
 ---
 
@@ -1132,7 +1138,7 @@ plan is grounded in real cases, not hypothetical ones:
    (GUI app). Drives the existing
    `warnSkillsTargetingClaudeDesktop` check.
 
-2. **`supports_mcp_project` (bool)** — false today for `antigravity`,
+2. **`supports_mcp_project` (bool)** — false today for `agy`, `antigravity`,
    `claude-desktop`, `cline`, `goose`, `windsurf`, `zencoder` (and
    uncertain for `openhands` whose project file is opt-in). Warrants a
    `WarnMCPProjectUnsupported` warning when a `global: false` entry

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -130,7 +130,7 @@ Quick reference:
 | `mcps` | `merge` | `true` (default) = upsert; `false` = overwrite |
 | _(top-level)_ | `telemetry` | `true` / `false`: opt in/out of anonymous usage telemetry (only `global` and `user` config files; workspace cannot override — see [docs/config.md](config.md#scope-restriction-policy)) |
 
-Supported agent names: `amp`, `claude-code`, `cursor`, `github-copilot`, `cline`, `roo`, `codex`, `continue`, `gemini-cli`, `goose`, `kilo`, `kiro-cli`, `opencode`, `openhands`, `trae`, `warp`, `windsurf`, and more. Run `gaal info agent` for the full list.
+Supported agent names: `amp`, `claude-code`, `cursor`, `github-copilot`, `cline`, `roo`, `codex`, `continue`, `agy`, `goose`, `kilo`, `kiro-cli`, `opencode`, `openhands`, `trae`, `warp`, `windsurf`, and more. Run `gaal info agent` for the full list.
 
 ---
 

--- a/internal/core/agent/agents.yaml
+++ b/internal/core/agent/agents.yaml
@@ -46,6 +46,21 @@ search_defaults:
     - ~/.claude/skills
 
 agents:
+  # Antigravity CLI (`agy`) — replaced the deprecated Gemini CLI (2026-06-18).
+  # Skills use the vendor-neutral .agents convention; MCP uses agy's own
+  # global file (shared with the Antigravity IDE). See agent-capabilities.md.
+  agy:
+    supports_generic_project: true
+    supports_generic_global: true
+    project_skills_dir: ""
+    global_skills_dir: ""
+    # Shared with the Antigravity IDE; project-local MCP is ignored by the CLI.
+    global_mcp_config_file: ~/.gemini/config/mcp_config.json
+    project_mcp_config_file: ""
+    project_skills_search: *cps
+    global_skills_search: *cgs
+    pm_skills_search: []
+
   amp:
     supports_generic_project: true
     project_skills_dir: ""
@@ -183,20 +198,6 @@ agents:
       - ~/.claude/skills
     pm_skills_search:
       - ~/.cursor/extensions
-
-  gemini-cli:
-    supports_generic_project: true
-    project_skills_dir: ""
-    global_skills_dir: ~/.gemini/skills
-    global_mcp_config_file: ~/.gemini/settings.json
-    project_mcp_config_file: ""
-    project_skills_search: *cps
-    global_skills_search:
-      - ~/.gemini/skills
-      - ~/.agents/skills
-      - ~/.copilot/skills
-    pm_skills_search:
-      - ~/.gemini/extensions
 
   generic:
     # Shared-convention agent. Owns .agents/skills (project) and

--- a/internal/core/agent/agents.yaml
+++ b/internal/core/agent/agents.yaml
@@ -64,7 +64,8 @@ agents:
     supports_generic_project: true
     project_skills_dir: ""
     global_skills_dir: ~/.gemini/antigravity/skills
-    global_mcp_config_file: ""
+    # Dedicated file, not ~/.gemini/settings.json (Gemini-CLI's). See agent-capabilities.md.
+    global_mcp_config_file: ~/.gemini/config/mcp_config.json
     project_mcp_config_file: ""
     project_skills_search: *cps
     global_skills_search:

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -225,7 +225,7 @@ func TestGenericAgentRegistered(t *testing.T) {
 func TestGenericProjectFlaggedAgents(t *testing.T) {
 	// Every agent that previously pointed its project_skills_dir at
 	// .agents/skills must now delegate to generic.
-	want := []string{"amp", "antigravity", "cline", "codex", "cursor", "gemini-cli", "opencode", "warp"}
+	want := []string{"agy", "amp", "antigravity", "cline", "codex", "cursor", "opencode", "warp"}
 	for _, name := range want {
 		info, ok := agent.Lookup(name)
 		if !ok {
@@ -242,9 +242,9 @@ func TestGenericProjectFlaggedAgents(t *testing.T) {
 }
 
 func TestGenericGlobalFlaggedAgents(t *testing.T) {
-	// Only cline and warp previously pointed their global_skills_dir at
-	// ~/.agents/skills.
-	want := []string{"cline", "warp"}
+	// cline, warp, and agy delegate their global skills to the shared
+	// ~/.agents/skills convention.
+	want := []string{"agy", "cline", "warp"}
 	for _, name := range want {
 		info, ok := agent.Lookup(name)
 		if !ok {

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -122,8 +122,8 @@ func TestMCPConfigPath_Unknown(t *testing.T) {
 }
 
 func TestMCPConfigPath_EmptyWhenNotSet(t *testing.T) {
-	// antigravity has an empty global_mcp_config_file.
-	_, ok := agent.GlobalMCPConfigPath("antigravity", "/home/user")
+	// generic has an empty global_mcp_config_file.
+	_, ok := agent.GlobalMCPConfigPath("generic", "/home/user")
 	if ok {
 		t.Error("expected ok=false for agent with empty GlobalMCPConfigFile")
 	}


### PR DESCRIPTION
## Summary

Replaces the deprecated `gemini-cli` agent with Google's new Antigravity CLI (`agy`), and fixes the existing `antigravity` (IDE) agent so gaal stops skipping it as an MCP target. Google shut down Gemini CLI for consumer tiers on 2026-06-18; `agy` is its Go-based successor. YAML-, docs-, and test-only — no code paths change.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation

## Related Issues

None.

## What's in it (two commits)

- **fix(agents): set antigravity global MCP config path** — `antigravity`'s `global_mcp_config_file` was empty, so gaal skipped it as an MCP target. Point it at the dedicated `~/.gemini/config/mcp_config.json` (not `~/.gemini/settings.json`, which is Gemini-CLI's).
- **feat(agents): replace deprecated gemini-cli with antigravity cli (agy)** — drop `gemini-cli`, add `agy`. Skills follow the vendor-neutral `.agents` convention (project + global); MCP targets agy's own global file, shared with the Antigravity IDE. The existing `antigravity` (IDE) entry is retained.

## Checklist

- [x] `make lint` passes — `gofmt` + `go vet` clean
- [x] `make build` passes (macOS; pure-Go, expect Linux parity)
- [x] Race-enabled `go test ./...` passes (`make test-ci` skipped: `gotestsum` not installed locally)
- [x] Every new function has a `slog.Debug` call — n/a, no new functions (registry table + tests + docs only)
- [x] Documentation updated (`README.md`, `docs/agent-capabilities.md`, `docs/quick_start.md`)
- [x] No secrets or credentials exposed

## Note for maintainers

`.understand-anything/knowledge-graph.json` (a checked-in generated baseline) still lists `gemini-cli` in a summary string. Left untouched here since it's a generated artifact — worth regenerating separately.
